### PR TITLE
[Relay] Use opaque for where op

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1601,7 +1601,7 @@ Examples::
 .set_support_level(4)
 .add_type_rel("Where", WhereRel)
 .set_attr<FTVMCompute>("FTVMCompute", WhereCompute)
-.set_attr<TOpPattern>("TOpPattern", kBroadcast);
+.set_attr<TOpPattern>("TOpPattern", kOpaque);
 
 
 // Squeeze


### PR DESCRIPTION
Fuse where op will cause significant performance degradation in BERT model