### PR TITLE
Work around typing.Deque import error for Python 3.5

### DIFF
--- a/python/tvm/relay/_parser.py
+++ b/python/tvm/relay/_parser.py
@@ -21,8 +21,20 @@ from __future__ import absolute_import
 
 import sys
 from ast import literal_eval
-from typing import Any, Deque, Dict, List, Optional, TypeVar, Tuple, Union
 from collections import deque
+
+try:
+    # no typing.Deque in Python 3.5
+    # https://bugs.python.org/issue29011
+    from typing import Any, Dict, List, Optional, TypeVar, Tuple, Union, MutableSequence, T, Deque
+except ImportError:
+    class Deque(deque, MutableSequence[T], extra=deque):
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, Deque):
+                raise TypeError("Type Deque cannot be instantiated; "
+                                "use deque() instead")
+            return deque.__new__(cls, *args, **kwds)
 
 import tvm
 


### PR DESCRIPTION
Issue is: https://discuss.tvm.ai/t/what-is-minimal-python3-version-requirements/4594

After https://github.com/apache/incubator-tvm/pull/4250 is merged, newest code still not worked in python 3.5. 

Because "from typing import Deque" will cause ImportError,  and it's from https://github.com/apache/incubator-tvm/pull/3863

I fix this and make tvm works in my env(python 3.5.2), however, I am not sure where this fix is appropriate or do we have more elegant way,  would you pls help take a look, thanks

@tqchen @MarisaKirisame