### PR TITLE
[Prelude][Relay] Add get tensor data utilities

### DIFF
--- a/python/tvm/relay/prelude.py
+++ b/python/tvm/relay/prelude.py
@@ -138,6 +138,134 @@ class TensorArrayOps(object):
                                tensor6_case], False),
                      tensor_t(), [])
 
+    def define_get_tensor0(self):
+        """Defines a function to extract a rank 0 tensor out of tensor_t.
+            get_tensor0(t): tensor_t -> Tensor[(), dtype]
+        """
+        get_tensor0_name = self.get_name("get_tensor0")
+        get_tensor0_var = GlobalVar(get_tensor0_name)
+        setattr(self.prelude, get_tensor0_name, get_tensor0_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor0')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor0_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([], self.dtype), [])
+
+    def define_get_tensor1(self):
+        """Defines a function to extract a rank 1 tensor out of tensor_t.
+            get_tensor1(t): tensor_t -> Tensor[(Any()), dtype]
+        """
+        get_tensor1_name = self.get_name("get_tensor1")
+        get_tensor1_var = GlobalVar(get_tensor1_name)
+        setattr(self.prelude, get_tensor1_name, get_tensor1_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor1')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor1_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([Any()], self.dtype), [])
+
+    def define_get_tensor2(self):
+        """Defines a function to extract a rank 2 tensor out of tensor_t.
+            get_tensor2(t): tensor_t -> Tensor[(Any(), Any()), dtype]
+        """
+        get_tensor2_name = self.get_name("get_tensor2")
+        get_tensor2_var = GlobalVar(get_tensor2_name)
+        setattr(self.prelude, get_tensor2_name, get_tensor2_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor2')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor2_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([Any(), Any()], self.dtype), [])
+
+    def define_get_tensor3(self):
+        """Defines a function to extract a rank 3 tensor out of tensor_t.
+            get_tensor3(t): tensor_t -> Tensor[(Any(), Any(), Any()), dtype]
+        """
+        get_tensor3_name = self.get_name("get_tensor3")
+        get_tensor3_var = GlobalVar(get_tensor3_name)
+        setattr(self.prelude, get_tensor3_name, get_tensor3_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor3')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor3_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([Any(), Any(), Any()], self.dtype), [])
+
+    def define_get_tensor4(self):
+        """Defines a function to extract a rank 4 tensor out of tensor_t.
+            get_tensor4(t): tensor_t -> Tensor[(Any(), Any(), Any(), Any()), dtype]
+        """
+        get_tensor4_name = self.get_name("get_tensor4")
+        get_tensor4_var = GlobalVar(get_tensor4_name)
+        setattr(self.prelude, get_tensor4_name, get_tensor4_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor4')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor4_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([Any(), Any(), Any(), Any()], self.dtype), [])
+
+    def define_get_tensor5(self):
+        """Defines a function to extract a rank 5 tensor out of tensor_t.
+            get_tensor5(t):
+                tensor_t -> Tensor[(Any(), Any(), Any(), Any(), Any()), dtype]
+        """
+        get_tensor5_name = self.get_name("get_tensor5")
+        get_tensor5_var = GlobalVar(get_tensor5_name)
+        setattr(self.prelude, get_tensor5_name, get_tensor5_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor5')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor5_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([Any(), Any(), Any(), Any(), Any()], self.dtype), [])
+
+    def define_get_tensor6(self):
+        """Defines a function to extract a rank 6 tensor out of tensor_t.
+            get_tensor6(t):
+                tensor_t -> Tensor[(Any(), Any(), Any(), Any(), Any(), Any()), dtype]
+        """
+        get_tensor6_name = self.get_name("get_tensor6")
+        get_tensor6_var = GlobalVar(get_tensor6_name)
+        setattr(self.prelude, get_tensor6_name, get_tensor6_var)
+        tensor_t = self.get_var('tensor_t')
+        tensor_var = self.get_var('tensor6')
+        t = Var('tensor', tensor_t())
+        tvar = Var('t')
+        case =\
+            Clause(PatternConstructor(tensor_var, [PatternVar(tvar)]), tvar)
+        self.prelude.mod[get_tensor6_var] =\
+            Function([t],
+                     Match(t, [case], False),
+                     TensorType([Any(), Any(), Any(), Any(), Any(), Any()], self.dtype), [])
+
     def define_tensor_expand_dims(self):
         """Defines a function to grow a tensor_t's rank by adding one dimension in front
         of the original tensor_t.
@@ -640,8 +768,14 @@ class TensorArrayOps(object):
         self.define_tensor_array_split()
         self.define_tensor_array_concat()
         self.define_tensor_array_stack()
-        # TODO(wweic): Gather fails in PartialEvaluate
-        # self.define_tensor_array_gather()
+        self.define_get_tensor0()
+        self.define_get_tensor1()
+        self.define_get_tensor2()
+        self.define_get_tensor3()
+        self.define_get_tensor4()
+        self.define_get_tensor5()
+        self.define_get_tensor6()
+        self.define_tensor_array_gather()
 
 class Prelude:
     """Contains standard definitions."""

--- a/src/relay/pass/partial_eval.cc
+++ b/src/relay/pass/partial_eval.cc
@@ -1008,7 +1008,7 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
           throw;
         }
       }
-      LOG(FATAL) << "No case Match";
+      LOG(FATAL) << "No case Match for value " << op->data << "\n";
       throw;
     });
   }

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -81,6 +81,10 @@ def vmobj_to_list(o):
             return hd
         elif o.constructor.name_hint == 'Nil':
             return []
+        elif 'tensor_nil' in o.constructor.name_hin:
+            return [0]
+        elif 'tensor' in o.constructor.name_hint:
+            return [o.fields[0].asnumpy()]
         else:
             raise RuntimeError("Unknown object type: %s" %
                                o.constructor.name_hint)

--- a/tests/python/relay/test_pass_partial_eval.py
+++ b/tests/python/relay/test_pass_partial_eval.py
@@ -50,8 +50,9 @@ def tipe(expr):
                                transform.InferType()])
 
 
-def dcpe(expr, mod=None, grad=False):
-    passes = [transform.PartialEvaluate(),
+def dcpe(expr, mod=None, entry_funcs=None, grad=False):
+    passes = [transform.RemoveUnusedFunctions(entry_funcs),
+              transform.PartialEvaluate(),
               transform.DeadCodeElimination(inline_once=True)]
     if grad:
         expr = gradient(run_infer_type(expr))
@@ -195,7 +196,7 @@ def test_map():
     mod["main"] = expected
     expected = mod["main"]
     orig = Function([], orig)
-    res = dcpe(orig, mod=mod)
+    res = dcpe(orig, mod=mod, entry_funcs=['f', 'main'])
     assert alpha_equal(res.body, expected.body)
 
 
@@ -328,8 +329,8 @@ def test_nat_update():
     p = Prelude(m)
     add_nat_definitions(p)
     m = transform.ToANormalForm()(m)
+    m = transform.RemoveUnusedFunctions([])(m)
     transform.PartialEvaluate()(m)
-
 
 def test_tuple_match():
     a = relay.Var("a")


### PR DESCRIPTION
This implements issue https://github.com/apache/incubator-tvm/issues/4291.

I also applied the optimization in tensorflow converter that it keeps track of all the ins and outs of every tensor array, so we can determine if a tensor array is homogeneous or not. If true, we will directly extract the tensor out of the `tensor_t` object, and it will eliminate the trouble of reading from `tensor_t`.

We should do the same optimization in the future when we encounter operators that needs to use `tensor_t` objects.

cc @zhiics @icemelon9 @yongwww @kevinthesun @srkreddy1238 @jroesch @slyubomirsky 