### PR TITLE
Fix incorrect call to Unicode Win32 InetPton

### DIFF
--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -59,7 +59,7 @@ static inline int poll(struct pollfd *pfd, int nfds,
   return WSAPoll(pfd, nfds, timeout);
 }
 static inline int inet_pton(int family, const char* addr_str, void* addr_buf) {
-  return InetPton(family, addr_str, addr_buf);
+  return InetPtonA(family, addr_str, addr_buf);
 }
 #else
 #include <sys/poll.h>

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -58,9 +58,6 @@ static inline int poll(struct pollfd *pfd, int nfds,
                        int timeout) {
   return WSAPoll(pfd, nfds, timeout);
 }
-static inline int inet_pton(int family, const char* addr_str, void* addr_buf) {
-  return InetPtonA(family, addr_str, addr_buf);
-}
 #else
 #include <sys/poll.h>
 #endif  // defined(_WIN32)


### PR DESCRIPTION
The recent commit for https://github.com/apache/incubator-tvm/pull/4281 is calling the Win32 MACRO InetPton.  If the Visual studio project is set to "Use Unicode Character Set", (which tvm.dll seems to be) this calls InetPtonW, which uses wchar_t* (aka PCWSTR).  This causes a build error as the "addr_buf" is a char*.

From [InetPton ](https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-inetptonw)docs:

> When UNICODE or _UNICODE is defined, InetPton is defined to InetPtonW, the Unicode version of this function. The pszAddrString parameter is defined to the PCWSTR data type.
> 
> When UNICODE or _UNICODE is not defined, InetPton is defined to InetPtonA, the ANSI version of this function. The ANSI version of this function is always defined as inet_pton. The pszAddrString parameter is defined to the PCSTR data type.

This can be fixed by directly calling InetPtonA, which is safe as the tvm function always uses a char* for add_str and InetPtonA always takes a char* (aka PCSTR)



