### PR TITLE
[AutoTVM] Added an autotuning Config Library to store autotune results

### DIFF
--- a/python/tvm/autotvm/__init__.py
+++ b/python/tvm/autotvm/__init__.py
@@ -36,6 +36,7 @@ from . import tuner
 from . import util
 from . import env
 from . import tophub
+from . import config_library
 
 # some shortcuts
 from .measure import measure_option, MeasureInput, MeasureResult, MeasureErrorNo, \

--- a/python/tvm/autotvm/config_library.py
+++ b/python/tvm/autotvm/config_library.py
@@ -1,0 +1,279 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.import datetime
+#pylint: disable=arguments-differ, method-hidden, inconsistent-return-statements
+"""Config Library to store tuning configs"""
+import json
+import os
+from _ctypes import PyObj_FromPtr
+from shutil import copyfile
+from pathlib import Path
+
+import numpy as np
+
+from . import record
+from .task import ApplyHistoryBest
+
+
+class ConfigLibraryException(Exception):
+    pass
+
+
+class ConfigLibrary:
+    """A library to store auto-tuning results for any number of targets/workloads.
+
+    Parameters
+    ----------
+    library_dir: str
+        Path to the config library directory. If the library does not already
+        exist, a new library will be initialised in the directory. This will
+        create an 'index.json' file in the directory which contains the location
+        of all other files used to store configs in the library.
+
+    """
+
+    LIBRARY_INDEX_FILE_NAME = "index.json"
+    JOBS_INDEX_FILE_NAME = "jobs.json"
+    JOBS_DIRECTORY_NAME = "jobs"
+
+    def __init__(self, library_dir):
+        # Handle if the directory doesn't exist
+        if not os.path.isdir(library_dir):
+            os.mkdir(library_dir)
+
+        index_file = os.path.join(library_dir, self.LIBRARY_INDEX_FILE_NAME)
+        if not os.path.isfile(index_file):
+            with open(index_file, "w") as f:
+                full_index_path = os.path.abspath(f.name)
+                index = {
+                    "root": os.path.dirname(full_index_path),
+                    "targets": {},
+                    "jobs_index": self.JOBS_INDEX_FILE_NAME,
+                    "jobs_dir": self.JOBS_DIRECTORY_NAME,
+                }
+                json.dump(index, f, indent=4)
+
+            with open(os.path.join(library_dir, self.JOBS_INDEX_FILE_NAME), "w") as f:
+                json.dump({}, f)
+
+        self.library_dir = library_dir
+        self.library_index = index_file
+        self.jobs_dir = os.path.join(self.library_dir, self.JOBS_DIRECTORY_NAME)
+        self.jobs_index = os.path.join(self.library_dir, self.JOBS_INDEX_FILE_NAME)
+        if not os.path.isdir(self.jobs_dir):
+            os.makedirs(self.jobs_dir)
+
+    def load(self, target):
+        """Load the configs for a given TVM target string.
+
+        Returns a DispatchContext with the appropriate configs loaded."""
+        target_configs = self._load_target_configs(target)
+        return ApplyHistoryBest(target_configs)
+
+    def _load_target_configs(self, target):
+        """Yield the configs in the library for a given target."""
+        target_file = self.get_config_file(target, create=False)
+        if target_file:
+            with open(target_file) as f:
+                configs = json.load(f)
+                for config in configs.values():
+                    row = json.dumps(config)
+                    yield record.decode(row)
+
+        else:
+            yield from []
+
+    def save_job(self, job, save_history=True):
+        """Save the results of an auto-tuning job to the library.
+
+        Parameters
+        ----------
+        job: TuningJob
+            The auto-tuning job to save.
+        save_history: bool
+            Whether to save the history log of the job.
+
+        """
+        with open(self.jobs_index, 'r+') as f:
+            job_index = json.load(f)
+            highest_job_id = 0
+            for job_id in job_index:
+                highest_job_id = max(highest_job_id, int(job_index[job_id]["id"]))
+
+            job_id = str(highest_job_id + 1)
+            job_log = None
+            if save_history:
+                job_log = self._create_job_log(job_id, job.target)
+                copyfile(job.log, job_log)
+
+            job_entry = {
+                "id": job_id,
+                "log": job_log,
+                "target": job.target,
+                "platform": job.platform,
+                "content": job.content,
+                "start_time": job.start_time,
+                "end_time": job.end_time,
+                "tasks": [],
+            }
+
+            for workload in job.results_by_workload:
+                inp, best_result, tuner_name, trials = job.results_by_workload[workload]
+                config_entry_str = record.encode(inp, best_result, 'json')
+                config_entry = json.loads(config_entry_str)
+                config_entry["t"] = [job_id, tuner_name, trials]
+                task_entry = json.dumps(config_entry)
+                self.save_config(config_entry)
+                job_entry["tasks"].append(task_entry)
+
+            job_index[job_id] = job_entry
+            f.seek(0)
+            json.dump(job_index, f, indent=4)
+
+
+    def _create_job_log(self, job_id, target):
+        """Returns a path to a job log file.
+
+        This will delete any log that exists with the same name."""
+        log_name = job_id + "_" + (
+            target.replace(" ", "").replace("-device=", "_").replace("-model=", "_")
+        )
+        job_log = os.path.join(self.jobs_dir, log_name + ".log")
+        if os.path.isfile(job_log):
+            os.remove(job_log)
+
+        Path(job_log).touch()
+        return job_log
+
+    def save_config(self, new_config):
+        """Save a config to the library if it's better than existing entries."""
+        target = new_config["i"][0]
+        workload = str(new_config["i"][4])
+        new_config_key = workload
+        config_file = self.get_config_file(target)
+        with open(config_file, 'r+') as f:
+            existing_configs = json.load(f)
+            if new_config_key in existing_configs:
+                existing_config = existing_configs[new_config_key]
+                if np.mean(new_config["r"][0]) < np.mean(existing_config["r"][0]):
+                    existing_configs[new_config_key] = new_config
+            else:
+                existing_configs[new_config_key] = new_config
+
+            for config_key in existing_configs:
+                existing_configs[config_key] = NoIndent(existing_configs[config_key])
+
+            configs_str = json.dumps(existing_configs, indent=4, cls=NoIndentEncoder)
+            # Delete the current file, then write the new configs
+            # TODO @mbarrett97 We should make a copy of the existing file here in
+            # case something bad happens before the write and the data is lost
+            f.truncate(0)
+            f.seek(0)
+            f.write(configs_str)
+
+    def get_config(self, target, workload):
+        """Get a config for a given target/workload from the library.
+
+        Parameters
+        ----------
+        target: str
+            The target string of the config.
+        workload: list
+            The workload of the config.
+
+        Returns
+        -------
+        config: Union[dict, None]
+            The config for the specified task. Returns None if no config was
+            found.
+
+        """
+        config_file = self.get_config_file(target, create=False)
+        if config_file:
+            with open(config_file) as f:
+                configs = json.load(f)
+                workload_key = str(workload)
+                if workload_key in configs:
+                    return configs[workload_key]
+
+        return None
+
+    def get_config_file(self, target, create=True):
+        """Return the config file path associated with a given target"""
+        with open(self.library_index, "r+") as f:
+            config_index = json.load(f)
+
+        target_file_name = self._get_target_file_name(target)
+        root = config_index["root"]
+        config_files = config_index["targets"]
+        if target_file_name in config_files:
+            return config_files[target_file_name]
+        elif create:  # Create the file if it's not already in the index
+            with open(self.library_index, "w") as f:
+                config_file_name = target_file_name + ".configs"
+                config_file = os.path.join(root, config_file_name)
+                with open(config_file, "w") as g:
+                    json.dump({}, g)
+
+                config_index["targets"][target_file_name] = config_file
+                json.dump(config_index, f, indent=4)
+                return config_file
+
+        return None
+
+    @staticmethod
+    def _get_target_file_name(target):
+        """Create a file name from a TVM target string."""
+        options = target.split(" ")
+        sorted_options = [options[0]] + sorted(options[1:])
+        return "-".join(sorted_options)
+
+
+class NoIndent(object):
+    def __init__(self, value):
+        self.value = value
+
+
+# TODO @mbarrett97 Find a more efficient way to pretty print the JSON
+class NoIndentEncoder(json.JSONEncoder):
+    """JSON pretty printing class to print configs on one line."""
+    marker = "~@{}@~"
+
+    def default(self, obj):
+        if isinstance(obj, NoIndent):
+            return self.marker.format(id(obj))
+        else:
+            super(NoIndentEncoder, self).default(obj)
+
+    def encode(self, obj):
+        json_obj = super(NoIndentEncoder, self).encode(obj)
+        offset = 0
+        while offset != -1:
+            no_indent_index_start = json_obj.find("~@", offset)
+            no_indent_index_stop = json_obj.find("@~", offset)
+            if no_indent_index_start == -1:
+                break
+
+            no_indent_id = int(json_obj[no_indent_index_start+2:no_indent_index_stop])
+            no_indent_obj = PyObj_FromPtr(no_indent_id)
+            no_indent_json = json.dumps(no_indent_obj.value)
+            json_obj = json_obj.replace(
+                '"{}"'.format(self.marker.format(no_indent_id)),
+                no_indent_json,
+            )
+            offset = no_indent_index_stop + 2
+
+        return json_obj

