### PR TITLE
[CI] Avoid content-length request in test data download

### DIFF
--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -155,5 +155,5 @@ def download_testdata(url, relpath, module=None):
     else:
         raise ValueError("Unsupported module: " + module)
     abspath = os.path.join(TEST_DATA_ROOT_PATH, module_path, relpath)
-    download(url, abspath, overwrite=False, size_compare=True)
+    download(url, abspath, overwrite=False, size_compare=False)
     return abspath


### PR DESCRIPTION
To avoid CI out-rage due to download limitations which happened today cc @icemelon9  

Perhaps we need a smarter way to verify the correctness of the file(e.g. including some local meta data).
