### PR TITLE
imp module is deprecated

### DIFF
--- a/python/tvm/hybrid/module.py
+++ b/python/tvm/hybrid/module.py
@@ -22,7 +22,6 @@ To enable this feature, you need to build with -DUSE_HYBRID_DUMP=ON.
 """
 
 import ast
-import imp
 
 from ..contrib import util
 from .util import _internal_assert
@@ -112,5 +111,9 @@ class HybridModule(object):
         if self.name is None:
             self.name = finder.name
         self.root_ = finder.root
-        py_module = imp.load_source(self.name, path)
-        self.func_ = getattr(py_module, self.name)
+
+        global_, local_ = {}, {}
+        exec(self.src_, globals_, local_)
+        func = list(local_.values())
+        assert len(func) == 1
+        self.func_ = func[0]

--- a/python/tvm/hybrid/module.py
+++ b/python/tvm/hybrid/module.py
@@ -114,6 +114,6 @@ class HybridModule(object):
 
         _, local_ = {}, {}
         exec(self.src_, _, local_) #pylint: disable=exec-used
-        func = list(local_.values())
-        assert len(func) == 1
-        self.func_ = func[0]
+        local_.pop('tvm')
+        assert len(local_) == 1
+        self.func_ = list(local_.values())[0]

--- a/python/tvm/hybrid/module.py
+++ b/python/tvm/hybrid/module.py
@@ -112,7 +112,7 @@ class HybridModule(object):
             self.name = finder.name
         self.root_ = finder.root
 
-        _, local_ = {}
+        _, local_ = {}, {}
         exec(self.src_, _, local_) #pylint: disable=exec-used
         func = list(local_.values())
         assert len(func) == 1

--- a/python/tvm/hybrid/module.py
+++ b/python/tvm/hybrid/module.py
@@ -112,7 +112,7 @@ class HybridModule(object):
             self.name = finder.name
         self.root_ = finder.root
 
-        local_ = {}
+        _, local_ = {}
         exec(self.src_, _, local_) #pylint: disable=exec-used
         func = list(local_.values())
         assert len(func) == 1

--- a/python/tvm/hybrid/module.py
+++ b/python/tvm/hybrid/module.py
@@ -112,8 +112,8 @@ class HybridModule(object):
             self.name = finder.name
         self.root_ = finder.root
 
-        global_, local_ = {}, {}
-        exec(self.src_, globals_, local_)
+        local_ = {}
+        exec(self.src_, _, local_) #pylint: disable=exec-used
         func = list(local_.values())
         assert len(func) == 1
         self.func_ = func[0]

--- a/topi/python/topi/cpp/__init__.py
+++ b/topi/python/topi/cpp/__init__.py
@@ -1,21 +1,5 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 """FFI for C++ TOPI ops and schedules"""
-from .cpp import *
+from .impl import *
 from . import cuda
 from . import nn
 from . import vision

--- a/topi/python/topi/cpp/__init__.py
+++ b/topi/python/topi/cpp/__init__.py
@@ -1,5 +1,5 @@
 """FFI for C++ TOPI ops and schedules"""
-from .impl import *
+from .impl import * #pylint: disable=wildcard-import
 from . import cuda
 from . import nn
 from . import vision

--- a/topi/python/topi/cpp/__init__.py
+++ b/topi/python/topi/cpp/__init__.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""FFI for C++ TOPI ops and schedules"""
+from .cpp import *
+from . import cuda
+from . import nn
+from . import vision
+from . import x86
+from . import generic
+from . import rocm
+from . import image

--- a/topi/python/topi/cpp/cpp.py
+++ b/topi/python/topi/cpp/cpp.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""FFI for C++ TOPI ops and schedules"""
 import sys
 import os
 import ctypes

--- a/topi/python/topi/cpp/cpp.py
+++ b/topi/python/topi/cpp/cpp.py
@@ -14,11 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""FFI for C++ TOPI ops and schedules"""
 import sys
 import os
 import ctypes