--- a/python/tvm/autotvm/config_library.py
+++ b/python/tvm/autotvm/config_library.py
@@ -112,7 +112,7 @@ class ConfigLibrary:
             self.backup_dir, self.JOBS_INDEX_FILE_NAME + ".backup"
         )
         copyfile(self.jobs_index, backup_jobs_index)
-        with open(self.jobs_index, 'r+') as f:
+        with open(self.jobs_index, "r+") as f:
             job_index = json.load(f)
             highest_job_id = 0
             for job_id in job_index:
@@ -137,7 +137,7 @@ class ConfigLibrary:
 
             for workload in job.results_by_workload:
                 inp, best_result, tuner_name, trials = job.results_by_workload[workload]
-                config_entry_str = record.encode(inp, best_result, 'json')
+                config_entry_str = record.encode(inp, best_result, "json")
                 config_entry = json.loads(config_entry_str)
                 config_entry["t"] = [job_id, tuner_name, trials]
                 task_entry = json.dumps(config_entry)
@@ -175,7 +175,7 @@ class ConfigLibrary:
             self.backup_dir, self._get_target_file_name(target) + ".configs.backup"
         )
         copyfile(config_file, backup_config_file)
-        with open(config_file, 'r+') as f:
+        with open(config_file, "r+") as f:
             existing_configs = json.load(f)
             if new_config_key in existing_configs:
                 existing_config = existing_configs[new_config_key]

