### PR TITLE
[Relay][Frontend][Tensorflow] Fix GatherV2, Add StopGradient

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -851,11 +851,14 @@ def _gather():
             axis = _get_num_param(params, inputs.pop(2))
         else:
             axis = 0
+        if int(attr.get('batch_dims', 0)) != 0:
+            raise tvm.error.OpAttributeUnImplemented(
+                'Attribute batch_dims is not supported')
         new_input = inputs[0:2]
         return AttrCvt(op_name="take",
                        extras={'axis': tvm.const(axis, 'int32')},
                        ignores=['Tindices', 'Tparams', 'validate_indices',
-                                'Taxis', '_class'])(new_input, attr)
+                                'Taxis', '_class', 'batch_dims'])(new_input, attr)
     return _impl
 
 def _gather_nd():
@@ -1438,6 +1441,7 @@ _convert_map = {
     'Square'                            : _square(),
     'SquaredDifference'                 : _squared_difference(),
     'Squeeze'                           : _squeeze(),
+    'StopGradient'                      : _identity(),
     'StridedSlice'                      : _stridedSlice(),
     'Sub'                               : _elemwise('subtract'),
     'Sum'                               : _sum(),


### PR DESCRIPTION
These changes are needed to parse a BERT TF model into relay.

1. GatherV2
TensorFlow recently [added `batch_dims` as an attribute of the GatherV2 op](https://github.com/tensorflow/tensorflow/commit/4d56e9709f1864699be7241a3d1938816d9f31c5#diff-0a1b05e2252bef657373e11f17bfa5d3) to support batched gather. This would cause the parser the fail since it didn't expect that attribute. I added a check to make sure the attribute doesn't change the behavior of the op if it happens to exist and also added it to the ignore list. We can support parsing of batched gather at a later date.

2. StopGradient
This is a training op meant to stop gradient flow over certain edges in the graph. It has no purpose in inference so it can be safely mapped to identity.