### PR TITLE
Fix the problem that android_rpc compilation failed

### DIFF
--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -66,7 +66,7 @@
 #endif
 
 #ifdef USE_SORT
-#include "../src/contrib/sort/sort.cc"
+#include "../src/runtime/contrib/sort/sort.cc"
 #endif
 
 


### PR DESCRIPTION
This small PR address the issue of header path in /apps/android_rpc/app/src/main/jni/tvm_runtime.h .

Description:
Error msg when compilation of android_rpc

```bash
make: Entering directory `/apps/android_rpc/app/src/main/jni'
[arm64-v8a] Compile++      : tvm4j_runtime_packed <= ml_dmlc_tvm_native_c_api.cc
In file included from 
/apps/android_rpc/app/src/main/jni/ml_dmlc_tvm_native_c_api.cc:25:
/apps/android_rpc/app/src/main/jni/tvm_runtime.h:69:10: fatal error: '../src/contrib/sort/sort.cc' file not found
#include "../src/contrib/sort/sort.cc"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
Fix:
modify the right sort.cc path