### PR TITLE
[Relay] Add print_ir parameter to build_config to print the IR between passes

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -96,8 +96,15 @@ class PassContextNode : public RelayNode {
 
   /*! \brief The list of required passes. */
   tvm::Array<tvm::Expr> required_pass;
+
   /*! \brief The list of disabled passes. */
   tvm::Array<tvm::Expr> disabled_pass;
+
+  /*! \brief Whether to print the IR before the first pass in a sequence. */
+  bool print_ir_before_first{false};
+
+  /*! \brief Whether to print the IR after each pass. */
+  bool print_ir_after_all{false};
 
   PassContextNode() = default;
 
@@ -106,6 +113,8 @@ class PassContextNode : public RelayNode {
     v->Visit("fallback_device", &fallback_device);
     v->Visit("required_pass", &required_pass);
     v->Visit("disabled_pass", &disabled_pass);
+    v->Visit("print_ir_before_first", &print_ir_before_first);
+    v->Visit("print_ir_after_all", &print_ir_after_all);
   }
 
   static constexpr const char* _type_key = "relay.PassContext";

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -73,12 +73,16 @@ class PassContext(RelayNode):
 
     disabled_pass : Optional[Union[List[str], Set[str], Tuple[str]]]
         The list of passes that are disabled.
+
+    print_ir: Optional[bool]
+        Whether to print the IR between passes.
     """
     def __init__(self,
                  opt_level=2,
                  fallback_device=_nd.cpu(),
                  required_pass=None,
-                 disabled_pass=None):
+                 disabled_pass=None,
+                 print_ir=False):
         if isinstance(fallback_device, str):
             fallback_device = _nd.context(fallback_device).device_type
         elif isinstance(fallback_device, TVMContext):
@@ -97,9 +101,12 @@ class PassContext(RelayNode):
             raise TypeError("disabled_pass is expected to be the type of " +
                             "list/tuple/set.")
 
+        if not isinstance(print_ir, bool):
+            raise TypeError("print_ir is expected to be of type bool.")
+
         self.__init_handle_by_constructor__(_transform.PassContext, opt_level,
                                             fallback_device, required,
-                                            disabled)
+                                            disabled, print_ir)
 
     def __enter__(self):
         _transform.EnterPassContext(self)
@@ -117,7 +124,8 @@ class PassContext(RelayNode):
 def build_config(opt_level=2,
                  fallback_device=_nd.cpu(),
                  required_pass=None,
-                 disabled_pass=None):
+                 disabled_pass=None,
+                 print_ir=False):
     """Configure the build behavior by setting config variables.
 
     Parameters
@@ -151,13 +159,16 @@ def build_config(opt_level=2,
     disabled_pass: set of str, optional
         Optimization passes to be disabled during optimization.
 
+    print_ir: bool, optional
+        Whether to print the IR between passes.
+
     Returns
     -------
     pass_context: PassContext
         The pass context for optimizations.
     """
     return PassContext(opt_level, fallback_device, required_pass,
-                       disabled_pass)
+                       disabled_pass, print_ir)
 
 
 @register_relay_node


### PR DESCRIPTION
Just a simple feature to get started with TVM. I was told that this feature is requested. Thanks to zhiics@ for help with figuring everything out. Please add whoever would be appropriate to review.

The feature is enabled by passing print_ir=True to build_config. Then the initial IR will be printed, and the IR will be printed after each pass that changes the IR, to avoid IR spam for non-modifying passes. There is a message to say which passes are run and whether the IR changed. Passes that are run due to being pre-requisites of other passes are marked as such. It would be even better to print the IR after each pass to a separate numbered file in a given directory, as in LLVM, but that's for another time.

Some questions and stuff I noticed:

1) I detect changes to the IR by recalling the string printed previously. I could also remember/compare modules directly or recall a hash code, but this seemed safest. Let me know if that's the not the right way to do it. It would be nice if passes would report whether they modified the IR, but I didn't find a feature for that.

2) Both before and after this change, the way pass prerequisites is handled seems broken to me. Suppose pass C depends on pass B which depends on pass A. Then running pass C will cause pass B to be run first, but in this case B will run without running pass A, because prerequisites are not inspected recursively.

3) Several passes have prerequisites that are not declared in their list of prerequisites, instead ensured by running those passes directly from the pass. Presumably passes are supposed to use the pre-requisite feature to do this, but they don't (perhaps as a work0around for 2 above?). This is done in fold_const.cc in ConstEvaluate(), for one example. This sometimes messes up the feature in this change to explain why a pass was run and it made it more complicated to print the IR before the first pass without doing that again in a nested sequence.


*** Example usage:

import tvm
import tvm.relay as relay

shape = (1, 2, 3)
t = relay.TensorType(shape, "float32")
x = relay.var("x", t)
two = relay.const(2, "float32")
four = relay.add(two, two)
xsum = relay.add(x, four)
func = relay.Function([x], xsum)

seq = relay.transform.Sequential([
    relay.transform.FuseOps(),
])

with relay.build_config(opt_level=3,print_ir=True):
    seq(relay.Module({"main": func}))

*** Example output:

[03:15:32] /home/ubuntu/tvm/src/relay/pass/pass_manager.cc:417: IR before first pass in sequence:
v0.0.4
def @main(%x: Tensor[(1, 2, 3), float32]) {
  %0 = add(2f, 2f);
  add(%x, %0)
}

[03:15:32] /home/ubuntu/tvm/src/relay/pass/pass_manager.cc:440: IR after InferType (required by FuseOps) changed:
v0.0.4
def @main(%x: Tensor[(1, 2, 3), float32]) -> Tensor[(1, 2, 3), float32] {
  %0 = add(2f /* ty=float32 */, 2f /* ty=float32 */) /* ty=float32 */;
  add(%x, %0) /* ty=Tensor[(1, 2, 3), float32] */
}


[03:15:32] /home/ubuntu/tvm/src/relay/pass/pass_manager.cc:440: IR after FuseOps changed:
v0.0.4
def @main(%x: Tensor[(1, 2, 3), float32]) -> Tensor[(1, 2, 3), float32] {
  %1 = fn (%p0: Tensor[(1, 2, 3), float32], Primitive=1) -> Tensor[(1, 2, 3), float32] {
    %0 = add(2f /* ty=float32 */, 2f /* ty=float32 */) /* ty=float32 */;
    add(%p0, %0) /* ty=Tensor[(1, 2, 3), float32] */
  };
  %1(%x) /* ty=Tensor[(1, 2, 3), float32] */
}

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
