### PR TITLE
[AutoTVM] Add batch_matmul to tunable operations

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -117,6 +117,7 @@ def extract_from_multiple_program(funcs, params, ops, target, target_host=None):
                                  topi.nn.group_conv2d_nchw, topi.nn.conv2d_NCHWc],
         tvm.relay.op.nn.conv2d_transpose: [topi.nn.conv2d_transpose_nchw],
         tvm.relay.op.nn.dense: [topi.nn.dense],
+        tvm.relay.op.nn.batch_matmul: [topi.nn.batch_matmul],
         tvm.relay.op.nn.deformable_conv2d: [topi.nn.deformable_conv2d_nchw],
     }
 

--- a/python/tvm/autotvm/task/topi_integration.py
+++ b/python/tvm/autotvm/task/topi_integration.py
@@ -87,6 +87,7 @@ class TaskExtractEnv:
             topi.nn.conv2d_NCHWc: "topi_x86_conv2d_NCHWc",
             topi.nn.conv2d_NCHWc_int8: "topi_x86_conv2d_NCHWc_int8",
             topi.nn.dense: "topi_nn_dense",
+            topi.nn.batch_matmul: "topi_nn_batch_matmul",
             topi.nn.bitserial_conv2d_nchw: "topi_nn_bitserial_conv2d_nchw",
             topi.nn.bitserial_conv2d_nhwc: "topi_nn_bitserial_conv2d_nhwc",
             topi.nn.bitserial_dense: "topi_nn_bitserial_dense",
@@ -103,6 +104,7 @@ class TaskExtractEnv:
             topi.nn.conv2d_NCHWc: [topi.generic.schedule_conv2d_NCHWc],
             topi.nn.conv2d_NCHWc_int8: [topi.generic.schedule_conv2d_NCHWc_int8],
             topi.nn.dense: [topi.generic.schedule_dense],
+            topi.nn.batch_matmul: [topi.generic.schedule_batch_matmul],
             topi.nn.bitserial_conv2d_nchw: [topi.generic.schedule_bitserial_conv2d_nchw],
             topi.nn.bitserial_conv2d_nhwc: [topi.generic.schedule_bitserial_conv2d_nhwc],
             topi.nn.bitserial_dense: [topi.generic.schedule_bitserial_dense],
@@ -118,6 +120,7 @@ class TaskExtractEnv:
             topi.nn.group_conv2d_nchw:      lambda x: setattr(topi.nn, 'group_conv2d_nchw', x),
             topi.nn.conv2d_transpose_nchw:  lambda x: setattr(topi.nn, 'conv2d_transpose_nchw', x),
             topi.nn.dense:                  lambda x: setattr(topi.nn, 'dense', x),
+            topi.nn.batch_matmul:           lambda x: setattr(topi.nn, 'batch_matmul', x),
             topi.nn.bitserial_conv2d_nchw:  lambda x: setattr(topi.nn, 'bitserial_conv2d_nchw', x),
             topi.nn.bitserial_conv2d_nhwc:  lambda x: setattr(topi.nn, 'bitserial_conv2d_nhwc', x),
             topi.nn.bitserial_dense:        lambda x: setattr(topi.nn, 'bitserial_dense', x),
@@ -225,6 +228,15 @@ class TaskExtractEnv:
             if bias is not None:
                 return s, [data, weight, bias, C]
             return s, [data, weight, C]
+
+        @register("topi_nn_batch_matmul")
+        def _topi_nn_batch_matmul(*args, **kwargs):
+            assert not kwargs, "Do not support kwargs in template function call"
+            args = deserialize_args(args)
+            A, B = args
+            C = topi.nn.batch_matmul(A, B)
+            s = topi.generic.schedule_batch_matmul([C])
+            return s, [A, B, C]
 
         @register("topi_nn_bitserial_conv2d_nhwc")
         def _topi_bitserial_conv2d_nhwc(*args, **kwargs):

--- a/topi/python/topi/x86/batch_matmul.py
+++ b/topi/python/topi/x86/batch_matmul.py
@@ -44,7 +44,7 @@ def _declaration_batch_matmul_nopack(cfg, in_A, in_B):
     cfg.define_split("tile_x", N, num_outputs=2)
     cfg.define_split("tile_k", K, num_outputs=2)
     if cfg.is_fallback:
