### PR TITLE
[PERF] Parallelize reduction for CPU

### DIFF
--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -8,6 +8,7 @@ from .binary_dense import schedule_binary_dense
 from .nn import *
 from .conv2d_int8 import *
 from .injective import *
+from .reduction import *
 from .pooling import schedule_pool, schedule_adaptive_pool
 from .bitserial_conv2d import schedule_bitserial_conv2d
 from .bitserial_dense import schedule_bitserial_dense

--- a/topi/python/topi/x86/reduction.py
+++ b/topi/python/topi/x86/reduction.py
@@ -33,7 +33,7 @@ def _schedule_reduce(sch, op, is_idx_reduce=False):
     const_shape = True
     out_shape = get_const_tuple(out.shape)
     for d in out_shape:
-        if isinstance(d, tvm.expr.Var):
+        if not isinstance(d, int):
             const_shape = False
             break
 
@@ -109,8 +109,10 @@ def schedule_reduce(outs):
             for tensor in input_tensors:
                 if tensor.op not in scheduled_ops:
                     traverse_before_reduce(tensor.op)
+        elif isinstance(operator, tvm.tensor.PlaceholderOp):
+            pass
         else:
-            raise RuntimeError("Unsupported operator: %s" % operator.tag)
+            raise RuntimeError("Unsupported operator: %s (tag: %s)" % (operator, operator.tag))
 
         scheduled_ops.append(operator)
 

--- a/topi/python/topi/x86/reduction.py
+++ b/topi/python/topi/x86/reduction.py
@@ -22,15 +22,13 @@ from .. import tag
 from .. import generic
 
 
-def _schedule_reduce(sch, out, is_idx_reduce=False):
+def _schedule_reduce(sch, out):
     if len(sch[out].op.axis) >= 5:
+        # avoid too many parallelism
         fused = sch[out].fuse(sch[out].op.axis[0], sch[out].op.axis[1], sch[out].op.axis[2])
         sch[out].parallel(fused)
-    elif len(sch[out].op.axis) >= 3:
-        fused = sch[out].fuse(sch[out].op.axis[0], sch[out].op.axis[1], sch[out].op.axis[2])
-        sch[out].parallel(fused)
-    elif len(sch[out].op.axis) >= 1:
-        sch[out].parallel(sch[out].op.axis[0])
+    else:
+        fused = sch[out].fuse(*sch[out].op.axis)
     
 
 @generic.schedule_reduce.register(["cpu"])

--- a/topi/python/topi/x86/reduction.py
+++ b/topi/python/topi/x86/reduction.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""x86 declaration and schedules."""
+from __future__ import absolute_import as _abs
+import tvm
+from .. import tag
+from .. import generic
+
+
+def _schedule_reduce(sch, out, is_idx_reduce=False):
+    if len(sch[out].op.axis) >= 5:
+        fused = sch[out].fuse(sch[out].op.axis[0], sch[out].op.axis[1], sch[out].op.axis[2])
+        sch[out].parallel(fused)
+    elif len(sch[out].op.axis) >= 3:
+        fused = sch[out].fuse(sch[out].op.axis[0], sch[out].op.axis[1], sch[out].op.axis[2])
+        sch[out].parallel(fused)
+    elif len(sch[out].op.axis) >= 1:
+        sch[out].parallel(sch[out].op.axis[0])
+    
+
+@generic.schedule_reduce.register(["cpu"])
+def schedule_reduce(outs):
+    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
+    sch = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
+    def traverse_before_reduce(operator):
+        """Internal travserse function"""
+        if isinstance(operator, tvm.tensor.PlaceholderOp):
+            return
+        if tag.is_injective(operator.tag):
+            sch[operator].compute_inline()
+            for tensor in operator.input_tensors:
+                if tensor.op not in scheduled_ops:
+                    traverse_before_reduce(tensor.op)
+        else:
+            raise RuntimeError("Unsupported operator: %s" % operator.tag)
+
+        scheduled_ops.append(operator)
+
+    def traverse_after_reduce(operator):
+        """Internal travserse function"""
+        if tag.is_broadcast(operator.tag):
+            if operator not in scheduled_ops:
+                generic.schedule_injective_from_existing(sch, operator)
+            for tensor in operator.input_tensors:
+                traverse_after_reduce(tensor.op)
+        elif operator.tag == 'comm_reduce':
+            _schedule_reduce(sch, operator, is_idx_reduce=False)
+            for tensor in operator.input_tensors:
+                if tensor.op not in scheduled_ops:
+                    traverse_before_reduce(tensor.op)
+        elif operator.tag == 'comm_reduce_idx':
+            _schedule_reduce(sch, operator, is_idx_reduce=True)
+            input_tensors = operator.input_tensors[0].op.input_tensors
+            for tensor in input_tensors:
+                if tensor.op not in scheduled_ops:
+                    traverse_before_reduce(tensor.op)
+        else:
+            raise RuntimeError("Unsupported operator: %s" % operator.tag)
+
+        scheduled_ops.append(operator)
+
+    traverse_after_reduce(outs[0].op)
+    return sch
+

--- a/topi/python/topi/x86/reduction.py
+++ b/topi/python/topi/x86/reduction.py
@@ -37,7 +37,7 @@ def _schedule_reduce(sch, op, is_idx_reduce=False):
             const_shape = False
             break
 
-    if const_shape: 
+    if const_shape:
         naxes = len(sch[out].op.axis)
         parallelism = 1
         fuse_axes = []

--- a/topi/python/topi/x86/reduction.py
+++ b/topi/python/topi/x86/reduction.py
@@ -76,4 +76,3 @@ def schedule_reduce(outs):
 
     traverse_after_reduce(outs[0].op)
     return sch
-


### PR DESCRIPTION
Can significantly reduce the latency for ops like mean and variance, but also increase latency for small reduction ops such as sum, max, etc. However these small ops are fast anyway. So I think it's worth to parallelize the reduction by default.

Will add some benchmark result soon...

@anijain2305 @Huyuwei @kevinthesun 