-from imp import new_module as _new_module
 from tvm._ffi.function import _init_api_prefix
 from tvm._ffi import libinfo
 
@@ -42,27 +40,3 @@ def _load_lib():
 _LIB, _LIB_NAME = _load_lib()
 
 _init_api_prefix("topi.cpp", "topi")
-
-def _create_module(name):
-    fullname = __name__ + "." + name
-    mod = _new_module(fullname)
-    sys.modules[fullname] = mod
-    return mod
-
-# pylint: disable-msg=C0103
-nn = _create_module("nn")
-_init_api_prefix("topi.cpp.nn", "topi.nn")
-generic = _create_module("generic")
-_init_api_prefix("topi.cpp.generic", "topi.generic")
-cuda = _create_module("cuda")
-_init_api_prefix("topi.cpp.cuda", "topi.cuda")
-rocm = _create_module("rocm")
-_init_api_prefix("topi.cpp.rocm", "topi.rocm")
-x86 = _create_module("x86")
-_init_api_prefix("topi.cpp.x86", "topi.x86")
-vision = _create_module("vision")
-_init_api_prefix("topi.cpp.vision", "topi.vision")
-yolo = _create_module("vision.yolo")
-_init_api_prefix("topi.cpp.vision.yolo", "topi.vision.yolo")
-image = _create_module("image")
-_init_api_prefix("topi.cpp.image", "topi.image")

--- a/topi/python/topi/cpp/cuda.py
+++ b/topi/python/topi/cpp/cuda.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for CUDA TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/cuda.py
+++ b/topi/python/topi/cpp/cuda.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.cuda", "topi.cuda")

--- a/topi/python/topi/cpp/cuda.py
+++ b/topi/python/topi/cpp/cuda.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.cuda", "topi.cuda")

--- a/topi/python/topi/cpp/cuda.py
+++ b/topi/python/topi/cpp/cuda.py
@@ -1,3 +1,5 @@
+"""FFI for CUDA TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.cuda", "topi.cuda")

--- a/topi/python/topi/cpp/generic.py
+++ b/topi/python/topi/cpp/generic.py
@@ -1,3 +1,5 @@
+"""FFI for generic TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.generic", "topi.generic")

--- a/topi/python/topi/cpp/generic.py
+++ b/topi/python/topi/cpp/generic.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.generic", "topi.generic")

--- a/topi/python/topi/cpp/generic.py
+++ b/topi/python/topi/cpp/generic.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for generic TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/generic.py
+++ b/topi/python/topi/cpp/generic.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.generic", "topi.generic")

--- a/topi/python/topi/cpp/image.py
+++ b/topi/python/topi/cpp/image.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.image", "topi.image")

--- a/topi/python/topi/cpp/image.py
+++ b/topi/python/topi/cpp/image.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for image TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/image.py
+++ b/topi/python/topi/cpp/image.py
@@ -1,3 +1,5 @@
+"""FFI for image TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.image", "topi.image")

--- a/topi/python/topi/cpp/image.py
+++ b/topi/python/topi/cpp/image.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.image", "topi.image")

--- a/topi/python/topi/cpp/impl.py
+++ b/topi/python/topi/cpp/impl.py
@@ -14,10 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""FFI for C++ TOPI ops and schedules"""
+"""Load Lib for C++ TOPI ops and schedules"""
 import sys
 import os
 import ctypes
+
 from tvm._ffi.function import _init_api_prefix
 from tvm._ffi import libinfo
 

