### PR TITLE
Add topi.nn.fifo_buffer to TOPI API doc

### DIFF
--- a/docs/api/python/topi.rst
+++ b/docs/api/python/topi.rst
@@ -69,6 +69,7 @@ List of operators
    topi.nn.conv2d_hwcn
    topi.nn.depthwise_conv2d_nchw
    topi.nn.depthwise_conv2d_nhwc
+   topi.nn.fifo_buffer
    topi.max
    topi.sum
    topi.min
@@ -199,6 +200,7 @@ topi.nn
 .. autofunction:: topi.nn.conv2d_hwcn
 .. autofunction:: topi.nn.depthwise_conv2d_nchw
 .. autofunction:: topi.nn.depthwise_conv2d_nhwc
+.. autofunction:: topi.nn.fifo_buffer
 
 topi.image
 ~~~~~~~~~~


### PR DESCRIPTION
Follow-up to #4039. Add `topi.nn.fifo_buffer` to the TOPI API doc.

cc @zhiics @kevinthesun @yongwww 