### PR TITLE
[Relay] Mutual Recursion

### DIFF
--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -87,6 +87,13 @@ class ModuleNode : public RelayNode {
   TVM_DLL void Add(const GlobalVar& var, const Function& func, bool update = false);
 
   /*!
+   * \brief Adds multiple functions simultaneously to the global environment.
+   * Supports mutual recursion.
+   * \param funcs A map of global vars to function definitions
+   */
+  TVM_DLL void AddMultiple(const Map<GlobalVar, Function>& funcs);
+
+  /*!
    * \brief Add a type-level definition to the global environment.
    * \param var The var of the global type definition.
    * \param type The type definition.
@@ -205,6 +212,11 @@ class ModuleNode : public RelayNode {
   TVM_DECLARE_NODE_TYPE_INFO(ModuleNode, Node);
 
  private:
+  /*! \brief Helper function for finding free vars in a function
+  * to be added and warning about them before appending them to the function's parameters.
+  */
+  Function AppendFreeVars(const Function& f);
+
   /*! \brief Helper function for registering a typedef's constructors */
   void RegisterConstructors(const GlobalTypeVar& var, const TypeData& type);
 

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -588,6 +588,24 @@ TVM_DLL Function InferType(const Function& f,
                            const GlobalVar& var);
 
 /*!
+ * \brief Infer the types of all the global functions in the map *simultaneously*.
+ * Hence the functions in the map can assume the existence of anything already in the module
+ * as well as everything else in the map.
+ *
+ * This function is intended to support type-checking mutual recursion
+ * (a situation where we have global variables v1 -> f1 and v2 -> f2
+ * and the definitions of f1 and f2 each use v2 and v1, respectively).
+ *
+ * \param global_funcs A mapping of global variables to their definitions (functions)
+ * \param mod The module used for referencing global functions not in global_funcs.
+ *
+ * \return A map of global vars to functions where each function's checked_type field is populated.
+ * \note this function mutates mod and is not thread-safe.
+ */
+TVM_DLL tvm::Map<GlobalVar, Function> InferTypes(const tvm::Map<GlobalVar, Function>& global_funcs,
+                                                 const Module& mod);
+
+/*!
  * \brief Apply rewrite rules to rewrite the expr in post DFS order. This
  * function is used as a helper function to rewrtie an expression in a pass.
  *

--- a/python/tvm/relay/module.py
+++ b/python/tvm/relay/module.py
@@ -109,6 +109,28 @@ class Module(RelayNode):
         else:
             return _module.Module_LookupDef(self, var)
 
+    def add_multiple(self, functions):
+        """
+        Simultaneously add multiple mappings to the module.
+        Supports mutual recursion.
+
+        Parameters
+        ---------
+        funcsfunctions: Map[GlobalVar, Function]
+        """
+        if functions is None:
+            functions = {}
+        elif isinstance(functions, dict):
+            mapped_funcs = {}
+            for k, v in functions.items():
+                if isinstance(k, _base.string_types):
+                    k = _expr.GlobalVar(k)
+                if not isinstance(k, _expr.GlobalVar):
+                    raise TypeError("Expect functions to be Dict[GlobalVar, Function]")
+                mapped_funcs[k] = v
+            functions = mapped_funcs
+        _module.Module_AddMultiple(self, functions)
+
     def update(self, other):
         """Insert functions in another Module to current one.
 

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -851,6 +851,5 @@ TVM_REGISTER_API("relay._transform.InferType")
 });
 
 }  // namespace transform
-
 }  // namespace relay
 }  // namespace tvm

--- a/tests/python/relay/test_adt.py
+++ b/tests/python/relay/test_adt.py
@@ -585,7 +585,7 @@ def test_wildcard_match_order():
 
 def test_nested_matches():
     a = relay.TypeVar('a')
-    x = relay.Var('x')
+    x = relay.Var('x', l(l(a)))
     y = relay.Var('y')
     w = relay.Var('w')
     h = relay.Var('h')

--- a/tests/python/relay/test_adt.py
+++ b/tests/python/relay/test_adt.py
@@ -585,7 +585,7 @@ def test_wildcard_match_order():
 
 def test_nested_matches():
     a = relay.TypeVar('a')
-    x = relay.Var('x', l(l(a)))
+    x = relay.Var('x')
     y = relay.Var('y')
     w = relay.Var('w')
     h = relay.Var('h')

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -429,6 +429,26 @@ def test_mutual_recursion_adt():
     assert mod[even].checked_type == expected_type
 
 
+def test_simple_add_multiple_case():
+    mod = relay.Module()
+    p = Prelude(mod)
+    l, nil, cons = p.l, p.nil, p.cons
+
+    a = relay.TypeVar('a')
+    x = relay.Var('x', a) # fails without this annotation
+    f = relay.GlobalVar('f')
+    func = relay.Function([x], cons(x, nil()), l(a), [a])
+
+    main = relay.GlobalVar('main')
+    main_func = relay.Function([], f(relay.Tuple([])))
+    mapping = {f : func, main : main_func}
+    mod.add_multiple({main : main_func, f : func})
+
+    print(mod[main].checked_type)
+    assert mod[main].checked_type == relay.FuncType([], l(relay.TupleType([])))
+    assert mod[f].checked_type == relay.FuncType([a], l(a), [a])
+
+
 def test_add_multiple_generic_recursive():
     mod = relay.Module()
     p = Prelude(mod)

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -478,3 +478,6 @@ if __name__ == "__main__":
     test_constructor_call()
     test_adt_match()
     test_let_polymorphism()
+    test_mutual_recursion()
+    test_mutual_recursion_adt()
+    test_add_multiple_with_type_var()

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -429,7 +429,7 @@ def test_mutual_recursion_adt():
     assert mod[even].checked_type == expected_type
 
 
-def test_add_multiple_with_type_var_recursive():
+def test_add_multiple_generic_recursive():
     mod = relay.Module()
     p = Prelude(mod)
     add_nat_definitions(p)
@@ -460,7 +460,7 @@ def test_add_multiple_with_type_var_recursive():
     assert mod[list_id].checked_type == relay.FuncType([l(a)], l(a), [a])
 
 
-def test_add_multiple_with_type_var_nonrecursive():
+def test_add_multiple_generic_nonrecursive():
     mod = relay.Module()
     p = Prelude(mod)
     add_nat_definitions(p)
@@ -510,5 +510,5 @@ if __name__ == "__main__":
     test_let_polymorphism()
     test_mutual_recursion()
     test_mutual_recursion_adt()
-    test_add_multiple_with_type_var()
-    test_add_multiple_with_type_var_nonrecursive()
+    test_add_multiple_generic_recursive()
+    test_add_multiple_generic_nonrecursive()

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -511,3 +511,4 @@ if __name__ == "__main__":
     test_mutual_recursion()
     test_mutual_recursion_adt()
     test_add_multiple_with_type_var()
+    test_add_multiple_with_type_var_nonrecursive()


### PR DESCRIPTION
This PR will implement mutual recursion, described in RFC #2603.

As the changes currently stand, this should allow all globals defined together to reference each other, i.e., for there to be mutual recursion with global functions. However, we will probably also want syntax changes to allow for local mutually recursive definitions (we can discuss that).

I welcome any review and discussion as to the handling of mutually recursive definitions in globals (e.g., from @jroesch, @MarisaKirisame, and any others who are interested).