### PR TITLE
Const loop partition fix

### DIFF
--- a/include/tvm/arithmetic.h
+++ b/include/tvm/arithmetic.h
@@ -635,7 +635,8 @@ IntSet Intersect(const Array<IntSet>& sets);
  */
 IntSet DeduceBound(Expr v, Expr cond,
                    const Map<Var, IntSet>& hint_map,
-                   const Map<Var, IntSet>& relax_map);
+                   const Map<Var, IntSet>& relax_map,
+                   const bool return_lower_bound=false);
 /*!
  * \brief Same as DeduceBound with  unordered_map signature.
  *
@@ -648,7 +649,8 @@ IntSet DeduceBound(Expr v, Expr cond,
  */
 IntSet DeduceBound(Expr v, Expr cond,
                    const std::unordered_map<const Variable*, IntSet>& hint_map,
-                   const std::unordered_map<const Variable*, IntSet>& relax_map);
+                   const std::unordered_map<const Variable*, IntSet>& relax_map,
+                   const bool return_lower_bound=false);
 
 /*!
  * \brief Infer a regular domain that covers all the calls or provides within the given statement.

--- a/src/pass/loop_partition.cc
+++ b/src/pass/loop_partition.cc
@@ -201,8 +201,13 @@ class PartitionFinder : public IRVisitor {
         // For cond, find out the interval, if exists, in which we can prove that cond is
         // true. Also find the interval, if exists, in which we can prove that cond is
         // false.
+        // Get the lower bound for the interval. This is specifically to get around the issue
+        // where interval be neg_inf, ...
+        // Here without asking for lower_bound max of the interval can be zero, due to round
+        // to zero of the integer division.
+        bool return_lower_bound(true);
         IntSet interval =
-                DeduceBound(current_var_, cond, hint_map_, relax_map_);
+                DeduceBound(current_var_, cond, hint_map_, relax_map_, return_lower_bound);
         if (!interval.is_nothing()) {
           // cond is true within interval
           partitions[{cond.get(), true}] = interval;
@@ -210,7 +215,7 @@ class PartitionFinder : public IRVisitor {
         Expr inverse_cond = InverseCond(cond);
         if (inverse_cond.defined()) {
           IntSet interval =
-                  DeduceBound(current_var_, inverse_cond, hint_map_, relax_map_);
+                  DeduceBound(current_var_, inverse_cond, hint_map_, relax_map_, return_lower_bound);
           if (!interval.is_nothing()) {
             // cond is false within interval
             partitions[{cond.get(), false}] = interval;

--- a/tests/python/unittest/test_pass_loop_partition.py
+++ b/tests/python/unittest/test_pass_loop_partition.py
@@ -365,6 +365,29 @@ def test_conv_tiling():
     stmt = tvm.ir_pass.Simplify(stmt)
     assert(not any(collect_visit(stmt, lambda x: isinstance(x, tvm.stmt.IfThenElse))))
 
+def test_multilevel_splitting_with_indivisble_factors():
+    import topi
+    A = tvm.placeholder((130, 54), dtype="float32")
+    B = topi.nn.relu(A)
+    s = tvm.create_schedule(B.op)
+    (y, x) = s[B].op.axis
+    (xo, xi) = s[B].split(x, factor=2)
+    (yo, yi) = s[B].split(y, factor=8)
+    (xoo, xoi) = s[B].split(xo, factor=16)
+    (yoo, yoi) = s[B].split(yo, factor=16)
+    s[B].reorder(yoo, xoo, yoi, xoi, yi, xi)
+    s[B].unroll(yi)
+    s[B].vectorize(xi)
+
+    # But this does the right thing.
+    with tvm.build_config(partition_const_loop=True):
+        lowered_body = tvm.lower(s, [A, B]).body
+        def visit_stmt(op):
+            return(isinstance(op, tvm.expr.Max))
+        num_max = collect_visit(lowered_body, visit_stmt)
+        assert num_max.count(True) == 20
+
+
 def test_double_splitting_with_indivisible_factors():
     m = 48
     dtype="float32"
@@ -443,4 +466,5 @@ if __name__ == "__main__":
     test_cce_loop_3()
     test_conv_tiling()
     test_double_splitting_with_indivisible_factors()
+    test_multilevel_splitting_with_indivisble_factors()
     test_simple_rfactor()


### PR DESCRIPTION
Partitioning was failing for the test added in this PR:

Originally the generated output is:
produce compute {
  for (i0.outer.inner, 0, 16) {
    compute[(i0.outer.inner*8)] = max(placeholder[(i0.outer.inner*8)], 0f)
    compute[((i0.outer.inner*8) + 1)] = max(placeholder[((i0.outer.inner*8) + 1)], 0f)
    compute[((i0.outer.inner*8) + 2)] = max(placeholder[((i0.outer.inner*8) + 2)], 0f)
    compute[((i0.outer.inner*8) + 3)] = max(placeholder[((i0.outer.inner*8) + 3)], 0f)
    compute[((i0.outer.inner*8) + 4)] = max(placeholder[((i0.outer.inner*8) + 4)], 0f)
    compute[((i0.outer.inner*8) + 5)] = max(placeholder[((i0.outer.inner*8) + 5)], 0f)
    compute[((i0.outer.inner*8) + 6)] = max(placeholder[((i0.outer.inner*8) + 6)], 0f)
    compute[((i0.outer.inner*8) + 7)] = max(placeholder[((i0.outer.inner*8) + 7)], 0f)
  }
  compute[128] = max(placeholder[128], 0f)
  compute[129] = max(placeholder[129], 0f)
  compute[130] = max(placeholder[130], 0f)
  compute[131] = max(placeholder[131], 0f)
  compute[132] = max(placeholder[132], 0f)
  compute[133] = max(placeholder[133], 0f)
  compute[134] = max(placeholder[134], 0f)
  compute[135] = max(placeholder[135], 0f)
}

Whereas it should be:

produce compute {
  for (i0.outer.inner, 0, 16) {
    compute[(i0.outer.inner*8)] = max(placeholder[(i0.outer.inner*8)], 0f)
    compute[((i0.outer.inner*8) + 1)] = max(placeholder[((i0.outer.inner*8) + 1)], 0f)
    compute[((i0.outer.inner*8) + 2)] = max(placeholder[((i0.outer.inner*8) + 2)], 0f)
    compute[((i0.outer.inner*8) + 3)] = max(placeholder[((i0.outer.inner*8) + 3)], 0f)
    compute[((i0.outer.inner*8) + 4)] = max(placeholder[((i0.outer.inner*8) + 4)], 0f)
    compute[((i0.outer.inner*8) + 5)] = max(placeholder[((i0.outer.inner*8) + 5)], 0f)
    compute[((i0.outer.inner*8) + 6)] = max(placeholder[((i0.outer.inner*8) + 6)], 0f)
    compute[((i0.outer.inner*8) + 7)] = max(placeholder[((i0.outer.inner*8) + 7)], 0f)
  }
  compute[128] = max(placeholder[128], 0f)
  compute[129] = max(placeholder[129], 0f)
}


Bounds check can return interval neg_inf, 0 for conditions such as
(1128 + iter_var*8 + 7) < 130. The bound it finds is
(122 - 128)/6. Here iter_var should not be able to take on value 0 since
with that we are already violating the condition. But since bound check
does div, which by default rounds to zero, we get zero.
This diff fixes this for const int bounds when before division it is
knowns that divisor and dividend are constants and if so it does
floordiv, instead of div. This seems ok for condition on iteration
variables, however not clear if it should do floordiv everywhere else.