-        _default_batch_matmul_nopack_config(cfg, B, M, N, K)
+        _default_batch_matmul_nopack_config(cfg, M, N, K)
 
     k = tvm.reduce_axis((0, K), name='k')
     C = tvm.compute(
@@ -102,7 +102,7 @@ def schedule_batch_matmul(cfg, outs):
     return s
 
 
-def _default_batch_matmul_nopack_config(cfg, B, M, N, K):
+def _default_batch_matmul_nopack_config(cfg, M, N, K):
     cfg["tile_k"] = SplitEntity([K // 16, 16])
     x_bn = get_max_power2_factor(N, 8)
     cfg["tile_x"] = SplitEntity([N // x_bn, x_bn])

--- a/topi/python/topi/x86/batch_matmul.py
+++ b/topi/python/topi/x86/batch_matmul.py
@@ -42,7 +42,7 @@ def _declaration_batch_matmul_nopack(cfg, x, y):
     -------
     output : tvm.Tensor
         3-D with shape [batch, M, N]
-    """    
+    """
     print("CFG TYPE: ", type(cfg))
     target = tvm.target.current_target()
     if "cblas" in target.libs:

--- a/topi/python/topi/x86/batch_matmul.py
+++ b/topi/python/topi/x86/batch_matmul.py
@@ -102,7 +102,7 @@ def schedule_batch_matmul(cfg, outs):
             cfg.define_split("tile_k", K, num_outputs=2)
 
             k, = s[C].op.reduce_axis
-            
+
             ko, ki = cfg["tile_k"].apply(s, C, k)
             CC = s.rfactor(C, ki)
 

--- a/topi/python/topi/x86/batch_matmul.py
+++ b/topi/python/topi/x86/batch_matmul.py
@@ -43,7 +43,6 @@ def _declaration_batch_matmul_nopack(cfg, x, y):
     output : tvm.Tensor
         3-D with shape [batch, M, N]
     """
-    print("CFG TYPE: ", type(cfg))
     target = tvm.target.current_target()
     if "cblas" in target.libs:
         return cblas.batch_matmul(x, y, False, True)

--- a/topi/python/topi/x86/dense.py
+++ b/topi/python/topi/x86/dense.py
@@ -52,13 +52,11 @@ def _declaration_dense_pack(cfg, data, weight, bias=None, out_dtype=None):
         out_dtype = data.dtype
     M, K = get_const_tuple(data.shape) # batch, in_dim
     N, _ = get_const_tuple(weight.shape) # out_dim
-    # create tuning space
-    cfg.define_split("tile_y", M, num_outputs=3)
-    cfg.define_split("tile_x", N, num_outputs=3)
-    cfg.define_split("tile_k", K, num_outputs=2)
+
     if cfg.is_fallback:
         _default_dense_pack_config(cfg, M, N, K)
 
+    cfg.define_split("tile_x", N, num_outputs=3)
     packw_bn = cfg["tile_x"].size[-1]
     packw_shape = (N // packw_bn, K, packw_bn)
     packw = tvm.compute(packw_shape,
@@ -84,15 +82,14 @@ def _declaration_dense_pack(cfg, data, weight, bias=None, out_dtype=None):
 def _declaration_dense_nopack(cfg, data, weight, bias=None, out_dtype=None):
     if out_dtype is None:
         out_dtype = data.dtype
+
     M, K = get_const_tuple(data.shape)
     N, _ = get_const_tuple(weight.shape)
-    # create tuning space
-    cfg.define_split("tile_y", M, num_outputs=2)
-    cfg.define_split("tile_x", N, num_outputs=2)
-    cfg.define_split("tile_k", K, num_outputs=2)
+
     if cfg.is_fallback:
         _default_dense_nopack_config(cfg, M, N, K)
 
+    cfg.define_split("tile_k", K, num_outputs=2)
     vec = cfg["tile_k"].size[-1]
     k = tvm.reduce_axis((0, K // vec), "k")
     CC = tvm.compute((M, N, vec),
@@ -160,6 +157,12 @@ def _schedule_dense_nopack(cfg, outs):
 
 def _schedule_dense_pack_template(cfg, s, C):
     A, packedB = s[C].op.input_tensors
+    # create tuning space
+    M, K = get_const_tuple(A.shape)
+    N_pack, _, pack_bn = get_const_tuple(packedB.shape)
+    N = N_pack * pack_bn
+    cfg.define_split("tile_y", M, num_outputs=3)
+    cfg.define_split("tile_k", K, num_outputs=2)
 
     CC = s.cache_write(C, "global")
     y, x = s[C].op.axis
@@ -190,6 +193,15 @@ def _schedule_dense_pack_template(cfg, s, C):
 
 
 def _schedule_dense_nopack_template(cfg, s, C):
+    CC, = s[C].op.input_tensors
+    data, weight = s[CC].op.input_tensors
+    M, K = get_const_tuple(data.shape)
+    N, _ = get_const_tuple(weight.shape)
+    # create tuning space
+    cfg.define_split("tile_y", M, num_outputs=2)
+    cfg.define_split("tile_x", N, num_outputs=2)
+    cfg.define_split("tile_k", K, num_outputs=2)
+
     y, x = s[C].op.axis
     kk, = s[C].op.reduce_axis
     yo, yi = cfg["tile_y"].apply(s, C, y)
@@ -199,7 +211,6 @@ def _schedule_dense_nopack_template(cfg, s, C):
     s[C].parallel(xyo)
     s[C].unroll(kk)
 
-    CC, = s[C].op.input_tensors
     s[CC].compute_at(s[C], xyo)
     z, y, x = s[CC].op.axis
     k, = s[CC].op.reduce_axis

--- a/topi/python/topi/x86/dense.py
+++ b/topi/python/topi/x86/dense.py
@@ -200,7 +200,6 @@ def _schedule_dense_nopack_template(cfg, s, C):
     # create tuning space
     cfg.define_split("tile_y", M, num_outputs=2)
     cfg.define_split("tile_x", N, num_outputs=2)
-    cfg.define_split("tile_k", K, num_outputs=2)
 
     y, x = s[C].op.axis
     kk, = s[C].op.reduce_axis


### PR DESCRIPTION
The rising popularity of BERT models suggests that batch matmul is going to become an increasingly important op for TVM to have first class support of. This PR adds batch_matmul to the list of operations that AutoTVM can tune for and templatizes the x86 schedule. Although the templatization and backends covered in this PR are very limited, it serves a starting point to build off of. The x86 fallback configuration is identical to the static schedule in master branch.