--- a/python/tvm/autotvm/config_library.py
+++ b/python/tvm/autotvm/config_library.py
@@ -18,7 +18,6 @@
 """Config Library to store tuning configs"""
 import json
 import os
-from _ctypes import PyObj_FromPtr
 from shutil import copyfile
 from pathlib import Path
 

--- a/python/tvm/autotvm/config_library.py
+++ b/python/tvm/autotvm/config_library.py
@@ -28,10 +28,6 @@ from . import record
 from .task import ApplyHistoryBest
 
 
-class ConfigLibraryException(Exception):
-    pass
-
-
 class ConfigLibrary:
     """A library to store auto-tuning results for any number of targets/workloads.
 

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -25,5 +25,6 @@ class AutotvmGlobalScope(object):
 
         self.cuda_target_arch = None
         self.in_tuning = False
+        self.tuning_job = None
 
 GLOBAL_SCOPE = AutotvmGlobalScope()

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -87,7 +87,12 @@ class Tuner(object):
             result for measurement
         """
 
-    def tune(self, n_trial, measure_option, early_stopping=None, callbacks=(), allow_skipping=True):
+    def tune(self,
+             n_trial,
+             measure_option,
+             early_stopping=None,
+             callbacks=(),
+             allow_skipping=False):
         """Begin tuning
 
         Parameters

--- a/python/tvm/autotvm/tuner/tuning_job.py
+++ b/python/tvm/autotvm/tuner/tuning_job.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tuning Job Class"""
+import datetime
+import numpy as np
+
+from ..env import GLOBAL_SCOPE
+from .callback import log_to_file
+from ..record import load_from_file
+
+
+class TuningJob:
+    """A context to hold information during an auto-tuning job.
+
+    The results of a tuning job can optionally be saved to either a
+    log file or a config library.
+    Parameters
+    ----------
+    log: str
+        A file path where to where the history log should be written.
+    target: str
+        A TVM target string describing the current target.
+    platform: dict
+        A dictionary to hold additional platform information.
+    content: dict
+        A dictionary to hold additional content information.
+    config_library: ConfigLibrary
+        The config library into which to store results.
+
+    """
+    def __init__(
+            self,
+            log,
+            target,
+            platform=None,
+            content=None,
+            config_library=None,
+    ):
+        self.log = log
+        self.target = target
+        if platform is None:
+            platform = {}
+        if content is None:
+            content = {}
+        self.platform = platform
+        self.content = content
+        self.config_library = config_library
+        self.results_by_workload = {}
+        self.start_time = None
+        self.end_time = None
+        self._logging_callback = log_to_file(self.log)
+
+    def log_configs(self, tuner, inputs, results):
+        """Log newly measured configs and update the best results.
+
+        Parameters
+        ----------
+        tuner: tuner.Tuner
+            The tuner used during tuning.
+        inputs: list
+            The list of tuning inputs measured.
+        results: list
+            The list of tuning results obtained.
+
+        """
+        self._logging_callback(tuner, inputs, results)
+        tuner_name = type(tuner).__name__
+        for inp, result in zip(inputs, results):
+            workload = inp.task.workload
+            if workload in self.results_by_workload:
+                _, best_result, _, trials = self.results_by_workload[workload]
+                if np.mean(result[0]) < np.mean(best_result[0]):
+                    self.results_by_workload[workload] = [inp, result, tuner_name, trials]
+            else:
+                self.results_by_workload[workload] = [inp, result, tuner_name, 0]
+
+            self.results_by_workload[workload][3] += 1  # Increment no. of trials
+
+    def get_records(self):
+        """Return the records of the active job."""
+        records = load_from_file(self.log)
+        return records
+
+    def __enter__(self):
+        GLOBAL_SCOPE.tuning_job = self
+        self.start_time = datetime.datetime.utcnow().isoformat()
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        GLOBAL_SCOPE.tuning_job = None
+        self.end_time = datetime.datetime.utcnow().isoformat()
+        if self.config_library:
+            self.config_library.save_job(self)