--- a/topi/python/topi/cpp/nn.py
+++ b/topi/python/topi/cpp/nn.py
@@ -1,3 +1,5 @@
+"""FFI for NN TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.nn", "topi.nn")

--- a/topi/python/topi/cpp/nn.py
+++ b/topi/python/topi/cpp/nn.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.nn", "topi.nn")

--- a/topi/python/topi/cpp/nn.py
+++ b/topi/python/topi/cpp/nn.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for NN TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/nn.py
+++ b/topi/python/topi/cpp/nn.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.nn", "topi.nn")

--- a/topi/python/topi/cpp/rocm.py
+++ b/topi/python/topi/cpp/rocm.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for Rocm TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/rocm.py
+++ b/topi/python/topi/cpp/rocm.py
@@ -1,3 +1,5 @@
+"""FFI for Rocm TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.rocm", "topi.rocm")

--- a/topi/python/topi/cpp/rocm.py
+++ b/topi/python/topi/cpp/rocm.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.rocm", "topi.rocm")

--- a/topi/python/topi/cpp/rocm.py
+++ b/topi/python/topi/cpp/rocm.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.rocm", "topi.rocm")

--- a/topi/python/topi/cpp/vision/__init__.py
+++ b/topi/python/topi/cpp/vision/__init__.py
@@ -1,0 +1,3 @@
+from . import yolo
+
+_init_api_prefix("topi.cpp.vision", "topi.vision")

--- a/topi/python/topi/cpp/vision/__init__.py
+++ b/topi/python/topi/cpp/vision/__init__.py
@@ -1,3 +1,4 @@
 from . import yolo
+from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.vision", "topi.vision")

--- a/topi/python/topi/cpp/vision/__init__.py
+++ b/topi/python/topi/cpp/vision/__init__.py
@@ -1,3 +1,5 @@
+"""FFI for vision TOPI ops and schedules"""
+
 from . import yolo
 from tvm._ffi.function import _init_api_prefix
 

--- a/topi/python/topi/cpp/vision/__init__.py
+++ b/topi/python/topi/cpp/vision/__init__.py
@@ -1,6 +1,7 @@
 """FFI for vision TOPI ops and schedules"""
 
-from . import yolo
 from tvm._ffi.function import _init_api_prefix
+
+from . import yolo
 
 _init_api_prefix("topi.cpp.vision", "topi.vision")

--- a/topi/python/topi/cpp/vision/yolo.py
+++ b/topi/python/topi/cpp/vision/yolo.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for Yolo TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/vision/yolo.py
+++ b/topi/python/topi/cpp/vision/yolo.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.vision.yolo", "topi.vision.yolo")

--- a/topi/python/topi/cpp/vision/yolo.py
+++ b/topi/python/topi/cpp/vision/yolo.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.vision.yolo", "topi.vision.yolo")

--- a/topi/python/topi/cpp/vision/yolo.py
+++ b/topi/python/topi/cpp/vision/yolo.py
@@ -1,3 +1,5 @@
+"""FFI for Yolo TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.vision.yolo", "topi.vision.yolo")

--- a/topi/python/topi/cpp/x86.py
+++ b/topi/python/topi/cpp/x86.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """FFI for x86 TOPI ops and schedules"""
 
 from tvm._ffi.function import _init_api_prefix

--- a/topi/python/topi/cpp/x86.py
+++ b/topi/python/topi/cpp/x86.py
@@ -1,3 +1,5 @@
+"""FFI for x86 TOPI ops and schedules"""
+
 from tvm._ffi.function import _init_api_prefix
 
 _init_api_prefix("topi.cpp.x86", "topi.x86")

--- a/topi/python/topi/cpp/x86.py
+++ b/topi/python/topi/cpp/x86.py
@@ -1,0 +1,1 @@
+_init_api_prefix("topi.cpp.x86", "topi.x86")

--- a/topi/python/topi/cpp/x86.py
+++ b/topi/python/topi/cpp/x86.py
@@ -1,1 +1,3 @@
+from tvm._ffi.function import _init_api_prefix
+
 _init_api_prefix("topi.cpp.x86", "topi.x86")


### PR DESCRIPTION
Python deprecated `imp` module, so we can no longer use `imp.load_source` to import a file by a path.

A workaround is to execute the source so that the defined closures are imported in the symbol table (aka. environment).