### PR TITLE
[CI] Add onnxruntime to CI Image

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -21,8 +21,8 @@ set -u
 set -o pipefail
 
 # fix to certain version for now
-pip3 install onnx==1.6.0
-pip3 install onnxruntime-gpu==1.0.0
+pip3 install onnx==1.5.0
+pip3 install onnxruntime==1.0.0
 
 # torch depends on a number of other packages, but unhelpfully, does
 # not expose that in the wheel!!!

--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -21,7 +21,8 @@ set -u
 set -o pipefail
 
 # fix to certain version for now
-pip3 install onnx==1.5.0
+pip3 install onnx==1.6.0
+pip3 install onnxruntime-gpu==1.0.0
 
 # torch depends on a number of other packages, but unhelpfully, does
 # not expose that in the wheel!!!

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -77,19 +77,18 @@ def get_tvm_output(graph_def, input_data, target, ctx, output_shape=None, output
         return tvm_output.asnumpy()
 
 
-def get_caffe2_output(model, x, dtype='float32'):
-    import caffe2.python.onnx.backend
-    prepared_backend = caffe2.python.onnx.backend.prepare(model)
-    W = {model.graph.input[0].name: x.astype(dtype)}
-    c2_out = prepared_backend.run(W)[0]
-    return c2_out
+def get_onnx_output(model, x, dtype='float32'):
+    import onnxruntime.backend
+    prepared_backend = onnxruntime.backend.prepare(model)
+    ort_out = prepared_backend.run(x.astype(dtype))[0]
+    return ort_out
 
 
 def verify_onnx_forward_impl(graph_file, data_shape, out_shape):
     dtype = 'float32'
     x = np.random.uniform(size=data_shape)
     model = onnx.load_model(graph_file)
-    c2_out = get_caffe2_output(model, x, dtype)
+    c2_out = get_onnx_output(model, x, dtype)
     for target, ctx in ctx_list():
         tvm_out = get_tvm_output(model, x, target, ctx, out_shape, dtype)
         tvm.testing.assert_allclose(c2_out, tvm_out, rtol=1e-5, atol=1e-5)
@@ -1372,7 +1371,7 @@ def check_torch_conversion(model, input_size):
     onnx_model = onnx.load(file_name)
     for target, ctx in ctx_list():
         input_data = np.random.uniform(size=input_size).astype('int32')
-        c2_out = get_caffe2_output(onnx_model, input_data)
+        c2_out = get_onnx_output(onnx_model, input_data)
         tvm_out = get_tvm_output(onnx_model, input_data, target, ctx)
         tvm.testing.assert_allclose(c2_out, tvm_out)
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -77,18 +77,19 @@ def get_tvm_output(graph_def, input_data, target, ctx, output_shape=None, output
         return tvm_output.asnumpy()
 
 
-def get_onnx_output(model, x, dtype='float32'):
-    import onnxruntime.backend
-    prepared_backend = onnxruntime.backend.prepare(model)
-    ort_out = prepared_backend.run(x.astype(dtype))[0]
-    return ort_out
+def get_caffe2_output(model, x, dtype='float32'):
+    import caffe2.python.onnx.backend
+    prepared_backend = caffe2.python.onnx.backend.prepare(model)
+    W = {model.graph.input[0].name: x.astype(dtype)}
+    c2_out = prepared_backend.run(W)[0]
+    return c2_out
 
 
 def verify_onnx_forward_impl(graph_file, data_shape, out_shape):
     dtype = 'float32'
     x = np.random.uniform(size=data_shape)
     model = onnx.load_model(graph_file)
-    c2_out = get_onnx_output(model, x, dtype)
+    c2_out = get_caffe2_output(model, x, dtype)
     for target, ctx in ctx_list():
         tvm_out = get_tvm_output(model, x, target, ctx, out_shape, dtype)
         tvm.testing.assert_allclose(c2_out, tvm_out, rtol=1e-5, atol=1e-5)
@@ -1371,7 +1372,7 @@ def check_torch_conversion(model, input_size):
     onnx_model = onnx.load(file_name)
     for target, ctx in ctx_list():
         input_data = np.random.uniform(size=input_size).astype('int32')
-        c2_out = get_onnx_output(onnx_model, input_data)
+        c2_out = get_caffe2_output(onnx_model, input_data)
         tvm_out = get_tvm_output(onnx_model, input_data, target, ctx)
         tvm.testing.assert_allclose(c2_out, tvm_out)
 


### PR DESCRIPTION
As discussed in PR #4271, using the caffe runtime for our onnx testing is not a good long term solution due to lack of op support. Instead, we should be using the onnxruntime. This PR adds onnxruntime to the onnx installation docker image.