--- a/tests/python/unittest/test_autotvm_config_library.py
+++ b/tests/python/unittest/test_autotvm_config_library.py
@@ -1,0 +1,252 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test Config Library"""
+
+import copy
+import datetime
+import filecmp
+import json
+import os
+import random
+import tempfile
+
+from tvm.autotvm.config_library import ConfigLibrary
+from tvm.autotvm.task.dispatcher import ApplyHistoryBest
+from tvm.autotvm.tuner.callback import log_to_file
+from tvm.autotvm.record import encode
+
+from test_autotvm_common import get_sample_records
+
+
+def get_random_configs(n):
+    records = get_sample_records(n)
+    random_configs = []
+    r = random.Random()
+    r.seed(42)
+    for record in records:
+        inp, result = record
+        config = json.loads(encode(inp, result))
+        # Generate random tuning data
+        job_id = r.randint(0, 10)
+        tuner = r.choice(["TunerA", "TunerB", "TunerC"])
+        trials = r.randint(0, 1000)
+        config["t"] = [job_id, tuner, trials]
+        # Generate random workload
+        config["i"][4][1] = r.randint(1, 256)
+        config["i"][4][2] = r.randint(1, 256)
+        config["i"][4][3] = r.randint(1, 256)
+        random_configs.append(config)
+
+    return random_configs
+
+
+def test_initialise_config_library():
+    with tempfile.TemporaryDirectory() as tmp_config_dir:
+        # Check library can initialise when directory exists
+        _ = ConfigLibrary(tmp_config_dir)
+        # Check library can initialise when directory doesn't exist
+        config_library = ConfigLibrary(tmp_config_dir + "/nested")
+        with open(config_library.library_index) as f:
+            library_index = json.load(f)
+
+        # Check library index contents are correct
+        library_root = library_index["root"]
+        assert library_root == os.path.join(tmp_config_dir, "nested")
+        assert library_index["targets"] == {}
+        assert library_index["jobs_index"] == config_library.JOBS_INDEX_FILE_NAME
+        assert library_index["jobs_dir"] == config_library.JOBS_DIRECTORY_NAME
+        # Check library job file/dir have been created properly
+        assert os.path.isdir(os.path.join(library_root, library_index["jobs_dir"]))
+        assert os.path.isfile(os.path.join(library_root, library_index["jobs_index"]))
+
+
+def test_save_config():
+    with tempfile.TemporaryDirectory() as tmp_config_dir:
+        config_library = ConfigLibrary(tmp_config_dir)
+        records = get_sample_records(4)
+        configs = []
+        for record in records:
+            inp, result = record
+            config = json.loads(encode(inp, result))
+            config["t"] = [0, "TestTuner", 100]
+            configs.append(config)
+
+        # Alternative target
+        configs[0]["i"][0] = "opencl"
+        # Alternative workload
+        configs[1]["i"][4][1] = 256
+        # Slow config
+        configs[2]["r"][0][0] = 1.0
+        # Fast config
+        configs[3]["r"][0][0] = 0.5
+
+        for config in configs:
+            config_library.save_config(config)
+
+        # Check the target configs files have been created
+        llvm_file = os.path.join(tmp_config_dir, "llvm.configs")
+        opencl_file = os.path.join(tmp_config_dir, "opencl.configs")
+        assert os.path.isfile(llvm_file)
+        assert os.path.isfile(opencl_file)
+        with open(llvm_file) as f:
+            f.seek(0)
+            configs = json.load(f)
+            assert len(configs) == 2, len(configs)
+            for workload in configs:
+                config = configs[workload]
+                assert json.loads(workload.replace("'", '"')) == config["i"][4], workload
+                if config["i"][4][1] == 128:
+                    assert config["r"][0][0] == 0.5, config
+
+
+def test_get_config_file():
+    with tempfile.TemporaryDirectory() as tmp_config_dir:
+        config_library = ConfigLibrary(tmp_config_dir)
+        same_targets = [
+            "llvm -mcpu=test1 -mfloat-abi=hard -mattr=+neon -target=aarch64-linux-gnu",
+            "llvm -mfloat-abi=hard -mcpu=test1 -target=aarch64-linux-gnu -mattr=+neon",
+            "llvm -target=aarch64-linux-gnu -mattr=+neon -mcpu=test1 -mfloat-abi=hard",
+        ]
+        different_targets = [
+            "opencl -device=bifrost",
+            "llvm -target=aarch64-linux-gnu",
+            "llvm -target=aarch64-linux-gnu -mattr=+neon",
+        ]
+        same_config_files = set()
+        for target in same_targets:
+            config_file = config_library.get_config_file(target, create=True)
+            same_config_files.add(config_file)
+
+        # Check that the same targets point to the same file
+        assert len(same_config_files) == 1, same_config_files
+        correct_name = "llvm--mattr=+neon--mcpu=test1--mfloat-abi=hard"\
+                       "--target=aarch64-linux-gnu.configs"
+        correct_path = os.path.join(tmp_config_dir, correct_name)
+        # Check that the file has the correct name
+        generated_path = same_config_files.pop()
+        assert generated_path == correct_path, generated_path
+        different_config_files = set()
+        for target in different_targets:
+            config_file = config_library.get_config_file(target, create=True)
+            different_config_files.add(config_file)
+
+        # Check that different targets point to different files
+        assert len(different_config_files) == 3, different_config_files
+
+
+def test_get_config():
+    with tempfile.TemporaryDirectory() as tmp_config_dir:
+        config_library = ConfigLibrary(tmp_config_dir)
+        configs = get_random_configs(100)
+        for config in configs:
+            config_library.save_config(config)
+
+        # Check all saved configs can be retrieved from the library
+        for config in configs:
+            workload = config["i"][4]
+            target = config["i"][0]
+            saved_config = config_library.get_config(target, workload)
+            assert saved_config == config, saved_config
+
+
+def test_load():
+    with tempfile.TemporaryDirectory() as tmp_config_dir:
+        config_library = ConfigLibrary(tmp_config_dir)
+        configs = get_random_configs(100)
+        for config in configs:
+            config_library.save_config(config)
+
+        context = config_library.load("llvm")
+        assert type(context) == ApplyHistoryBest
+
+
+def test_save_job():
+    class _MockJob:
+        pass
+
+    r = random.Random()
+    r.seed(42)
+    with tempfile.TemporaryDirectory() as tmp_config_dir:
+        config_library = ConfigLibrary(tmp_config_dir)
+        # Make a mock TuningJob object
+        mock_job = _MockJob()
+        mock_job.target = "llvm"
+        mock_job.platform = {"board": "hikey960"}
+        mock_job.content = {"model": "resnet50v2"}
+        mock_job.start_time = datetime.datetime.utcnow().isoformat()
+        mock_job.end_time = datetime.datetime.utcnow().isoformat()
+        # Make mock results
+        records = get_sample_records(4)
+        results_by_workload = {}
+        inputs = []
+        results = []
+        correct_tasks = []
+        for i, record in enumerate(records):
+            inp, result = copy.deepcopy(record)
+            workload = ('matmul', i, 128, 128, 'float32')
+            inp.task.workload = workload
+            tuner = "TestTuner"
+            trials = i*100
+            inputs.append(inp)
+            results.append(result)
+            config_entry = json.loads(encode(inp, result, 'json'))
+            config_entry["t"] = ["1", tuner, trials]
+            correct_tasks.append(json.dumps(config_entry))
+            results_by_workload[workload] = copy.copy([inp, result, tuner, trials])
+
+        mock_job.results_by_workload = results_by_workload
+        # Make mock tuning log
+        tuning_log = os.path.join(tmp_config_dir, 'tuning.log')
+        logging_callback = log_to_file(tuning_log)
+        logging_callback("TestTuner", inputs, results)
+        mock_job.log = tuning_log
+        # Save the mock job
+        config_library.save_job(mock_job, save_history=True)
+        saved_log = os.path.join(tmp_config_dir, "jobs/1_llvm.log")
+        with open(config_library.jobs_index) as f:
+            jobs_index = json.load(f)
+            correct_index = {
+                "1":
+                    {
+                        "id": "1",
+                        "log": saved_log,
+                        "target": mock_job.target,
+                        "platform": mock_job.platform,
+                        "content": mock_job.content,
+                        "start_time": mock_job.start_time,
+                        "end_time": mock_job.end_time,
+                    }
+            }
+            tasks = jobs_index["1"].pop("tasks")
+            # Check the saved tasks are correct
+            assert set(tasks) == set(correct_tasks), tasks
+            # Check the index entry is correct
+            assert jobs_index == correct_index, jobs_index
+
+        # Check saved tuning log exists
+        assert os.path.isfile(saved_log)
+        # Check saved tuning log is equal to the original log
+        assert filecmp.cmp(saved_log, tuning_log)
+
+
+if __name__ == "__main__":
+    test_initialise_config_library()
+    test_save_config()
+    test_get_config_file()
+    test_get_config()
+    test_load()
+    test_save_job()

--- a/tests/python/unittest/test_autotvm_config_library.py
+++ b/tests/python/unittest/test_autotvm_config_library.py
@@ -97,8 +97,16 @@ def test_save_config():
         # Check the target configs files have been created
         llvm_file = os.path.join(tmp_config_dir, "llvm.configs")
         opencl_file = os.path.join(tmp_config_dir, "opencl.configs")
+        backup_llvm_file = os.path.join(
+            tmp_config_dir, ConfigLibrary.BACKUP_DIRECTORY_NAME, "llvm.configs.backup"
+        )
+        backup_opencl_file = os.path.join(
+            tmp_config_dir, ConfigLibrary.BACKUP_DIRECTORY_NAME, "opencl.configs.backup"
+        )
         assert os.path.isfile(llvm_file)
         assert os.path.isfile(opencl_file)
+        assert os.path.isfile(backup_llvm_file)
+        assert os.path.isfile(backup_opencl_file)
         with open(llvm_file) as f:
             f.seek(0)
             configs = json.load(f)
@@ -211,6 +219,12 @@ def test_save_job():
         mock_job.log = tuning_log
         # Save the mock job
         config_library.save_job(mock_job, save_history=True)
+        backup_job_index = os.path.join(
+            tmp_config_dir,
+            ConfigLibrary.BACKUP_DIRECTORY_NAME,
+            ConfigLibrary.JOBS_INDEX_FILE_NAME + ".backup",
+        )
+        assert os.path.isfile(backup_job_index)
         saved_log = os.path.join(tmp_config_dir, "jobs/1_llvm.log")
         with open(config_library.jobs_index) as f:
             jobs_index = json.load(f)

--- a/tests/python/unittest/test_autotvm_config_library.py
+++ b/tests/python/unittest/test_autotvm_config_library.py
@@ -21,7 +21,6 @@ import datetime
 import filecmp
 import json
 import os
-import random
 import tempfile
 
 from tvm.autotvm.config_library import ConfigLibrary
@@ -33,23 +32,21 @@ from test_autotvm_common import get_sample_records
 
 
 def get_random_configs(n):
-    records = get_sample_records(n)
+    hard_configs = [
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 141, 126, 115, 'float32'], {'i': 0, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 1]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[1], 0, 0, 1574432749.5476737], 'v': 0.1, 't': [10, 'TunerA', 25]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 45, 217, 17, 'float32'], {'i': 1, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 2]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[2], 0, 1, 1574432749.5476935], 'v': 0.1, 't': [2, 'TunerC', 104]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 120, 14, 102, 'float32'], {'i': 2, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 4]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[3], 0, 2, 1574432749.5477045], 'v': 0.1, 't': [0, 'TunerA', 223]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 215, 113, 230, 'float32'], {'i': 3, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 8]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[4], 0, 3, 1574432749.547714], 'v': 0.1, 't': [10, 'TunerC', 558]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 4, 82, 217, 'float32'], {'i': 4, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 16]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[5], 0, 4, 1574432749.5477228], 'v': 0.1, 't': [9, 'TunerB', 828]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 111, 173, 53, 'float32'], {'i': 5, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 32]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[6], 0, 5, 1574432749.5477316], 'v': 0.1, 't': [5, 'TunerB', 159]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 184, 177, 136, 'float32'], {'i': 6, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 64]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[7], 0, 6, 1574432749.5477402], 'v': 0.1, 't': [1, 'TunerB', 99]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 64, 194, 41, 'float32'], {'i': 7, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 128]], ['tile_x', 'sp', [-1, 1]]]}], 'r': [[8], 0, 7, 1574432749.547748], 'v': 0.1, 't': [0, 'TunerC', 470]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 186, 99, 36, 'float32'], {'i': 8, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 1]], ['tile_x', 'sp', [-1, 2]]]}], 'r': [[9], 0, 8, 1574432749.547757], 'v': 0.1, 't': [8, 'TunerB', 849]},
+        {'i': ['llvm', 'matmul', [128, 128, 128, 'float32'], {}, ['matmul', 149, 41, 120, 'float32'], {'i': 9, 't': '', 'c': None, 'e': [['tile_y', 'sp', [-1, 2]], ['tile_x', 'sp', [-1, 2]]]}], 'r': [[10], 0, 9, 1574432749.5477653], 'v': 0.1, 't': [0, 'TunerC', 233]},
+    ]
     random_configs = []
-    r = random.Random()
-    r.seed(42)
-    for record in records:
-        inp, result = record
-        config = json.loads(encode(inp, result))
-        # Generate random tuning data
-        job_id = r.randint(0, 10)
-        tuner = r.choice(["TunerA", "TunerB", "TunerC"])
-        trials = r.randint(0, 1000)
-        config["t"] = [job_id, tuner, trials]
-        # Generate random workload
-        config["i"][4][1] = r.randint(1, 256)
-        config["i"][4][2] = r.randint(1, 256)
-        config["i"][4][3] = r.randint(1, 256)
-        random_configs.append(config)
+    for i in range(n):
+        random_configs.append(hard_configs[i // 10])
 
     return random_configs
 
@@ -178,8 +175,6 @@ def test_save_job():
     class _MockJob:
         pass
 
-    r = random.Random()
-    r.seed(42)
     with tempfile.TemporaryDirectory() as tmp_config_dir:
         config_library = ConfigLibrary(tmp_config_dir)
         # Make a mock TuningJob object

--- a/tests/python/unittest/test_autotvm_tuning_job.py
+++ b/tests/python/unittest/test_autotvm_tuning_job.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test Tuning Job"""
+import copy
+import numpy as np
+import random
+import tempfile
+
+from tvm.autotvm.tuner.tuning_job import TuningJob
+
+from test_autotvm_common import get_sample_records
+
+
+class MockTuner:
+    pass
+
+
+def test_log_configs():
+    r = random.Random()
+    r.seed(42)
+    with tempfile.TemporaryFile("w") as log_file:
+        job = TuningJob(
+            log_file,
+            "llvm",
+        )
+        timings = [[r.randint(0, 10) for _ in range(4)] for _ in range(10)]
+        avg_timings = np.mean(timings, axis=1)
+        min_time = min(avg_timings)
+        # Create first workload results
+        records = get_sample_records(10)
+        workloads = [
+            ("matmul", 64, 64, 64, "float32"),
+            ("matmul", 128, 128, 128, "float32"),
+            ("matmul", 256, 256, 256, "float32"),
+        ]
+        inputs = []
+        results = []
+        for workload in workloads:
+            for record, timing in zip(records, timings):
+                inp, result = copy.deepcopy(record)
+                result = result._replace(costs=tuple(timing))
+                inp.task.workload = workload
+                inputs.append(inp)
+                results.append(result)
+
+        job.log_configs(MockTuner(), inputs, results)
+        # Check the workloads have been saved
+        assert set(workloads) == set(job.results_by_workload.keys())
+        for workload in job.results_by_workload:
+            inp, result, tuner_name, trials = job.results_by_workload[workload]
+            # Check the best record was saved
+            assert tuner_name == "MockTuner"
+            assert trials == 10
+            assert inp.task.workload == workload
+            assert np.mean(result.costs) == min_time
+
+
+def test_get_records():
+    with tempfile.NamedTemporaryFile("w") as log_file:
+        job = TuningJob(
+            log_file.name,
+            "llvm",
+        )
+        records = get_sample_records(10)
+        inputs = []
+        results = []
+        for record in records:
+            inp, result = record
+            inputs.append(inp)
+            results.append(result)
+
+        job.log_configs(MockTuner(), inputs, results)
+        record_generator = job.get_records()
+        record_count = len([1 for _ in record_generator])
+        assert record_count == 10
+
+
+if __name__ == "__main__":
+    test_log_configs()
+    test_get_records()

