### PR TITLE
Require LLVM >= 9 for AMDGPU backend

### DIFF
--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -183,6 +183,11 @@ inline int DetectROCMComputeVersion(const std::string& target) {
 }
 
 runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
+#if TVM_LLVM_VERSION < 90
+  LOG(FATAL) << "AMDGPU backend requires at least LLVM 9";
+  // Lower versions will crash when loading the bitcode, see
+  // issue #4087 for a discussion
+#endif
   InitializeLLVM();
   CHECK(target.length() >= 4 &&
         target.substr(0, 4) == "rocm");


### PR DESCRIPTION
LLVM 8 will crash when loading the bitcodes

This is a runtime check as the file will be compiled in even when
USE_ROCM OFF is used in the configuration if ROCM is installed
in the default location.

Fixes: #4087
