### PR TITLE
[CMAKE][VTA] Modularizing Runtime Sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,27 +175,26 @@ file(GLOB_RECURSE NNVM_COMPILER_SRCS
     nnvm/src/top/*.cc
     )
 
-file(GLOB TOPI_SRCS
-    topi/src/*.cc
-)
+file(GLOB TOPI_SRCS topi/src/*.cc)
 
-file(GLOB RUNTIME_SRCS
-  src/runtime/*.cc
-  src/runtime/vm/*.cc
-)
+file(GLOB RUNTIME_SRCS src/runtime/*.cc)
 
 # Package runtime rules
 if(NOT USE_RTTI)
   add_definitions(-DDMLC_ENABLE_RTTI=0)
 endif()
 
-list(APPEND RUNTIME_SRCS 3rdparty/bfloat16/bfloat16.cc)
-
 if(USE_RPC)
-  message(STATUS "Build with RPC support...")
+  message(STATUS "Build with RPC support in runtime...")
   file(GLOB RUNTIME_RPC_SRCS src/runtime/rpc/*.cc)
   list(APPEND RUNTIME_SRCS ${RUNTIME_RPC_SRCS})
 endif(USE_RPC)
+
+file(GLOB VM_RUNTIME_SRCS src/runtime/vm/*.cc)
+if(USE_RELAY_VM)
+  message(STATUS "Build with Relay VM support in runtime...")
+  list(APPEND RUNTIME_SRCS ${VM_RUNTIME_SRCS})
+endif(USE_RELAY_VM)
 
 file(GLOB STACKVM_RUNTIME_SRCS src/runtime/stackvm/*.cc)
 file(GLOB STACKVM_CODEGEN_SRCS src/codegen/stackvm/*.cc)
@@ -226,6 +225,11 @@ if(USE_VM_PROFILER)
   file(GLOB RUNTIME_VM_PROFILER_SRCS src/runtime/vm/profiler/*.cc)
   list(APPEND RUNTIME_SRCS ${RUNTIME_VM_PROFILER_SRCS})
 endif(USE_VM_PROFILER)
+
+if(USE_BFLOAT)
+  list(APPEND RUNTIME_SRCS 3rdparty/bfloat16/bfloat16.cc)
+endif
+
 
 # Module rules
 include(cmake/modules/VTA.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,6 @@ file(GLOB_RECURSE NNVM_COMPILER_SRCS
     )
 
 file(GLOB TOPI_SRCS topi/src/*.cc)
-
 file(GLOB RUNTIME_SRCS src/runtime/*.cc)
 
 # Package runtime rules
@@ -228,7 +227,7 @@ endif(USE_VM_PROFILER)
 
 if(USE_BFLOAT)
   list(APPEND RUNTIME_SRCS 3rdparty/bfloat16/bfloat16.cc)
-endif
+endif(USE_BFLOAT)
 
 
 # Module rules

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -144,8 +144,8 @@ set(USE_ANTLR OFF)
 # Whether use Relay debug mode
 set(USE_RELAY_DEBUG OFF)
 
-# Whether use bfloat16
-set(USE_BFLOAT OFF)
+# Whether to enable bfloat16
+set(USE_BFLOAT ON)
 
 # Whether to build fast VTA simulator driver
 set(USE_VTA_FSIM ON)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -88,6 +88,9 @@ set(USE_GRAPH_RUNTIME ON)
 # Whether enable additional graph debug functions
 set(USE_GRAPH_RUNTIME_DEBUG OFF)
 
+# Whether enable Relay VM
+set(USE_RELAY_VM ON)
+
 # Whether enable additional vm profiler functions
 set(USE_VM_PROFILER OFF)
 
@@ -140,6 +143,9 @@ set(USE_ANTLR OFF)
 
 # Whether use Relay debug mode
 set(USE_RELAY_DEBUG OFF)
+
+# Whether use bfloat16
+set(USE_BFLOAT OFF)
 
 # Whether to build fast VTA simulator driver
 set(USE_VTA_FSIM ON)

--- a/docs/vta/install.md
+++ b/docs/vta/install.md
@@ -117,6 +117,8 @@ ssh xilinx@192.168.2.99
 cd /home/xilinx/tvm
 mkdir build
 cp cmake/config.cmake build/.
+
+echo 'set(USE_RELAY_VM OFF)' >> build/config.cmake
 echo 'set(USE_VTA_FSIM OFF)' >> build/config.cmake
 echo 'set(USE_VTA_TSIM OFF)' >> build/config.cmake
 echo 'set(USE_VTA_FPGA ON)' >> build/config.cmake

--- a/docs/vta/install.md
+++ b/docs/vta/install.md
@@ -117,8 +117,8 @@ ssh xilinx@192.168.2.99
 cd /home/xilinx/tvm
 mkdir build
 cp cmake/config.cmake build/.
-
 echo 'set(USE_RELAY_VM OFF)' >> build/config.cmake
+echo 'set(USE_BFLOAT OFF)' >> build/config.cmake
 echo 'set(USE_VTA_FSIM OFF)' >> build/config.cmake
 echo 'set(USE_VTA_TSIM OFF)' >> build/config.cmake
 echo 'set(USE_VTA_FPGA ON)' >> build/config.cmake


### PR DESCRIPTION
The idea of this PR is to further modularize runtime sources so we can minimize the number of source files compiled on edge nodes that require a RPC and graph runtime. On compute constrained nodes like the pynq board, trimming sources reduces the compile time from 6 mins down to 5 mins. 
