### PR TITLE
[TOPI] Fix bug in Winograd on CUDA

### DIFF
--- a/topi/python/topi/cuda/conv2d_winograd.py
+++ b/topi/python/topi/cuda/conv2d_winograd.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name,unused-variable,unused-argument
 """Winograd template for cuda backend"""
 
+import logging
 import tvm
 from tvm import autotvm
 
@@ -26,6 +27,8 @@ from ..util import get_const_int, get_const_tuple, traverse_inline
 from ..generic import schedule_conv2d_winograd_without_weight_transform
 from ..nn.winograd_util import winograd_transform_matrices
 
+
+logger = logging.getLogger('conv2d_winograd')
 
 def _infer_tile_size(data, kernel):
     N, CI, H, W = get_const_tuple(data.shape)
@@ -42,25 +45,24 @@ def winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dty
 
     N, CI, H, W = get_const_tuple(data.shape)
 
-    if not pre_computed: # kernel tensor is raw tensor, do strict check
-        if isinstance(dilation, int):
-            dilation_h = dilation_w = dilation
-        else:
-            dilation_h, dilation_w = dilation
-        if dilation_h != 1 or dilation_w != 1:
-            kernel = dilate(kernel, (1, 1, dilation_h, dilation_w))
+    if isinstance(dilation, int):
+        dilation_h = dilation_w = dilation
+    else:
+        dilation_h, dilation_w = dilation
+    HPAD, WPAD, _, _ = nn.get_pad_tuple(padding, kernel)
+    HSTR, WSTR = (strides, strides) if isinstance(strides, int) else strides
 
+    if not pre_computed: # kernel tensor is raw tensor, do strict check
+        if dilation_h != 1 or dilation_w != 1:
+            kernel = dilation(kernel, (1, 1, dilation_h, dilation_w))
         CO, CI, KH, KW = get_const_tuple(kernel.shape)
-        HPAD, WPAD, _, _ = nn.get_pad_tuple(padding, kernel)
-        HSTR, WSTR = (strides, strides) if isinstance(strides, int) else strides
         assert HSTR == 1 and WSTR == 1 and KH == KW
-    else:                   # kernel tensor is pre-transfomred. this op is created by
-                            # alter op layout, do not check
+    else:
+        # kernel tensor is pre-transfomred. this op is created by alter op layout.
         # dilation is not supported
-        HSTR = WSTR = 1
-        HPAD = WPAD = 1
-        KH = KW = 3
         _, _, CI, CO = get_const_tuple(kernel.shape)
+        KH = KW = 3
+        assert HSTR == 1 and WSTR == 1 and dilation_h == 1 and dilation_w == 1
 
     data_pad = nn.pad(data, (0, 0, HPAD, WPAD), (0, 0, HPAD, WPAD), name="data_pad")
 
@@ -384,7 +386,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, F):
             return F.nn.conv2d(*copy_inputs, **new_attrs)
 
         if attrs.get_int_tuple("dilation") != (1, 1):
-            warnings.warn("Does not support weight pre-transform for dilated convolution.")
+            logger.warning("Does not support weight pre-transform for dilated convolution.")
             return None
 
         # pre-compute weight transformation in winograd

--- a/topi/python/topi/cuda/conv2d_winograd.py
+++ b/topi/python/topi/cuda/conv2d_winograd.py
@@ -49,7 +49,6 @@ def winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dty
         dilation_h = dilation_w = dilation
     else:
         dilation_h, dilation_w = dilation
-    HPAD, WPAD, _, _ = nn.get_pad_tuple(padding, kernel)
     HSTR, WSTR = (strides, strides) if isinstance(strides, int) else strides
 
     if not pre_computed: # kernel tensor is raw tensor, do strict check
@@ -64,6 +63,7 @@ def winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dty
         KH = KW = 3
         assert HSTR == 1 and WSTR == 1 and dilation_h == 1 and dilation_w == 1
 
+    HPAD, WPAD, _, _ = nn.get_pad_tuple(padding, kernel)
     data_pad = nn.pad(data, (0, 0, HPAD, WPAD), (0, 0, HPAD, WPAD), name="data_pad")
 
     r = KW

--- a/topi/tests/python/common.py
+++ b/topi/tests/python/common.py
@@ -40,4 +40,5 @@ class Int8Fallback(autotvm.FallbackContext):
         cfg = FallbackConfigEntity()
         cfg.template_key = 'int8'
         self.memory[key] = cfg
+        cfg.is_fallback = False
         return cfg

--- a/topi/tests/python/test_topi_conv2d_winograd.py
+++ b/topi/tests/python/test_topi_conv2d_winograd.py
@@ -99,6 +99,7 @@ class WinogradFallback(autotvm.FallbackContext):
         cfg = FallbackConfigEntity()
         cfg.template_key = 'winograd'
         self.memory[key] = cfg
+        cfg.is_fallback = False
         return cfg
 
 


### PR DESCRIPTION
Several topics [1, 2, 3] in the discuss mention that the conv2d failed to pass the shape checking in the runtime after the conv2d has been tuned by AutoTVM. This PR investigated the reason and resolved the issue. (thanks the help from @kevinthesun, @Laurawly  and @vinx13 with the investigation).

**Investigation**
All errors happen at the same dimension: the output image height (arg2.shape[2]).
For example in [1], the workload has input (1, 80, 73, 73) with stride=1 and padding=0, so the output shape should be (1, 192, 71, 71). However, it encountered the following error:

```bash
TVMError: Check failed: ret == 0 (-1 vs. 0) : Assert fail: (73 == int32(arg2.shape[2])), Argument arg2.shape[2] has an unsatisfied constraint
```
It means that somehow the output shape is set to 73 instead of 71 during scheduling. After digging into the code, we found that Winograd schedule overrides the strides and padding to be 1 regardless the input workload.

**Modification**
Accordingly, this PR modified two parts. First, we get the stride and padding directly from the input workload and check if it is valid like previous. This change passed the isolated [example](https://gist.github.com/idy002/6f846c02a05d9b1d8e01ab77638e7226) that yyding provided in the TVM discuss.

Second, the Winograd unittest uses fallback config, but the Winograd schedule will fallback to the direct template if the config is fallback. It means the alter layer for Winograd schedule is never tested. This PR also forced the fallback to be False to enable the testing, which was suggested by @vinx13.

[1] https://discuss.tvm.ai/t/auto-tune-error-occurs-during-inference-when-using-auto-tuned-schedule
[2] https://discuss.tvm.ai/t/error-float16-for-cuda-with-autotvm
[3] https://discuss.tvm.ai/t/graphruntime-module-run-failed-when-created-with-logfile-from-autotvm-tuning