### PR TITLE
[Relay][Frontend][Tensorflow] Fix type assignment for 'tf.range' operator

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1067,6 +1067,7 @@ def _rank():
 
     return _impl
 
+
 def _range():
     def _impl(inputs, attr, params):
         start = _get_param(params, inputs[0])[0]
@@ -1074,7 +1075,7 @@ def _range():
             if hasattr(inputs[1], "name_hint") or isinstance(inputs[1], _expr.Constant) \
             else params.pop('Rank').asnumpy()[0]
         delta = _get_param(params, inputs[2])[0]
-        dtype = attr['dtype'].name if 'dtype' in attr else "int32"
+        dtype = attr['Tidx'].name if 'Tidx' in attr else str(start.dtype)
         return AttrCvt(
             op_name="arange",
             ignores=['Tidx'],
@@ -1083,6 +1084,7 @@ def _range():
                     'step': _expr.const(delta),
                     'dtype': dtype})([], attr)
     return _impl
+
 
 def _elu():
     def _impl(inputs, attr, params):
@@ -1194,7 +1196,7 @@ def _topk():
             raise tvm.error.OpAttributeInvalid(
                 'Attribute k must be positive in operator TopKV2')
         if attr['sorted'] is False:
-            raise tvm.error.OpAttributeUnimplemented(
+            raise tvm.error.OpAttributeUnImplemented(
                 'Attribute sorted=False is not supported in operator TopKV2')
         return AttrCvt(op_name='topk',
                        ignores=['sorted'],

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1617,6 +1617,11 @@ def test_forward_range():
     tf.range(1, 18, 3, name="range")
     compare_tf_with_tvm([], [], 'range:0')
 
+    """test type assignment for operator Range"""
+    tf.reset_default_graph()
+    tf.range(1, 256 + 1, 1, dtype=tf.float32)
+    compare_tf_with_tvm([], [], 'range:0')
+
 #######################################################################
 # Pad
 # ---


### PR DESCRIPTION
Hi @FinnWeng

Following issue #4265 , this PR tries to fix the type assignment for  `range` operator, and change the default type assignment from `int32` to `start.dtype`. I would appreciate if you can help me to confirm this patch is work or not, thank you.