### PR TITLE
[ThreadPool] Solve thread transitions issue

### DIFF
--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -373,7 +373,7 @@ class ThreadPool {
   int num_workers_;
   // number of workers used (can be restricted with affinity pref)
   int num_workers_used_;
-  // if excluding worker 0 and using master to run task 0
+  // if or not to exclude worker 0 and use master to run task 0
 #ifndef _LIBCPP_SGX_CONFIG
   bool exclude_worker0_{true};
 #else

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -284,8 +284,8 @@ class ThreadPool {
       queues_.emplace_back(std::unique_ptr<SpscTaskQueue>(new SpscTaskQueue()));
     }
     const char* exclude_worker0 = getenv("TVM_EXCLUDE_WORKER0");
-    if (exclude_worker0 && atoi(exclude_worker0) == 1) {
-      exclude_worker0_ = true;
+    if (exclude_worker0 && atoi(exclude_worker0) == 0) {
+      exclude_worker0_ = false;
     }
     threads_ = std::unique_ptr<tvm::runtime::threading::ThreadGroup>(
         new tvm::runtime::threading::ThreadGroup(
@@ -374,7 +374,11 @@ class ThreadPool {
   // number of workers used (can be restricted with affinity pref)
   int num_workers_used_;
   // if excluding worker 0 and using master to run task 0
+#ifndef _LIBCPP_SGX_CONFIG
+  bool exclude_worker0_{true};
+#else
   bool exclude_worker0_{false};
+#endif
   std::vector<std::unique_ptr<SpscTaskQueue> > queues_;
   std::unique_ptr<tvm::runtime::threading::ThreadGroup> threads_;
 };

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -283,6 +283,10 @@ class ThreadPool {
       // The SpscTaskQueue only hosts ONE item at a time
       queues_.emplace_back(std::unique_ptr<SpscTaskQueue>(new SpscTaskQueue()));
     }
+    const char* exclude_worker0 = getenv("TVM_EXCLUDE_WORKER0");
+    if (exclude_worker0 && atoi(exclude_worker0) == 1) {
+      exclude_worker0_ = true;
+    }
     threads_ = std::unique_ptr<tvm::runtime::threading::ThreadGroup>(
         new tvm::runtime::threading::ThreadGroup(
           num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
@@ -370,11 +374,7 @@ class ThreadPool {
   // number of workers used (can be restricted with affinity pref)
   int num_workers_used_;
   // if excluding worker 0 and using master to run task 0
-#ifndef _LIBCPP_SGX_CONFIG
-  bool exclude_worker0_{true};
-#else
   bool exclude_worker0_{false};
-#endif
   std::vector<std::unique_ptr<SpscTaskQueue> > queues_;
   std::unique_ptr<tvm::runtime::threading::ThreadGroup> threads_;
 };

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -148,8 +148,8 @@ class ThreadGroup::Impl {
         }
       }
      pthread_atfork(nullptr, nullptr, ThreadGroup::Impl::SetFullCpuAffinity);
-    }
 #endif
+    }
 #endif
   }
 
@@ -248,6 +248,8 @@ int MaxConcurrency() {
   }
   return std::max(max_concurrency, 1);
 }
+
+
 }  // namespace threading
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -248,7 +248,6 @@ int MaxConcurrency() {
   }
   return std::max(max_concurrency, 1);
 }
-
-}  // namespace threading
-}  // namespace runtime
-}  // namespace tvm
+} // namespace threading
+} // namespace runtime
+} // namespace tvm

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -150,10 +150,10 @@ class ThreadGroup::Impl {
     CPU_ZERO(&cpuset);
     CPU_SET(ThreadGroup::Impl::core0_id_, &cpuset);
 #if defined(__ANDROID__)
-    sched_setaffinity(pthread_self(),
+      sched_setaffinity(pthread_self(),
         sizeof(cpu_set_t), &cpuset);
 #else
-    pthread_setaffinity_np(pthread_self(),
+      pthread_setaffinity_np(pthread_self(),
         sizeof(cpu_set_t), &cpuset);
 #endif
 #endif

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -248,6 +248,6 @@ int MaxConcurrency() {
   }
   return std::max(max_concurrency, 1);
 }
-} // namespace threading
-} // namespace runtime
-} // namespace tvm
+}  // namespace threading
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -249,7 +249,6 @@ int MaxConcurrency() {
   return std::max(max_concurrency, 1);
 }
 
-
 }  // namespace threading
 }  // namespace runtime
 }  // namespace tvm


### PR DESCRIPTION
This pr solves thread transitions issue. 

When we use OpenCV + TVM, we will produce much thread transitions so that OpenCV + TVM is slow. Auto tuning has issue too. The reason is we bind task 0 to master cpu by default.

More detail / background and reproduceable test case: https://discuss.tvm.ai/t/use-tvm-darknet-to-detect-vidoes-after-relay-build-module-build-cv2-ops-cost-much-more-time/4730/

After this PR, we don't bind task 0 to master cpu by default but export one environment `TVM_EXCLUDE_WORKER0` to set. If users set `TVM_EXCLUDE_WORKER0` be 1, we will bind task 0 to master as previous.

@vinx13 @yidawang @tqchen 