--- a/tests/python/unittest/test_autotvm_tuning_job.py
+++ b/tests/python/unittest/test_autotvm_tuning_job.py
@@ -17,7 +17,6 @@
 """Test Tuning Job"""
 import copy
 import numpy as np
-import random
 import tempfile
 
 from tvm.autotvm.tuner.tuning_job import TuningJob
@@ -30,14 +29,13 @@ class MockTuner:
 
 
 def test_log_configs():
-    r = random.Random()
-    r.seed(42)
     with tempfile.TemporaryFile("w") as log_file:
         job = TuningJob(
             log_file,
             "llvm",
         )
-        timings = [[r.randint(0, 10) for _ in range(4)] for _ in range(10)]
+        timings = [[1, 4, 2], [5, 1, 3], [8, 3, 2], [9, 7, 8], [3, 7, 6],
+                   [2, 8, 2], [1, 2, 1], [7, 7, 7], [9, 3, 3], [5, 3, 9]]
         avg_timings = np.mean(timings, axis=1)
         min_time = min(avg_timings)
         # Create first workload results

--- a/tutorials/autotvm/tune_with_config_library.py
+++ b/tutorials/autotvm/tune_with_config_library.py
@@ -1,0 +1,162 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Auto-tuning using a 'ConfigLibrary'
+===============================================
+**Author**: `Matt Barrett <https://github.com/mbarrett97>`
+
+This tutorial describes how to use a ConfigLibrary when
+auto-tuning a network.
+"""
+import numpy as np
+
+import tvm
+from tvm import autotvm
+from tvm import relay
+from tvm.relay import testing
+from tvm.autotvm.tuner import GridSearchTuner
+from tvm.autotvm.config_library import ConfigLibrary
+from tvm.autotvm.tuner.tuning_job import TuningJob
+import tvm.contrib.graph_runtime as runtime
+
+#################################################################
+# Define network
+# --------------
+# First we need to define the network in relay frontend API.
+# In this tutorial, we choose resnet-18 as simple example.
+
+
+def get_network():
+    """Get the symbol definition and random weight of a resnet network"""
+    input_shape = (1, 3, 224, 224)
+    output_shape = (1, 1000)
+    mod, params = relay.testing.resnet.get_workload(num_layers=18, batch_size=1, dtype="float32")
+    return mod, params, input_shape, output_shape
+
+
+#################################################################
+# We also choose some generic CPU tuning options
+target = "llvm"
+tuning_option = {
+    'log_filename': 'tuning.log',
+    'measure_option': autotvm.measure_option(
+        builder=autotvm.LocalBuilder(),
+        runner=autotvm.LocalRunner(number=10, repeat=1,
+                                   min_repeat_ms=1000),
+    ),
+}
+
+#################################################################
+# Perform the auto-tuning using jobs
+# ----------------------------------
+# To make use of the config library during auto-tuning, we should
+# use a TuningJob. A job consists of a series of tuning tasks
+# that have been tuned sequentially. We can annotate a tuning
+# job with additional information such as the platform the tuning
+# was performed on and when the job was run. If a config library
+# is supplied to a TuningJob, the job will be saved in the
+# library so that its results can be used during both compilation
+# and subsequent tuning jobs.
+#
+# The following shows a simple tuning loop that utilises a
+# TuningJob and ConfigLibrary. As the TuningJob is aware of a
+# library, it can skip over tasks that have already been tuned
+# during a previous job.
+
+
+def tune_kernels(tasks,
+                 n_trial,
+                 config_library,
+                 measure_option,
+                 log_filename='tuning.log'):
+
+    # Create a tuning job and point it at a config library
+    job = TuningJob(
+        log_filename,
+        target,
+        config_library=config_library,
+    )
+    # Use the tuning job during the tuning loop
+    with job:
+        for i, tsk in enumerate(tasks):
+            prefix = "[Task %2d/%2d] " % (i+1, len(tasks))
+
+            # Convert conv2d tasks to conv2d_NCHWc tasks
+            task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=tsk.args,
+                                       target=target, template_key='direct')
+            task.workload = tsk.workload
+
+            # Create tuner
+            tuner_obj = GridSearchTuner(task)
+
+            # Do tuning - the tuner will skip tasks which have already been tuned
+            # in the config library
+            tuner_obj.tune(
+                n_trial=n_trial,
+                early_stopping=n_trial,
+                measure_option=measure_option,
+                callbacks=[autotvm.callback.progress_bar(n_trial, prefix=prefix)],
+            )
+
+########################################################################
+# Once we have auto-tuned a network and saved that into a config
+# library, we need to use that library during compilation. This can be
+# done simply by using config_library.load(target) where 'target' is the
+# same as the target used during tuning.
+#
+# If you run this example for a second time, you should see that the
+# tuning completes almost immediately as all pre-tuned tasks are
+# loaded from the library.
+
+
+def tune_and_evaluate(tuning_opt):
+    # extract workloads from relay program
+    print("Extract tasks...")
+    mod, params, data_shape, out_shape = get_network()
+    tasks = autotvm.task.extract_from_program(mod["main"], target=target,
+                                              params=params, ops=(relay.op.nn.conv2d,))
+
+    # Initialise a ConfigLibrary with a given index file
+    config_library = ConfigLibrary("./configs")
+    # run tuning tasks
+    print("Tuning...")
+    tune_kernels(tasks, 20, config_library, **tuning_opt)
+
+    # To use the results in the config library, use load(target)
+    with config_library.load(target):
+        print("Compile...")
+        with relay.build_config(opt_level=3):
+            graph, lib, params = relay.build_module.build(
+                mod, target=target, params=params)
+
+        # upload parameters to device
+        ctx = tvm.cpu()
+        data_tvm = tvm.nd.array((np.random.uniform(size=data_shape)).astype("float32"))
+        module = runtime.create(graph, lib, ctx)
+        module.set_input("data", data_tvm)
+        module.set_input(**params)
+
+        # evaluate
+        print("Evaluate inference time cost...")
+        ftimer = module.module.time_evaluator("run", ctx, number=100, repeat=3)
+        prof_res = np.array(ftimer().results) * 1000  # convert to millisecond
+        print("Mean inference time (std dev): %.2f ms (%.2f ms)" %
+              (np.mean(prof_res), np.std(prof_res)))
+
+
+# Uncomment this line to run the tutorial
+# tune_and_evaluate(tuning_option)

--- a/tutorials/autotvm/tune_with_config_library.py
+++ b/tutorials/autotvm/tune_with_config_library.py
@@ -103,13 +103,14 @@ def tune_kernels(tasks,
             # Create tuner
             tuner_obj = GridSearchTuner(task)
 
-            # Do tuning - the tuner will skip tasks which have already been tuned
-            # in the config library
+            # Do tuning - by setting allow_skipping=True, the tuner will skip
+            # tasks which have already been tuned in the config library
             tuner_obj.tune(
                 n_trial=n_trial,
                 early_stopping=n_trial,
                 measure_option=measure_option,
                 callbacks=[autotvm.callback.progress_bar(n_trial, prefix=prefix)],
+                allow_skipping=True,
             )
 
 ########################################################################


### PR DESCRIPTION
This implements the first stage of an offline AutoTVM cache, somewhat like an offline TopHub. Auto-tuning can be performed in 'jobs' which are a series of sequentially tuned tasks. Data describing the platform on which the job was performed + when it took place can also be saved into the library.
    
This is initial infrastructure to allow for more advanced management of the auto-tuning process. It includes a mechanism to skip tasks that are already tuned in the library.
    
For further information, see the tutorial: 'tutorials/autotvm/tune_with_config_library.py'.

RFC is here: https://github.com/dmlc/tvm/issues/4150