### PR TITLE
[Docker] Fix TVM folder name for installing on Android and OpenCL

### DIFF
--- a/docker/Dockerfile.demo_android
+++ b/docker/Dockerfile.demo_android
@@ -56,7 +56,7 @@ RUN git clone https://github.com/KhronosGroup/OpenCL-Headers /usr/local/OpenCL-H
 
 # Build TVM
 RUN cd /usr && \
-    git clone --depth=1 https://github.com/apache/incubator-tvm --recursive && \
+    git clone --depth=1 https://github.com/apache/incubator-tvm tvm --recursive && \
     cd /usr/tvm && \
     mkdir -p build && \
     cd build && \

--- a/docker/Dockerfile.demo_opencl
+++ b/docker/Dockerfile.demo_opencl
@@ -62,7 +62,7 @@ RUN echo "Cloning TVM source & submodules"
 ENV TVM_PAR_DIR="/usr"
 RUN mkdir -p TVM_PAR_DIR && \
 	cd ${TVM_PAR_DIR} && \
-	git clone --depth=1 https://github.com/apache/incubator-tvm --recursive
+	git clone --depth=1 https://github.com/apache/incubator-tvm tvm --recursive
 #RUN git submodule update --init --recursive
 
 


### PR DESCRIPTION
After cloning `incubator-tvm`, we need to rename the folder back to `tvm` to make the script working.