### PR TITLE
[Build][Windows] Fix Windows build by including cctype

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -35,8 +35,8 @@
 #include <sstream>
 #include <algorithm>
 #include <array>
-#include <cctype>
 #include <memory>
+#include <cctype>
 
 namespace tvm {
 namespace common {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <cctype>
 
 namespace tvm {
 namespace common {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -35,8 +35,8 @@
 #include <sstream>
 #include <algorithm>
 #include <array>
-#include <memory>
 #include <cctype>
+#include <memory>
 
 namespace tvm {
 namespace common {


### PR DESCRIPTION
The Windows build is currently broken with the error: `isdigit is not a member of standard`. It looks like `std::isdigit` is in header `<cctype>`. Including it fixes the build.

@tqchen @jmorrill could you take a look?

Also, is there an ETA to get the Azure build pipeline back up?