### PR TITLE
[LINT] Remove unnecessary copyright message for files with ASF header

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache TVM (incubating)
-Copyright 2017 and onwards The Apache Software Foundation
+Copyright 2019 and onwards The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/apps/android_deploy/app/src/main/jni/Android.mk
+++ b/apps/android_deploy/app/src/main/jni/Android.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 LOCAL_PATH := $(call my-dir)
 MY_PATH := $(LOCAL_PATH)
 

--- a/apps/android_deploy/app/src/main/jni/Application.mk
+++ b/apps/android_deploy/app/src/main/jni/Application.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ifndef config
 	ifneq ("$(wildcard ./config.mk)","")
 	  config ?= config.mk

--- a/apps/android_deploy/app/src/main/jni/make/config.mk
+++ b/apps/android_deploy/app/src/main/jni/make/config.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #-------------------------------------------------------------------------------
 #  Template configuration for compiling
 #

--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ifndef config
     ifneq ("$(wildcard ./config.mk)","")
         config ?= config.mk

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file tvm_runtime.h
  * \brief Pack all tvm runtime source files
  */

--- a/apps/extension/src/tvm_ext.cc
+++ b/apps/extension/src/tvm_ext.cc
@@ -19,7 +19,6 @@
 
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Example package that uses TVM.
  * \file tvm_ext.cc
  */

--- a/apps/howto_deploy/cpp_deploy.cc
+++ b/apps/howto_deploy/cpp_deploy.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Example code on load and run TVM module.s
  * \file cpp_deploy.cc
  */

--- a/apps/howto_deploy/python_deploy.py
+++ b/apps/howto_deploy/python_deploy.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Copyright (c) 2017 by Contributors
 # brief Example code on load and run TVM module.s
 # file python_deploy.py
 

--- a/apps/ios_rpc/tvmrpc.xcodeproj/project.pbxproj
+++ b/apps/ios_rpc/tvmrpc.xcodeproj/project.pbxproj
@@ -1,4 +1,23 @@
 // !$*UTF8*$!
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 {
 	archiveVersion = 1;
 	classes = {

--- a/apps/ios_rpc/tvmrpc.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/apps/ios_rpc/tvmrpc.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
 <Workspace
    version = "1.0">
    <FileRef

--- a/apps/ios_rpc/tvmrpc/AppDelegate.h
+++ b/apps/ios_rpc/tvmrpc/AppDelegate.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file AppDelegate.h
  */
 

--- a/apps/ios_rpc/tvmrpc/AppDelegate.m
+++ b/apps/ios_rpc/tvmrpc/AppDelegate.m
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file AppDelegate.mm
  */
 

--- a/apps/ios_rpc/tvmrpc/Base.lproj/Main.storyboard
+++ b/apps/ios_rpc/tvmrpc/Base.lproj/Main.storyboard
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16D30" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>

--- a/apps/ios_rpc/tvmrpc/Info.plist
+++ b/apps/ios_rpc/tvmrpc/Info.plist
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/apps/ios_rpc/tvmrpc/TVMRuntime.h
+++ b/apps/ios_rpc/tvmrpc/TVMRuntime.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file TVMRuntime.h
  */
 #import <Foundation/Foundation.h>

--- a/apps/ios_rpc/tvmrpc/ViewController.h
+++ b/apps/ios_rpc/tvmrpc/ViewController.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file ViewController.h
  */
 

--- a/apps/ios_rpc/tvmrpc/ViewController.mm
+++ b/apps/ios_rpc/tvmrpc/ViewController.mm
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file ViewController.mm
  */
 

--- a/apps/ios_rpc/tvmrpc/main.m
+++ b/apps/ios_rpc/tvmrpc/main.m
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file main.m
  */
 

--- a/apps/ios_rpc/tvmrpcLauncher/Info.plist
+++ b/apps/ios_rpc/tvmrpcLauncher/Info.plist
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/apps/ios_rpc/tvmrpcLauncher/tvmrpcLauncher.mm
+++ b/apps/ios_rpc/tvmrpcLauncher/tvmrpcLauncher.mm
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief A hook to launch RPC server via xcodebuild test
  * \file tvmrpcLauncher.mm
  */

--- a/golang/sample/complex.go
+++ b/golang/sample/complex.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application deployment over tvm.
  * \file complex.go
  */

--- a/golang/sample/pack_func_closure_arg.go
+++ b/golang/sample/pack_func_closure_arg.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application to demonstrate go-closure given to a packed function argument.
  * \file pack_func_closure_arg.go
  */

--- a/golang/sample/pack_func_closure_return.go
+++ b/golang/sample/pack_func_closure_return.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application to demonstrate go-closure returned from a callback function.
  * \file pack_func_closure_return.go
  */

--- a/golang/sample/pack_func_convert.go
+++ b/golang/sample/pack_func_convert.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application to demonstrate function conversion to packed function.
  * \file pack_func_convert.go
  */

--- a/golang/sample/pack_func_handle_arg.go
+++ b/golang/sample/pack_func_handle_arg.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application to demonstrate converted packed
  * function handle passed to another packed function.
  * \file pack_func_handle_arg.go

--- a/golang/sample/pack_func_register.go
+++ b/golang/sample/pack_func_register.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application to demonstrate function register into TVM global functions.
  * \file pack_func_register.go
  */

--- a/golang/sample/simple.go
+++ b/golang/sample/simple.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Sample golang application deployment over tvm.
  * \file simple.go
  */

--- a/golang/src/array_test.go
+++ b/golang/src/array_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file array_test.go
  */

--- a/golang/src/bytearray.go
+++ b/golang/src/bytearray.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for TVMByteArray interface.
  * \file bytearray.go
  */

--- a/golang/src/bytearray_test.go
+++ b/golang/src/bytearray_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file bytearray_test.go
  */

--- a/golang/src/context.go
+++ b/golang/src/context.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for TVMContext interface
  * \file context.go
  */

--- a/golang/src/error.go
+++ b/golang/src/error.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for error related API interface.
  * \file error.go
  */

--- a/golang/src/error_test.go
+++ b/golang/src/error_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file error_test.go
  */

--- a/golang/src/function.go
+++ b/golang/src/function.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for TVMFunction interface.
  * \file function.go
  */

--- a/golang/src/function_test.go
+++ b/golang/src/function_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file function_test.go
  */

--- a/golang/src/gotvm.cc
+++ b/golang/src/gotvm.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm native interface definition
  * \file gotvm.cxx
  */

--- a/golang/src/gotvm.go
+++ b/golang/src/gotvm.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file gotvm.go
  */

--- a/golang/src/gotvm.h
+++ b/golang/src/gotvm.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm native interface declaration.
  * \file gotvm.h
  *

--- a/golang/src/gotvm_test.go
+++ b/golang/src/gotvm_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file gotvm_test.go
  */

--- a/golang/src/module.go
+++ b/golang/src/module.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for TVMModule interface.
  * \file module.go
  */

--- a/golang/src/module_test.go
+++ b/golang/src/module_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file module_test.go
  */

--- a/golang/src/ndarray.go
+++ b/golang/src/ndarray.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for TVMArray aka DLTensor
  * \file ndarray.go
  */

--- a/golang/src/type.go
+++ b/golang/src/type.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package for TVMType interface
  * \file type.go
  */

--- a/golang/src/util.go
+++ b/golang/src/util.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for common utilities
  * \file util.go
  */

--- a/golang/src/value.go
+++ b/golang/src/value.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package source for TVMValue interface
  * \file value.go
  */

--- a/golang/src/value_test.go
+++ b/golang/src/value_test.go
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief gotvm package
  * \file value_test.go
  */

--- a/include/tvm/relay/attrs/reduce.h
+++ b/include/tvm/relay/attrs/reduce.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/relay/attrs/reduce.h
  * \brief Auxiliary attributes for reduce operators.
  */

--- a/nnvm/include/nnvm/base.h
+++ b/nnvm/include/nnvm/base.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/base.h
  * \brief Configuration of nnvm as well as basic data structure.
  */

--- a/nnvm/include/nnvm/c_api.h
+++ b/nnvm/include/nnvm/c_api.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/c_api.h
  * \brief C API of NNVM symbolic construction and pass.
  *  Enables construction and transformation of Graph

--- a/nnvm/include/nnvm/compiler/op_attr_types.h
+++ b/nnvm/include/nnvm/compiler/op_attr_types.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nnvm/compiler/op_attr_types.h
  * \brief The Expr and related elements in DataFlow construction.
  */

--- a/nnvm/include/nnvm/compiler/packed_func_ext.h
+++ b/nnvm/include/nnvm/compiler/packed_func_ext.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nnvm/compiler/packed_func_ext.h
  * \brief Extension to enable packed functionn for nnvm types
  */

--- a/nnvm/include/nnvm/compiler/util.h
+++ b/nnvm/include/nnvm/compiler/util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
-*  Copyright (c) 2016 by Contributors
 * \file nnvm/compiler/util.h
 * \brief Utility functions for nnvm compiler
 */

--- a/nnvm/include/nnvm/graph.h
+++ b/nnvm/include/nnvm/graph.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/graph.h
  * \brief Configuation of nnvm as well as basic data structure.
  */

--- a/nnvm/include/nnvm/graph_attr_types.h
+++ b/nnvm/include/nnvm/graph_attr_types.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/graph_attr_types.h
  * \brief Data structures that can appear in graph attributes.
  */

--- a/nnvm/include/nnvm/layout.h
+++ b/nnvm/include/nnvm/layout.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file nnvm/layout.h
  * \brief Layout expression.
  *        The layout is composed of upper cases, lower cases and numbers,

--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/node.h
  * \brief Graph node data structure.
  */

--- a/nnvm/include/nnvm/op.h
+++ b/nnvm/include/nnvm/op.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/op.h
  * \brief Operator information structor.
  */

--- a/nnvm/include/nnvm/op_attr_types.h
+++ b/nnvm/include/nnvm/op_attr_types.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/op_attr_types.h
  * \brief Data structures that can appear in operator attributes.
  */

--- a/nnvm/include/nnvm/pass.h
+++ b/nnvm/include/nnvm/pass.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/pass.h
  * \brief Pass that can be applied to a graph.
  */

--- a/nnvm/include/nnvm/pass_functions.h
+++ b/nnvm/include/nnvm/pass_functions.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/pass_functions.h
  * \brief Pass functions that simply redirect the calls to ApplyPass
  *

--- a/nnvm/include/nnvm/symbolic.h
+++ b/nnvm/include/nnvm/symbolic.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/symbolic.h
  * \brief Symbolic graph construction API
  *

--- a/nnvm/include/nnvm/top/nn.h
+++ b/nnvm/include/nnvm/top/nn.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nnvm/top/nn.h
  * \brief Auxiliary param for tensor primitive.
  */

--- a/nnvm/include/nnvm/top/tensor.h
+++ b/nnvm/include/nnvm/top/tensor.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nnvm/top/tensor.h
  * \brief Auxiliary param for tensor primitive.
  */

--- a/nnvm/include/nnvm/tuple.h
+++ b/nnvm/include/nnvm/tuple.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file nnvm/tuple.h
  * \brief Data structure Tuple and TShape to store dynamic sized shapes.
  */

--- a/nnvm/src/c_api/c_api_common.h
+++ b/nnvm/src/c_api/c_api_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file c_api_error.h
  * \brief Common fields of all C APIs
  */

--- a/nnvm/src/c_api/c_api_error.cc
+++ b/nnvm/src/c_api/c_api_error.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file c_api_error.cc
  * \brief C error handling
  */

--- a/nnvm/src/c_api/c_api_graph.cc
+++ b/nnvm/src/c_api/c_api_graph.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file c_api_graph.cc
  * \brief C API related to Graph IR.
  */

--- a/nnvm/src/c_api/c_api_symbolic.cc
+++ b/nnvm/src/c_api/c_api_symbolic.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file c_api_symbolic.cc
  * \brief C API related to symbolic graph compsition.
  */

--- a/nnvm/src/compiler/alter_op_layout.cc
+++ b/nnvm/src/compiler/alter_op_layout.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file alter_op_layout.cc
  * \brief Alter the operator layouts. Keep inferred layouts (if any) from previous stages.
  *        e.g., convolution may calculates faster with NCHW16c layout.

--- a/nnvm/src/compiler/compile_engine.cc
+++ b/nnvm/src/compiler/compile_engine.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file compile_engine.cc
  * \brief The compile engine.
  */

--- a/nnvm/src/compiler/compile_engine.h
+++ b/nnvm/src/compiler/compile_engine.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file compile_engine.h
  * \brief Internal engine to compile a subgraph fragment and cache compilation.
  */

--- a/nnvm/src/compiler/fold_scale_axis.cc
+++ b/nnvm/src/compiler/fold_scale_axis.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file fold_scale_axis.cc
  * \author Fold scaling parameter of axis into weight of conv/dense
 */

--- a/nnvm/src/compiler/graph_compile.cc
+++ b/nnvm/src/compiler/graph_compile.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file graph_compile.cc
  * \brief Compile a graph. It lowers the graph nodes into low level IR.
  */

--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file graph_fuse.cc
  * \brief Fuse the operators together.
  */

--- a/nnvm/src/compiler/graph_fuse.h
+++ b/nnvm/src/compiler/graph_fuse.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  * \file graph_fuse.h
  * \brief Definition of structs used by graph fusion
 */

--- a/nnvm/src/compiler/graph_hash.cc
+++ b/nnvm/src/compiler/graph_hash.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file graph_deep_compare.cc
  * \brief Deep compare two graph structure
  */

--- a/nnvm/src/compiler/graph_hash.h
+++ b/nnvm/src/compiler/graph_hash.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file graph_hash.h
  * \brief The graph hashing function.
  */

--- a/nnvm/src/compiler/graph_runtime.h
+++ b/nnvm/src/compiler/graph_runtime.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file graph_runtime.h
  * \brief Interface code with TVM graph runtime.
 */

--- a/nnvm/src/compiler/graph_transform.h
+++ b/nnvm/src/compiler/graph_transform.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file graph_transform.h
  * \brief A mutator class that does local pattern matching and mutates a node.
 */

--- a/nnvm/src/compiler/node_attr.h
+++ b/nnvm/src/compiler/node_attr.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file node_attr.h
  * \brief utility to access node attributes
 */

--- a/nnvm/src/compiler/packed_func_ext.cc
+++ b/nnvm/src/compiler/packed_func_ext.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file packed_func_ext.cc
  * \brief Registeration of extension type.
  */

--- a/nnvm/src/compiler/pattern_util.h
+++ b/nnvm/src/compiler/pattern_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file pattern_util.h
  * \brief Utilities for doing various pattern matching in graph.
 */

--- a/nnvm/src/compiler/precompute_prune.cc
+++ b/nnvm/src/compiler/precompute_prune.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file precompute_prune.cc
  * \brief Split the graph into a pre-compute graph and a execution graph.
  *

--- a/nnvm/src/compiler/simplify_inference.cc
+++ b/nnvm/src/compiler/simplify_inference.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file simplify_inference.cc
  * \author Ziheng Jiang
 */

--- a/nnvm/src/core/graph.cc
+++ b/nnvm/src/core/graph.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file graph_attr_types.cc
  * \brief Graph node data structure.
  */

--- a/nnvm/src/core/node.cc
+++ b/nnvm/src/core/node.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file node.cc
  * \brief Graph node data structure.
  */

--- a/nnvm/src/core/op.cc
+++ b/nnvm/src/core/op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file op.cc
  * \brief Support for operator registry.
  */

--- a/nnvm/src/core/pass.cc
+++ b/nnvm/src/core/pass.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file pass.cc
  * \brief Support for pass registry.
  */

--- a/nnvm/src/core/symbolic.cc
+++ b/nnvm/src/core/symbolic.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file symbolic.cc
  * \brief Symbolic graph composition API.
  */

--- a/nnvm/src/pass/correct_layout.cc
+++ b/nnvm/src/pass/correct_layout.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file correct_layout.cc
  * \brief Infer and correct layout.
  */

--- a/nnvm/src/pass/gradient.cc
+++ b/nnvm/src/pass/gradient.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file gradients.cc
  * \brief Passes that takes gradient of the graph
  * This code code was modified based on mxnet codebase by Min Lin

--- a/nnvm/src/pass/graph_algorithm.h
+++ b/nnvm/src/pass/graph_algorithm.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2016 by Contributors
  * \file graph_algorithm.h
  * \brief This header contains graph algorithms on StaticGraph.
  *  It is used  compute informations such as whether two

--- a/nnvm/src/pass/infer_shape_type.cc
+++ b/nnvm/src/pass/infer_shape_type.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file infer_shape.cc
  * \brief Inference the shapes given existin information.
  */

--- a/nnvm/src/pass/order_mutation.cc
+++ b/nnvm/src/pass/order_mutation.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file order_mutation.cc
  * \brief Add control flow dependencies between nodes
  *  To correctly order mutation and read to resolve

--- a/nnvm/src/pass/place_device.cc
+++ b/nnvm/src/pass/place_device.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file place_device.cc
  * \brief Inference the device of each operator given known information.
  *  Insert a copy node automatically when there is a cross device.

--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file plan_memory.cc
  * \brief Assign memory tag to each of the data entries.
  */

--- a/nnvm/src/pass/print_graph_ir.cc
+++ b/nnvm/src/pass/print_graph_ir.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file print_graph_ir.cc
  * \brief Print the graph IR in LLVM style human readable format.
  */

--- a/nnvm/src/pass/saveload_json.cc
+++ b/nnvm/src/pass/saveload_json.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file saveload_json.cc
  * \brief Save and load graph to/from JSON file.
  */

--- a/nnvm/src/top/elemwise_op_common.h
+++ b/nnvm/src/top/elemwise_op_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file elemwise_op_common.h
  * \brief Common operator utilities
  */

--- a/nnvm/src/top/image/resize.cc
+++ b/nnvm/src/top/image/resize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file resize.cc
  * \brief Property def of resize operators.
  */

--- a/nnvm/src/top/image/resize.h
+++ b/nnvm/src/top/image/resize.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file resize.h
  */
 #ifndef NNVM_TOP_IMAGE_RESIZE_H_

--- a/nnvm/src/top/nn/convolution.cc
+++ b/nnvm/src/top/nn/convolution.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file convolution.cc
  * \brief Convolution operators
  */

--- a/nnvm/src/top/nn/nn.cc
+++ b/nnvm/src/top/nn/nn.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nn.cc
  * \brief Property def of nn operators.
  */

--- a/nnvm/src/top/nn/nn_common.h
+++ b/nnvm/src/top/nn/nn_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nn_common.h
  * \brief Common utilities for nn ops.
  */

--- a/nnvm/src/top/nn/pooling.cc
+++ b/nnvm/src/top/nn/pooling.cc
@@ -19,7 +19,6 @@
 
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file pooling.cc
  * \brief Property def of pooling operators.
  */

--- a/nnvm/src/top/op_common.h
+++ b/nnvm/src/top/op_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file op_common.h
  * \brief Common operator utilities
  */

--- a/nnvm/src/top/tensor/broadcast.cc
+++ b/nnvm/src/top/tensor/broadcast.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file broadcast.cc
  * \brief broadcast operator.
  */

--- a/nnvm/src/top/tensor/elemwise.cc
+++ b/nnvm/src/top/tensor/elemwise.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file elemwise.cc
  * \brief Elemenwise operators
  */

--- a/nnvm/src/top/tensor/matrix_op.cc
+++ b/nnvm/src/top/tensor/matrix_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file matrix_op.cc
  * \brief Matrix operators
  */

--- a/nnvm/src/top/tensor/reduce.cc
+++ b/nnvm/src/top/tensor/reduce.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file reduce.cc
  * \brief reduce operator.
  */

--- a/nnvm/src/top/tensor/state_op.cc
+++ b/nnvm/src/top/tensor/state_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file state_op.cc
  * \brief Experimental operators
  *   Currently we only support assign

--- a/nnvm/src/top/tensor/transform.cc
+++ b/nnvm/src/top/tensor/transform.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file transform.cc
  * \brief Injective transformation of shape or type.
  */

--- a/nnvm/src/top/vision/nms.cc
+++ b/nnvm/src/top/vision/nms.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file nms.cc
  * \brief Property def of SSD non-maximum suppression operator.
  */

--- a/nnvm/src/top/vision/ssd/mutibox_op.cc
+++ b/nnvm/src/top/vision/ssd/mutibox_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file multibox_op.cc
  * \brief Property def of SSD multibox related operators.
  */

--- a/nnvm/src/top/vision/yolo/reorg.cc
+++ b/nnvm/src/top/vision/yolo/reorg.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file reorg.cc
  */
 #include <nnvm/op.h>

--- a/nnvm/src/top/vision/yolo/reorg.h
+++ b/nnvm/src/top/vision/yolo/reorg.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file reorg.h
  */
 #ifndef NNVM_TOP_VISION_YOLO_REORG_H_

--- a/nnvm/tutorials/web/resnet.html
+++ b/nnvm/tutorials/web/resnet.html
@@ -1,4 +1,21 @@
 <html>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
 
 <head>
   <meta charset="UTF-8">

--- a/src/api/api_arith.cc
+++ b/src/api/api_arith.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  *  Implementation of API functions related to arith
  * \file api_arith.cc
  */

--- a/src/api/api_base.cc
+++ b/src/api/api_base.cc
@@ -18,7 +18,6 @@
  */
 
  /*!
- *  Copyright (c) 2017 by Contributors
  *  Implementation of basic API functions
  * \file api_base.cc
  */

--- a/src/api/api_codegen.cc
+++ b/src/api/api_codegen.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  *  Implementation of API functions related to Codegen
  * \file c_api_codegen.cc
  */

--- a/src/api/api_pass.cc
+++ b/src/api/api_pass.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *  Exposre of pass functions.
  * \file api_pass.cc
  */

--- a/src/api/api_test.cc
+++ b/src/api/api_test.cc
@@ -18,7 +18,6 @@
  */
 
  /*!
- *  Copyright (c) 2018 by Contributors
  *  Code mainly used for test purposes.
  * \file api_test.cc
  */

--- a/src/arithmetic/analyzer.cc
+++ b/src/arithmetic/analyzer.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/arithmetic/analyzer.cc
  */
 #include <tvm/ir.h>

--- a/src/arithmetic/bound_deducer.cc
+++ b/src/arithmetic/bound_deducer.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file bound_deducer.cc
  * \brief Utility to deduce bound of expression
  */

--- a/src/arithmetic/const_int_bound.cc
+++ b/src/arithmetic/const_int_bound.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/arithmetic/const_int_bound.cc
  */
 #include <tvm/arithmetic.h>

--- a/src/arithmetic/detect_linear_equation.cc
+++ b/src/arithmetic/detect_linear_equation.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file detect_linear_equation.cc
  * \brief Utility to detect patterns in the expression.
  */

--- a/src/arithmetic/domain_touched.cc
+++ b/src/arithmetic/domain_touched.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file bound_deducer.cc
  * \brief Utility to deduce bound of expression
  */

--- a/src/arithmetic/int_operator.h
+++ b/src/arithmetic/int_operator.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file int_operator.h
  * \brief Additional useful operators for integer.
  */

--- a/src/autotvm/feature_visitor.cc
+++ b/src/autotvm/feature_visitor.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file feature_visitor.cc
  * \brief Base class for feature extractor.
  *        These features are used for machine learning cost model

--- a/src/autotvm/feature_visitor.h
+++ b/src/autotvm/feature_visitor.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file feature_visitor.h
  * \brief Base class for feature extractor.
  *        These features are used for machine learning cost model

--- a/src/autotvm/touch_extractor.cc
+++ b/src/autotvm/touch_extractor.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file touch_extractor.cc
  * \brief Extract feature of touch pattern of axes in lowered IR
  */

--- a/src/autotvm/touch_extractor.h
+++ b/src/autotvm/touch_extractor.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file touch_extractor.h
  * \brief Extract feature of touch pattern of axes in lowered IR
  */

--- a/src/codegen/build_common.h
+++ b/src/codegen/build_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *  Common build utilities
  * \file build_common.h
  */

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen.cc
  * \brief Common utilities to generated C style code.
  */

--- a/src/codegen/codegen_aocl.cc
+++ b/src/codegen/codegen_aocl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file codegen_aocl.cc
  */
 #include <tvm/build_module.h>

--- a/src/codegen/codegen_c.cc
+++ b/src/codegen/codegen_c.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_c.cc
  */
 #include <iomanip>

--- a/src/codegen/codegen_c.h
+++ b/src/codegen/codegen_c.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file codegen_c.h
  * \brief Common utilities to generated C style code.
  */

--- a/src/codegen/codegen_c_host.cc
+++ b/src/codegen/codegen_c_host.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_c_host.cc
  */
 #include <tvm/packed_func_ext.h>

--- a/src/codegen/codegen_c_host.h
+++ b/src/codegen/codegen_c_host.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_c_host.h
  * \brief Generate C host code.
  */

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_cuda.cc
  */
 #include <tvm/base.h>

--- a/src/codegen/codegen_cuda.h
+++ b/src/codegen/codegen_cuda.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_cuda.h
  * \brief Utility to generate cuda code
  */

--- a/src/codegen/codegen_metal.cc
+++ b/src/codegen/codegen_metal.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_metal.cc
  */
 #include <tvm/packed_func_ext.h>

--- a/src/codegen/codegen_metal.h
+++ b/src/codegen/codegen_metal.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_metal.h
  * \brief Generate Metal device code.
  */

--- a/src/codegen/codegen_opencl.cc
+++ b/src/codegen/codegen_opencl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_opencl.cc
  */
 #include <tvm/packed_func_ext.h>

--- a/src/codegen/codegen_opencl.h
+++ b/src/codegen/codegen_opencl.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_opencl.h
  * \brief Generate OpenCL device code.
  */

--- a/src/codegen/codegen_opengl.cc
+++ b/src/codegen/codegen_opengl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_opengl.cc
  *
  * We are targeting OpenGL 3.3. The reason of not targeting a recent version

--- a/src/codegen/codegen_opengl.h
+++ b/src/codegen/codegen_opengl.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_opengl.h
  * \brief Generate OpenGL device code.
  */

--- a/src/codegen/codegen_source_base.cc
+++ b/src/codegen/codegen_source_base.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_source_base.cc
  */
 #include "codegen_source_base.h"

--- a/src/codegen/codegen_source_base.h
+++ b/src/codegen/codegen_source_base.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file codegen_source_base.h
  * \brief Common utilities to source code in text form.
  */

--- a/src/codegen/codegen_vhls.cc
+++ b/src/codegen/codegen_vhls.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file codegen_vhls.cc
  */
 #include <tvm/build_module.h>

--- a/src/codegen/codegen_vhls.h
+++ b/src/codegen/codegen_vhls.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file codegen_vhls.h
  * \brief Utility to generate vhls code
  */

--- a/src/codegen/intrin_rule.cc
+++ b/src/codegen/intrin_rule.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_default.cc
  * \brief Default intrinsic rules.
  */

--- a/src/codegen/intrin_rule.h
+++ b/src/codegen/intrin_rule.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule.h
  * \brief Utility to generate intrinsic rules
  */

--- a/src/codegen/intrin_rule_aocl.cc
+++ b/src/codegen/intrin_rule_aocl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file intrin_rule_aocl.cc
  * \brief AOCL intrinsic rules.
  */

--- a/src/codegen/intrin_rule_cuda.cc
+++ b/src/codegen/intrin_rule_cuda.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_cuda.cc
  * \brief CUDA intrinsic rules.
  */

--- a/src/codegen/intrin_rule_metal.cc
+++ b/src/codegen/intrin_rule_metal.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_metal.cc
  * \brief Metal intrinsic rules.
  */

--- a/src/codegen/intrin_rule_opencl.cc
+++ b/src/codegen/intrin_rule_opencl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_opencl.cc
  * \brief OpenCL intrinsic rules.
  */

--- a/src/codegen/intrin_rule_opengl.cc
+++ b/src/codegen/intrin_rule_opengl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_opencl.cc
  * \brief OpenCL intrinsic rules.
  */

--- a/src/codegen/intrin_rule_vhls.cc
+++ b/src/codegen/intrin_rule_vhls.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file intrin_rule_vhls.cc
  * \brief VHLS intrinsic rules.
  */

--- a/src/codegen/literal/cuda_half_t.h
+++ b/src/codegen/literal/cuda_half_t.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file cuda_half_t.h
  * \brief half_t (fp16) definition for cuda codegen.
  */

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_amdgpu.cc
  * \brief AMDGPU code generator.
  */

--- a/src/codegen/llvm/codegen_arm.cc
+++ b/src/codegen/llvm/codegen_arm.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_arm.cc
  * \brief ARM specific code generator
  */

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_llvm.cc
  */
 #ifdef TVM_LLVM_VERSION

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_llvm.h
  * \brief Common base class for generating into LLVM IR
  */

--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_nvptx.cc
  * \brief NVPTX code generator.
  */

--- a/src/codegen/llvm/codegen_x86_64.cc
+++ b/src/codegen/llvm/codegen_x86_64.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file codegen_x86_64.cc
  * \brief X86-64 specific code generator
  */

--- a/src/codegen/llvm/intrin_rule_llvm.cc
+++ b/src/codegen/llvm/intrin_rule_llvm.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_llvm.cc
  */
 #ifdef TVM_LLVM_VERSION

--- a/src/codegen/llvm/intrin_rule_llvm.h
+++ b/src/codegen/llvm/intrin_rule_llvm.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_llvm.h
  * \brief Common utilities for llvm intrinsics.
  */

--- a/src/codegen/llvm/intrin_rule_nvptx.cc
+++ b/src/codegen/llvm/intrin_rule_nvptx.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_nvptx.cc
  */
 #ifdef TVM_LLVM_VERSION

--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file intrin_rule_rocm.cc
  */
 #ifdef TVM_LLVM_VERSION

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file llvm_common.cc
  */
 #ifdef TVM_LLVM_VERSION

--- a/src/codegen/llvm/llvm_common.h
+++ b/src/codegen/llvm/llvm_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file llvm_common.h
  * \brief Common utilities for llvm initialization.
  */

--- a/src/codegen/opt/build_aocl_off.cc
+++ b/src/codegen/opt/build_aocl_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build aocl is switched to off
  */
 #include "../codegen_source_base.h"

--- a/src/codegen/opt/build_cuda_off.cc
+++ b/src/codegen/opt/build_cuda_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build cuda is switched to off
  */
 #include "../../runtime/cuda/cuda_module.h"

--- a/src/codegen/opt/build_cuda_on.cc
+++ b/src/codegen/opt/build_cuda_on.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *  Build cuda modules from source.
  *  requires cuda to be available.
  *

--- a/src/codegen/opt/build_metal_off.cc
+++ b/src/codegen/opt/build_metal_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build metal is switched to off
  */
 #include "../codegen_source_base.h"

--- a/src/codegen/opt/build_opencl_off.cc
+++ b/src/codegen/opt/build_opencl_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build opencl is switched to off
  */
 #include "../codegen_source_base.h"

--- a/src/codegen/opt/build_opengl_off.cc
+++ b/src/codegen/opt/build_opengl_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build opencl is switched to off
  */
 #include "../codegen_source_base.h"

--- a/src/codegen/opt/build_rocm_off.cc
+++ b/src/codegen/opt/build_rocm_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build rocm is switched to off
  */
 #include "../codegen_source_base.h"

--- a/src/codegen/opt/build_sdaccel_off.cc
+++ b/src/codegen/opt/build_sdaccel_off.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  *  Optional module when build opencl is switched to off
  */
 #include "../codegen_source_base.h"

--- a/src/codegen/spirv/build_vulkan.cc
+++ b/src/codegen/spirv/build_vulkan.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file build_vulkan.cc
  * \brief Build SPIRV block
  */

--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file codegen_spirv.cc
  * \brief Generate SPIRV block
  */

--- a/src/codegen/spirv/codegen_spirv.h
+++ b/src/codegen/spirv/codegen_spirv.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file ir_builder.h
  * \brief Utility for building SPIRV code block
  */

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file ir_builder.cc
  * \brief IRBuilder for SPIRV block
  */

--- a/src/codegen/spirv/ir_builder.h
+++ b/src/codegen/spirv/ir_builder.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file ir_builder.h
  * \brief Utility for building SPIRV code block
  */

--- a/src/codegen/stackvm/codegen_stackvm.cc
+++ b/src/codegen/stackvm/codegen_stackvm.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_stackvm.cc
  */
 #include <tvm/runtime/registry.h>

--- a/src/codegen/stackvm/codegen_stackvm.h
+++ b/src/codegen/stackvm/codegen_stackvm.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file codegen_stack_vm.h
  * \brief Codegen into Simple Stack VM.
  */

--- a/src/common/arena.h
+++ b/src/common/arena.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright 2018 by Contributors
  *
  * \file arena.h
  * \brief Arena allocator that allocates

--- a/src/common/base64.h
+++ b/src/common/base64.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright 2018 by Contributors
  *
  * \file base64.h
  * \brief data stream support to input and output from/to base64 stream

--- a/src/common/pipe.h
+++ b/src/common/pipe.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file pipe.h
  * \brief Platform independent pipe, used for IPC.
  */

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file ring_buffer.h
  * \brief this file aims to provide a wrapper of sockets
  */

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file socket.h
  * \brief this file aims to provide a wrapper of sockets
  * \author Tianqi Chen

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file util.h
  * \brief Defines some common utility function..
  */

--- a/src/contrib/hybrid/codegen_hybrid.cc
+++ b/src/contrib/hybrid/codegen_hybrid.cc
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-/*!  Copyright (c) 2019 by Contributors
  * \file codegen_hybrid.cc
  */
 #include <iomanip>

--- a/src/contrib/hybrid/codegen_hybrid.cc
+++ b/src/contrib/hybrid/codegen_hybrid.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+/*!
  * \file codegen_hybrid.cc
  */
 #include <iomanip>

--- a/src/lang/api_registry.cc
+++ b/src/lang/api_registry.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file api_registry.cc
  */
 #include <tvm/api_registry.h>

--- a/src/lang/attrs.cc
+++ b/src/lang/attrs.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file attrs.cc
  */
 #include <tvm/attrs.h>

--- a/src/lang/buffer.cc
+++ b/src/lang/buffer.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file buffer.cc
  */
 #include <tvm/buffer.h>

--- a/src/lang/channel.cc
+++ b/src/lang/channel.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file channel.cc
  */
 #include <tvm/channel.h>

--- a/src/lang/data_layout.cc
+++ b/src/lang/data_layout.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/lang/data_layout.cc
  * \brief Data Layout expression.
  */

--- a/src/lang/lowered_func.cc
+++ b/src/lang/lowered_func.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file lowered_func.cc
  */
 #include <tvm/lowered_func.h>

--- a/src/lang/tensor.cc
+++ b/src/lang/tensor.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file tensor.cc
  */
 #include <tvm/tensor.h>

--- a/src/op/compute_op.h
+++ b/src/op/compute_op.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Helper utilities to implement compute_op.
  * \file compute_op.h
  */

--- a/src/op/cross_thread_reduction.cc
+++ b/src/op/cross_thread_reduction.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Logics related to cross thread reduction, used by ComputeOpNode.
  * \file cross_thread_reduction.cc
  */

--- a/src/op/hybrid_op.h
+++ b/src/op/hybrid_op.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \brief Helper utilities to implement hybrid_op.
  * \file hybrid_op.h
  */

--- a/src/op/op_util.h
+++ b/src/op/op_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file op_util.h
  * \brief Common utility used in operator construction.
  */

--- a/src/op/placeholder_op.cc
+++ b/src/op/placeholder_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Placeholder op.
  * \file placeholder_op.cc
  */

--- a/src/op/tensor_compute_op.cc
+++ b/src/op/tensor_compute_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Tensor Compute Op.
  * \file tensor_compute_op.cc
  */

--- a/src/op/tensorize.cc
+++ b/src/op/tensorize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Logics related to tensorize, used by ComputeOpNode.
  * \file tensorize.cc
  */

--- a/src/pass/arg_binder.h
+++ b/src/pass/arg_binder.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file arg_binder.h
  * \brief Helper utility to match and bind arguments.
  */

--- a/src/pass/bound_checker.cc
+++ b/src/pass/bound_checker.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file bounds_checker.cc
  */
 // Instrument checkers for out of the bounds access.

--- a/src/pass/combine_context_call.cc
+++ b/src/pass/combine_context_call.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *  Combine calls into context related function into one.
  *
  * \file combine_context_call.cc

--- a/src/pass/coproc_sync.cc
+++ b/src/pass/coproc_sync.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file coproc_sync.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/detect_device.cc
+++ b/src/pass/detect_device.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file detect_device.cc
  */
 

--- a/src/pass/infer_fragment.cc
+++ b/src/pass/infer_fragment.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  * \brief Infer TensorCore metadata from tensor intrinsic.
  * \file tensorcore_fragment.cc
  */

--- a/src/pass/inject_copy_intrin.cc
+++ b/src/pass/inject_copy_intrin.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Replace certain copy with copy intrinsics.
  * \file copy_intrin_rewrite.cc
  */

--- a/src/pass/inline.cc
+++ b/src/pass/inline.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file inline.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/ir_deep_compare.cc
+++ b/src/pass/ir_deep_compare.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file ir_deep_compare.cc
  */
 #include <tvm/ir_pass.h>

--- a/src/pass/ir_mutator.cc
+++ b/src/pass/ir_mutator.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file ir_mutator.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/ir_util.cc
+++ b/src/pass/ir_util.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file ir_util.cc
  * \brief Helper functions to construct and compose IR nodes.
  */

--- a/src/pass/ir_util.h
+++ b/src/pass/ir_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file ir_util.h
  * \brief Helper functions to construct and compose IR nodes.
  */

--- a/src/pass/ir_visitor.cc
+++ b/src/pass/ir_visitor.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file ir_visitor.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/lift_attr_scope.cc
+++ b/src/pass/lift_attr_scope.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *
  * \brief Lift specified AttrStmt scope to outer if
  *   the body contains the same scope.

--- a/src/pass/loop_partition.cc
+++ b/src/pass/loop_partition.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file loop_partition.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/lower_custom_datatypes.cc
+++ b/src/pass/lower_custom_datatypes.cc
@@ -17,7 +17,6 @@
  * under the License.
  */
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/src/pass/lower_custom_datatypes.cc
  * \brief Pass for lowering custom datatypes
  */

--- a/src/pass/lower_thread_allreduce.cc
+++ b/src/pass/lower_thread_allreduce.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *  Lower allreduce to device implementable ir.
  * \file lower_thread_allreduce.cc
  */

--- a/src/pass/lower_tvm_builtin.cc
+++ b/src/pass/lower_tvm_builtin.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  *  Lower TVM related buildin intrinsics such as packed call.
  * \file lower_tvm_buildin.cc
  */

--- a/src/pass/make_api.cc
+++ b/src/pass/make_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file make_api.cc Build API function.
  */
 #include <tvm/ir_pass.h>

--- a/src/pass/narrow_channel_access.cc
+++ b/src/pass/narrow_channel_access.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file narrow_channel_access.cc
  * \brief Narrow channel access to a smaller range
  *  when possible by bringing it to the internal loop.

--- a/src/pass/remap_thread_axis.cc
+++ b/src/pass/remap_thread_axis.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file remap_thread_axis.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/remove_no_op.cc
+++ b/src/pass/remove_no_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file remove_no_op.cc
  * \brief Remove no op from the stmt
  */

--- a/src/pass/rewrite_unsafe_select.cc
+++ b/src/pass/rewrite_unsafe_select.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file unsafe_select_rewrite.cc
  * \brief Rewrite uinsafe select expression.
  */

--- a/src/pass/simple_passes.cc
+++ b/src/pass/simple_passes.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file simple_passes.cc
  * \brief Implementation of simple passes
  */

--- a/src/pass/split_host_device.cc
+++ b/src/pass/split_host_device.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file split_host_device.cc
  * \brief Split device function from host.
  */

--- a/src/pass/split_pipeline.cc
+++ b/src/pass/split_pipeline.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file split_pipeline.cc
  * \brief Split statement into pipeline stage modules.
  */

--- a/src/pass/ssa.cc
+++ b/src/pass/ssa.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  *  SSA related checks and pass.
  *
  *  SSA requires each varaible to be only defined once.

--- a/src/pass/storage_access.cc
+++ b/src/pass/storage_access.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file storage_access.cc
  */
 #include <tvm/ir_pass.h>

--- a/src/pass/storage_access.h
+++ b/src/pass/storage_access.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2017 by Contributors
  * \file storage_access.h
  * \brief Common data structure for storage access analysis.
  */

--- a/src/pass/storage_flatten.cc
+++ b/src/pass/storage_flatten.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file storage_flatten.cc
  */
 // Flattens storage from multi-dimensional array to 1D

--- a/src/pass/storage_sync.cc
+++ b/src/pass/storage_sync.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file storage_sync.cc
  */
 #include <tvm/ir.h>

--- a/src/pass/tensor_core.cc
+++ b/src/pass/tensor_core.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tensor_core.cc
  */
 // IR Passes for TensorCore CodeGen

--- a/src/pass/verify_compact_buffer.cc
+++ b/src/pass/verify_compact_buffer.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file verify_compact_buffer.cc
  * \brief Verify if there was any compact buffer bound to a statement.
  */

--- a/src/pass/verify_gpu_code.cc
+++ b/src/pass/verify_gpu_code.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file verify_gpu_code.cc
  * \brief Verify the correctness of a GPU IR.
  *        It will check the whether the amount of memory usage or the number of threads

--- a/src/pass/verify_memory.cc
+++ b/src/pass/verify_memory.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file verify_memory.cc
  * \brief Pass to check if memory accesses are legal.
  */

--- a/src/relay/backend/compile_engine.h
+++ b/src/relay/backend/compile_engine.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file relay/backend/compile_engine.h
  * \brief Internal compialtion engine handle function cache.
  *  and interface to low level code generation.

--- a/src/relay/backend/graph_plan_memory.cc
+++ b/src/relay/backend/graph_plan_memory.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file relay/backend/graph_mem_alloca.cc
  * \brief Memory index assignment pass for executing
  *   the program in the graph runtime.

--- a/src/relay/backend/param_dict.h
+++ b/src/relay/backend/param_dict.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file param_dict.h
  * \brief Definitions for serializing and deserializing parameter dictionaries.
  */

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file relay/backend/utils.h
  * \brief Utils function for backend
  */

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/backend/vm/compiler.h
  * \brief A compiler from relay::Module to the VM byte code.
  */

--- a/src/relay/backend/vm/inline_primitives.cc
+++ b/src/relay/backend/vm/inline_primitives.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/relay/backend/vm/inline_primitives.cc
  * \brief Ensure that primitives only appear in the call position.
  */

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/relay/backend/vm/lambda_lift.cc
  * \brief Lift all local functions into global functions.
  */

--- a/src/relay/backend/vm/removed_unused_funcs.cc
+++ b/src/relay/backend/vm/removed_unused_funcs.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/relay/backend/vm/remove_unused_funcs.cc
  * \brief Remove unused global relay functions in a relay module.
  */

--- a/src/relay/ir/doc.cc
+++ b/src/relay/ir/doc.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/tvm/relay/doc.cc
  * \brief Doc ADT used for pretty printing.
  * Based on Section 1 of https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf.

--- a/src/relay/ir/doc.h
+++ b/src/relay/ir/doc.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/relay/doc.h
  * \brief Doc ADT used for pretty printing.
  *  Based on Section 1 of

--- a/src/relay/ir/error.cc
+++ b/src/relay/ir/error.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file error_reporter.h
  * \brief The set of errors raised by Relay.
  */

--- a/src/relay/ir/op.cc
+++ b/src/relay/ir/op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file src/tvm/relay/op.cc
  * \brief Resolve incomplete types to complete types.
  */

--- a/src/relay/ir/pattern_functor.cc
+++ b/src/relay/ir/pattern_functor.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/ir/pattern_functor.cc
  * \brief Implementations of visitors and mutators for ADT patterns.
  */

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file pretty_printer.cc
  * \brief Pretty printer for Relay programs
  * Supports ANF, GNF, and metadata.

--- a/src/relay/ir/type_functor.cc
+++ b/src/relay/ir/type_functor.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file type_functor.cc
  * \brief Implementations of type functors.
  */

--- a/src/relay/op/algorithm/argsort.cc
+++ b/src/relay/op/algorithm/argsort.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file argsort.cc
  * \brief Argsort operators
  */

--- a/src/relay/op/algorithm/topk.cc
+++ b/src/relay/op/algorithm/topk.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file topk.cc
  * \brief TopK operators
  */

--- a/src/relay/op/annotation/annotation.cc
+++ b/src/relay/op/annotation/annotation.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file src/relay/op/annotation/annotation.cc
  * \brief Registration of annotation operators.

--- a/src/relay/op/debug.cc
+++ b/src/relay/op/debug.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file nn.cc
  * \brief Property def of nn operators.
  */

--- a/src/relay/op/device_copy.cc
+++ b/src/relay/op/device_copy.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file src/relay/op/device_copy.cc
  * \brief Crossing device data copy operator.

--- a/src/relay/op/image/resize.cc
+++ b/src/relay/op/image/resize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file resize.cc
  * \brief Image operators
  */

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file bitserial.cc
  * \brief Property def of bitserial operators.
  */

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file convolution.cc
  * \brief Convolution operators
  */

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/op/nn/convolution.h
  * \brief Properties def of convlution operator for sharing.
  */

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file nn.cc
  * \brief Property def of nn operators.
  */

--- a/src/relay/op/nn/nn.h
+++ b/src/relay/op/nn/nn.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/op/nn/nn.h
  * \brief Properties def of nn operators for sharing.
  */

--- a/src/relay/op/nn/pad.cc
+++ b/src/relay/op/nn/pad.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file pad.cc
  * \brief Implementation of operator pad
  */

--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file pooling.cc
  * \brief Pooling operators
  */

--- a/src/relay/op/nn/sparse.cc
+++ b/src/relay/op/nn/sparse.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sparse.cc
  * \brief Property def of nn.sparse_dense operator.
  */

--- a/src/relay/op/nn/upsampling.cc
+++ b/src/relay/op/nn/upsampling.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file upsampling.cc
  * \brief upsampling operator
  */

--- a/src/relay/op/op_common.h
+++ b/src/relay/op/op_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file op_common.h
  * \brief A set of utilities and common functionality
  * for relay ops.

--- a/src/relay/op/tensor/binary.cc
+++ b/src/relay/op/tensor/binary.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file binary.cc
  * \brief binary broadcast operators.
  */

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file reduce.cc
  * \brief Reduction operators.
  */

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/op/tensor/transform.h
  * \brief Transform op attributes that can be shared among Relay and its dialects.
  */

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file unary.cc
  * \brief Unary operators.
  */

--- a/src/relay/op/type_relations.cc
+++ b/src/relay/op/type_relations.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file type_relations.cc
  * \brief A set of utilities and common functionality
  * for type relations.

--- a/src/relay/op/type_relations.h
+++ b/src/relay/op/type_relations.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file tvm/relay/op/type_relations.h
  * \brief A set of utilities and common functionality
  * for type relations.

--- a/src/relay/op/vision/multibox_op.cc
+++ b/src/relay/op/vision/multibox_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  * \file multibox_op.cc
  * \brief Multibox related operators
  */

--- a/src/relay/op/vision/nms.cc
+++ b/src/relay/op/vision/nms.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file nms.cc
  * \brief Non-maximum suppression operators
  */

--- a/src/relay/op/vision/rcnn_op.cc
+++ b/src/relay/op/vision/rcnn_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file rcnn_op.cc
  * \brief Faster RCNN and Mask RCNN operators
  */

--- a/src/relay/op/vision/yolo.cc
+++ b/src/relay/op/vision/yolo.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file yolo.cc
  * \brief Yolo related operators
  */

--- a/src/relay/pass/alter_op_layout.h
+++ b/src/relay/pass/alter_op_layout.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file alter_op_layout.h
  * \brief Alternate the layouts of operators or replace primitive operators with
           other expressions. This pass can be used for computing convolution in

--- a/src/relay/pass/canonicalize_cast.cc
+++ b/src/relay/pass/canonicalize_cast.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  * \file canonicalize_cast.cc
  * \brief Canonicalize cast expressions to make operator fusion more efficient.
  */

--- a/src/relay/pass/canonicalize_ops.cc
+++ b/src/relay/pass/canonicalize_ops.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  * \file canonicalize_ops.cc
  * \brief Canonicalize special operators to basic operators.
     This can simplify latter analysis. (e.g. Expand bias_add to expand_dims and broadcast_add.)

--- a/src/relay/pass/combine_parallel_conv2d.cc
+++ b/src/relay/pass/combine_parallel_conv2d.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file combine_parallel_conv2d.cc
  * \brief Combine parallel 2d convolutions into a single convolution.

--- a/src/relay/pass/combine_parallel_dense.cc
+++ b/src/relay/pass/combine_parallel_dense.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file combine_parallel_dense.cc
  * \brief Combine parallel dense ops into a single dense.

--- a/src/relay/pass/combine_parallel_op.cc
+++ b/src/relay/pass/combine_parallel_op.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file combine_parallel_op.cc
  * \brief Abstract class to combine parallel ops and their successive element-wise ops.

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file combine_parallel_op.h
  * \brief Abstract class to combine parallel ops and their successive element-wise ops.

--- a/src/relay/pass/combine_parallel_op_batch.cc
+++ b/src/relay/pass/combine_parallel_op_batch.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file combine_parallel_op_batch.cc
  * \brief Combine parallel ops into a single batch op.

--- a/src/relay/pass/combine_parallel_op_batch.h
+++ b/src/relay/pass/combine_parallel_op_batch.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  * \file combine_parallel_op_batch.cc
  * \brief Combine parallel ops into a single batch op.
  */

--- a/src/relay/pass/de_duplicate.cc
+++ b/src/relay/pass/de_duplicate.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file de_duplicate.cc
  * \brief Use a fresh Id for every Var to make the result well-formed.

--- a/src/relay/pass/dead_code.cc
+++ b/src/relay/pass/dead_code.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file dead_code.cc
  *

--- a/src/relay/pass/dependency_graph.cc
+++ b/src/relay/pass/dependency_graph.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  * \file tvm/relay/pass/dependency_graph.cc
  * \brief
  */

--- a/src/relay/pass/dependency_graph.h
+++ b/src/relay/pass/dependency_graph.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors.
  * \file tvm/relay/pass/dependency_graph.h
  * \brief create a dependency graph.
  */

--- a/src/relay/pass/eliminate_common_subexpr.cc
+++ b/src/relay/pass/eliminate_common_subexpr.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file eliminate_common_subexpr.cc
  * \brief Combine common subexpressions.

--- a/src/relay/pass/expr_subst.cc
+++ b/src/relay/pass/expr_subst.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file expr_subst.h
  * \brief Utility functions for substituting expressions.
  */

--- a/src/relay/pass/expr_subst.h
+++ b/src/relay/pass/expr_subst.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file expr_subst.h
  * \brief Utility functions for substituting expressions.
  */

--- a/src/relay/pass/feature.cc
+++ b/src/relay/pass/feature.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  * \file feature.cc
  * \brief Detect features used in Expr/Module
  */

--- a/src/relay/pass/fold_constant.cc
+++ b/src/relay/pass/fold_constant.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  * \file constant_folding.cc
  */
 #include <tvm/relay/analysis.h>

--- a/src/relay/pass/forward_rewrite.cc
+++ b/src/relay/pass/forward_rewrite.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file forward_rewrite.cc
  * \brief Apply rewriting rules in a forward fashion.

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file src/tvm/relay/pass/fuse_ops.cc
  *

--- a/src/relay/pass/gradient.cc
+++ b/src/relay/pass/gradient.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file ad.cc
  * \brief API for Automatic Differentiation for the Relay IR.
  */

--- a/src/relay/pass/kind_check.cc
+++ b/src/relay/pass/kind_check.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file kindchecker.cc
  *

--- a/src/relay/pass/legalize.cc
+++ b/src/relay/pass/legalize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  * \file legalize.cc
  * \brief Converts an expr to another expr. This pass can be used to transform an op based on its
  * shape, dtype or layout to another op or a sequence of ops.

--- a/src/relay/pass/let_list.h
+++ b/src/relay/pass/let_list.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file let_list.h
  * \brief LetList record let binding and insert let expression implicitly.
  *  using it, one can treat AST as value instead of expression,

--- a/src/relay/pass/mac_count.cc
+++ b/src/relay/pass/mac_count.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file mac_count.cc
  * \brief Pass to roughly count the number of MACs (Multiply-Accumulate) 

--- a/src/relay/pass/match_exhaustion.cc
+++ b/src/relay/pass/match_exhaustion.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file match_exhaustion.cc
  * \brief Checking Relay match expression exhaustiveness.
  *

--- a/src/relay/pass/pass_util.h
+++ b/src/relay/pass/pass_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors.
  *
  * \file tvm/relay/pass/pass_util.h
  * \brief Utilities for writing passes

--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors.
  *
  * \file tvm/relay/pass/pattern_util.h
  * \brief Header of internal operator functions

--- a/src/relay/pass/print_ir.cc
+++ b/src/relay/pass/print_ir.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file src/relay/pass/print_ir.cc
  *

--- a/src/relay/pass/quantize/annotate.cc
+++ b/src/relay/pass/quantize/annotate.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file annotate.cc
  *

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file calibrate.cc
  *

--- a/src/relay/pass/quantize/partition.cc
+++ b/src/relay/pass/quantize/partition.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file partition.cc
  *

--- a/src/relay/pass/quantize/realize.cc
+++ b/src/relay/pass/quantize/realize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file realize.cc
  *

--- a/src/relay/pass/simplify_inference.cc
+++ b/src/relay/pass/simplify_inference.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  * \file simplify_inference.cc
  */
 #include <tvm/relay/analysis.h>

--- a/src/relay/pass/to_a_normal_form.cc
+++ b/src/relay/pass/to_a_normal_form.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file to_a_normal_form.cc
  *

--- a/src/relay/pass/to_cps.cc
+++ b/src/relay/pass/to_cps.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2019 by Contributors
  *
  * \file to_cps.cc
  *

--- a/src/relay/pass/to_graph_normal_form.cc
+++ b/src/relay/pass/to_graph_normal_form.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file to_gnf.cc
  *

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file type_infer.cc
  * \brief Relay type inference and checking.
  *

--- a/src/relay/pass/type_solver.cc
+++ b/src/relay/pass/type_solver.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file type_solver.cc
  * \brief Type solver implementations.
  */

--- a/src/relay/pass/type_solver.h
+++ b/src/relay/pass/type_solver.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file type_solver.h
  * \brief Solver logic for type inference.
  */

--- a/src/relay/pass/util.cc
+++ b/src/relay/pass/util.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  *
  * \file util.cc
  *

--- a/src/relay/pass/well_formed.cc
+++ b/src/relay/pass/well_formed.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file well_formed.cc
  * \brief check that expression is well formed.
  */

--- a/src/relay/qnn/op/add.cc
+++ b/src/relay/qnn/op/add.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/add.cc
  * \brief QNN add operator.
  */

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/concatenate.cc
  * \brief QNN concatenate operator. It concatenates quantized input tensors along a given axis.
  */

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/convolution.cc
  * \brief Property def of qnn convolution operator.
  */

--- a/src/relay/qnn/op/dense.cc
+++ b/src/relay/qnn/op/dense.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/dense.cc
  * \brief Property def of qnn dense operator.
  */

--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/dequantize.cc
  * \brief QNN dequantize operator. Dequantize operator converts from quantized
  * domain to unquantized domain.

--- a/src/relay/qnn/op/mul.cc
+++ b/src/relay/qnn/op/mul.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/mul.cc
  * \brief QNN mul operator.
  */

--- a/src/relay/qnn/op/op_common.h
+++ b/src/relay/qnn/op/op_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file src/relay/qnn/op/op_common.h
  * \brief A set of utilities and common functionality for QNN ops.
  */

--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/quantize.cc
  * \brief QNN dequantize operator. Dequantize operator converts from quantized
  * domain to unquantized domain.

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/op/requantize.cc
  * \brief QNN requantize operator.
  */

--- a/src/relay/qnn/util.cc
+++ b/src/relay/qnn/util.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/relay/qnn/util.cc
  * \brief Utility functions for QNN.
  */

--- a/src/runtime/builtin_fp16.cc
+++ b/src/runtime/builtin_fp16.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
  * \file builtin_fp16.cc
  * \brief Functions for conversion between fp32 and fp16
 */

--- a/src/runtime/contrib/cublas/cublas_utils.h
+++ b/src/runtime/contrib/cublas/cublas_utils.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file Use external cudnn utils function
  */
 

--- a/src/runtime/contrib/nnpack/convolution.cc
+++ b/src/runtime/contrib/nnpack/convolution.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file Use external nnpack library call.
  */
 #include <tvm/runtime/device_api.h>

--- a/src/runtime/contrib/nnpack/fully_connected.cc
+++ b/src/runtime/contrib/nnpack/fully_connected.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file Use external nnpack library call.
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/contrib/nnpack/nnpack_utils.cc
+++ b/src/runtime/contrib/nnpack/nnpack_utils.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file Use external nnpack library call.
  */
 #include "nnpack_utils.h"

--- a/src/runtime/contrib/nnpack/nnpack_utils.h
+++ b/src/runtime/contrib/nnpack/nnpack_utils.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file Use external nnpack library call.
  */
 #ifndef TVM_RUNTIME_CONTRIB_NNPACK_NNPACK_UTILS_H_

--- a/src/runtime/contrib/random/mt_random_engine.cc
+++ b/src/runtime/contrib/random/mt_random_engine.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file random/mt_random_engine.cc
  * \brief mt19937 random engine
  */

--- a/src/runtime/contrib/random/random.cc
+++ b/src/runtime/contrib/random/random.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file External random functions for tensor.
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/contrib/random/sgx_random_engine.cc
+++ b/src/runtime/contrib/random/sgx_random_engine.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file random/sgx_random_engine.h
  * \brief SGX trusted random engine
  */

--- a/src/runtime/contrib/rocblas/rocblas.cc
+++ b/src/runtime/contrib/rocblas/rocblas.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file Use external rocblas library call.
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/contrib/sort/sort.cc
+++ b/src/runtime/contrib/sort/sort.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file Use standard C library call.
  */
 

--- a/src/runtime/cpu_device_api.cc
+++ b/src/runtime/cpu_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file cpu_device_api.cc
  */
 #include <dmlc/logging.h>

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file cuda_common.h
  * \brief Common utilities for CUDA
  */

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file cuda_device_api.cc
  * \brief GPU specific API
  */

--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file cuda_module.cc
  */
 #include "cuda_module.h"

--- a/src/runtime/file_util.cc
+++ b/src/runtime/file_util.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file file_util.cc
  */
 #include <dmlc/json.h>

--- a/src/runtime/file_util.h
+++ b/src/runtime/file_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file file_util.h
  * \brief Minimum file manipulation util for runtime.
  */

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file meta_data.h
  * \brief Meta data related utilities
  */

--- a/src/runtime/metal/metal_common.h
+++ b/src/runtime/metal/metal_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file metal_common.h
  * \brief Metal common header
  */

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file metal_device_api.mm
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/metal/metal_module.h
+++ b/src/runtime/metal/metal_module.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file metal_module.h
  * \brief Execution handling of Metal kernels
  */

--- a/src/runtime/micro/device/utvm_device_dylib_redirect.c
+++ b/src/runtime/micro/device/utvm_device_dylib_redirect.c
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file utvm_device_dylib_redirect.cc
  * \brief uTVM dynamic linking stubs
  *

--- a/src/runtime/micro/device/utvm_runtime.c
+++ b/src/runtime/micro/device/utvm_runtime.c
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file utvm_runtime.cc
  * \brief uTVM runtime
  *

--- a/src/runtime/micro/device/utvm_runtime.h
+++ b/src/runtime/micro/device/utvm_runtime.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file utvm_runtime.h
  * \brief uTVM runtime headers
  */

--- a/src/runtime/micro/host_low_level_device.cc
+++ b/src/runtime/micro/host_low_level_device.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file host_low_level_device.cc
  * \brief emulated low-level micro device implementation on host machine
  */

--- a/src/runtime/micro/low_level_device.h
+++ b/src/runtime/micro/low_level_device.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file low_level_device.h
  * \brief Abstract low-level micro device management
  */

--- a/src/runtime/micro/micro_common.cc
+++ b/src/runtime/micro/micro_common.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file micro_common.cc
  * \brief common utilties for uTVM
  */

--- a/src/runtime/micro/micro_common.h
+++ b/src/runtime/micro/micro_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file micro_common.h
  */
 #ifndef TVM_RUNTIME_MICRO_MICRO_COMMON_H_

--- a/src/runtime/micro/micro_section_allocator.h
+++ b/src/runtime/micro/micro_section_allocator.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file micro_section_allocator.h
  */
 #ifndef TVM_RUNTIME_MICRO_MICRO_SECTION_ALLOCATOR_H_

--- a/src/runtime/micro/openocd_low_level_device.cc
+++ b/src/runtime/micro/openocd_low_level_device.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file openocd_low_level_device.cc
  */
 #include <sstream>

--- a/src/runtime/micro/target_data_layout_encoder.h
+++ b/src/runtime/micro/target_data_layout_encoder.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file target_data_layout_encoder.h
  * \brief uTVM data layout encoder
  */

--- a/src/runtime/micro/tcl_socket.cc
+++ b/src/runtime/micro/tcl_socket.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tcl_socket.cc
  */
 #include <string>

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file ndarray.cc
  * \brief NDArray container infratructure.
  */

--- a/src/runtime/opencl/aocl/aocl_module.cc
+++ b/src/runtime/opencl/aocl/aocl_module.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file aocl_module.cc
  */
 #include <dmlc/memory_io.h>

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file opencl_common.h
  * \brief OpenCL common header
  */

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file opencl_device_api.cc
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/opencl/sdaccel/sdaccel_common.h
+++ b/src/runtime/opencl/sdaccel/sdaccel_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sdaccel_common.h
  * \brief SDAccel common header
  */

--- a/src/runtime/opencl/sdaccel/sdaccel_device_api.cc
+++ b/src/runtime/opencl/sdaccel/sdaccel_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sdaccel_device_api.cc
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/opencl/sdaccel/sdaccel_module.cc
+++ b/src/runtime/opencl/sdaccel/sdaccel_module.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sdaccel_module.cc
  */
 #include <dmlc/memory_io.h>

--- a/src/runtime/opencl/sdaccel/sdaccel_module.h
+++ b/src/runtime/opencl/sdaccel/sdaccel_module.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sdaccel_module.h
  * \brief Execution handling of OPENCL kernels for SDAccel FPGAs
  */

--- a/src/runtime/opengl/opengl_common.h
+++ b/src/runtime/opengl/opengl_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file opengl_common.h
  * \brief OpenGL common header
  */

--- a/src/runtime/opengl/opengl_device_api.cc
+++ b/src/runtime/opengl/opengl_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file opengl_device_api.cc
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/opengl/opengl_module.cc
+++ b/src/runtime/opengl/opengl_module.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file opengl_module.cc
  */
 #include <tvm/runtime/registry.h>

--- a/src/runtime/opengl/opengl_module.h
+++ b/src/runtime/opengl/opengl_module.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file opengl_module.h
  * \brief Execution handling of OpenGL kernels
  */

--- a/src/runtime/pack_args.h
+++ b/src/runtime/pack_args.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file pack_args.h
  * \brief Utility to pack TVMArgs to other type-erased fution calling convention.
  *

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file registry.cc
  * \brief The global registry of packed function.
  */

--- a/src/runtime/rocm/rocm_common.h
+++ b/src/runtime/rocm/rocm_common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rocm_common.h
  * \brief Common utilities for ROCM
  */

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rocm_device_api.cc
  * \brief GPU specific API
  */

--- a/src/runtime/rocm/rocm_module.h
+++ b/src/runtime/rocm/rocm_module.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rocm_module.h
  * \brief Execution handling of ROCM kernels
  */

--- a/src/runtime/rpc/rpc_device_api.cc
+++ b/src/runtime/rpc/rpc_device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rpc_device_api.cc
  */
 #include <dmlc/logging.h>

--- a/src/runtime/rpc/rpc_event_impl.cc
+++ b/src/runtime/rpc/rpc_event_impl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rpc_event_impl.cc
  * \brief Event based RPC server implementation.
  */

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rpc_device_api.cc
  * \brief RPC module.
  */

--- a/src/runtime/rpc/rpc_server_env.cc
+++ b/src/runtime/rpc/rpc_server_env.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rpc_server_env.cc
  * \brief Server environment of the RPC.
  */

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rpc_session.cc
  * \brief RPC session for remote function call.
  */

--- a/src/runtime/rpc/rpc_socket_impl.cc
+++ b/src/runtime/rpc/rpc_socket_impl.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file rpc_socket_impl.cc
  * \brief Socket based RPC implementation.
  */

--- a/src/runtime/rpc/rpc_socket_impl.h
+++ b/src/runtime/rpc/rpc_socket_impl.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file rpc_socket_impl.h
  * \brief Socket based RPC implementation.
  */

--- a/src/runtime/runtime_base.h
+++ b/src/runtime/runtime_base.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file runtime_base.h
  * \brief Base of all C APIs
  */

--- a/src/runtime/sgx/common.h
+++ b/src/runtime/sgx/common.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file common.h
  * \brief TVM SGX common API.
  */

--- a/src/runtime/sgx/trusted/ecall_registry.h
+++ b/src/runtime/sgx/trusted/ecall_registry.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file ecall_registry.h
  * \brief The global registry of packed functions available via ecall_packed_func.
  */

--- a/src/runtime/sgx/trusted/runtime.cc
+++ b/src/runtime/sgx/trusted/runtime.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file runtime_t.cc
  */
 #include <tvm/runtime/c_runtime_api.h>

--- a/src/runtime/sgx/trusted/runtime.h
+++ b/src/runtime/sgx/trusted/runtime.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file trusted/runtime.h
  * \brief TVM SGX trusted API.
  */

--- a/src/runtime/sgx/trusted/threading_backend.cc
+++ b/src/runtime/sgx/trusted/threading_backend.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sgx/threading_backend.cc
  * \brief SGX threading backend
  */

--- a/src/runtime/sgx/untrusted/sgx_module.cc
+++ b/src/runtime/sgx/untrusted/sgx_module.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sgx_module.cc
  * \brief SGX enclave module.
  */

--- a/src/runtime/stackvm/stackvm.h
+++ b/src/runtime/stackvm/stackvm.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file stackvm.h
  * \brief A simple stack-based virtual machine.
  *

--- a/src/runtime/stackvm/stackvm_module.h
+++ b/src/runtime/stackvm/stackvm_module.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file stackvm_module.h
  * \brief StackVM module
  */

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file thread_pool.cc
  * \brief Threadpool for multi-threading runtime.
  */

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file thread_storage_scope.h
  * \brief Extract thread axis configuration from TVMArgs.
  */

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file threading_backend.cc
  * \brief Native threading backend
  */

--- a/src/runtime/vm/memory_manager.cc
+++ b/src/runtime/vm/memory_manager.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file tvm/runtime/vm/memory_manager.cc
  * \brief Allocate and manage memory for the runtime.
  */

--- a/src/runtime/vm/memory_manager.h
+++ b/src/runtime/vm/memory_manager.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/runtime/memory_manager.h
  * \brief Abstract device memory management API
  */

--- a/src/runtime/vm/naive_allocator.h
+++ b/src/runtime/vm/naive_allocator.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/runtime/naive_allocator.h
  */
 #ifndef TVM_RUNTIME_VM_NAIVE_ALLOCATOR_H_

--- a/src/runtime/vm/pooled_allocator.h
+++ b/src/runtime/vm/pooled_allocator.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file runtime/pooled_allocator.h
  */
 #ifndef TVM_RUNTIME_VM_POOLED_ALLOCATOR_H_

--- a/src/runtime/vm/serialize_util.h
+++ b/src/runtime/vm/serialize_util.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file src/runtime/vm/serialize_util.h
  * \brief Definitions of helpers for serializing and deserializing a Relay VM.
  */

--- a/src/runtime/workspace_pool.cc
+++ b/src/runtime/workspace_pool.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file workspace_pool.h
  * \brief Workspace pool utility.
  */

--- a/src/runtime/workspace_pool.h
+++ b/src/runtime/workspace_pool.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file workspace_pool.h
  * \brief Workspace pool utility.
  */

--- a/src/schedule/auto_inline_elem_wise.cc
+++ b/src/schedule/auto_inline_elem_wise.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file auto_inline_elem_wise.cc
  */
 #include <tvm/schedule_pass.h>

--- a/src/schedule/bound.cc
+++ b/src/schedule/bound.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file bound.cc
  * \brief The bound inference logic.
  */

--- a/src/schedule/graph.h
+++ b/src/schedule/graph.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file graph.h
  * \brief Utilities to get information about schedule graph.
  */

--- a/src/schedule/message_passing.h
+++ b/src/schedule/message_passing.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file message_passing.h
  * \brief Common utilities to do message passing
  *  on the schedule hyper graph.

--- a/src/schedule/schedule_ops.cc
+++ b/src/schedule/schedule_ops.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2016 by Contributors
  * \file schedule_ops.cc
  */
 #include <tvm/ir.h>

--- a/tests/lint/add_asf_header.py
+++ b/tests/lint/add_asf_header.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 """Helper tool to add ASF header to files that cannot be handled by Rat."""
 import os
 import sys
@@ -119,6 +118,10 @@ header_groovystyle = """
 FMT_MAP = {
     "sh" : header_pystyle,
     "cc" : header_cstyle,
+    "c" : header_cstyle,
+    "mm" : header_cstyle,
+    "m" : header_cstyle,
+    "go" : header_cstyle,
     "java" : header_cstyle,
     "h" : header_cstyle,
     "py" : header_pystyle,
@@ -134,48 +137,76 @@ FMT_MAP = {
     "tcl": header_pystyle,
 }
 
+
+def copyright_line(line):
+    # Following two items are intentionally break apart
+    # so that the copyright detector won't detect the file itself.
+    if line.find("Copyright " + "(c)") != -1:
+        return True
+    if (line.find("Copyright") != -1 and
+        line.find(" by") != -1):
+        return True
+    return False
+
+
 def add_header(fname, header):
     """Add header to file"""
     if not os.path.exists(fname):
         print("Cannot find %s ..." % fname)
         return
 
-    orig = open(fname).read()
-    if orig.find("Licensed to the Apache Software Foundation") != -1:
+    lines = open(fname).readlines()
+
+    has_asf_header = False
+    has_copyright = False
+
+    for i, l in enumerate(lines):
+        if l.find("Licensed to the Apache Software Foundation") != -1:
+            has_asf_header = True
+        elif copyright_line(l):
+            has_copyright = True
+            lines[i] = ""
+
+    if has_asf_header and not has_copyright:
         print("Skip file %s ..." % fname)
         return
 
+
     with open(fname, "w") as outfile:
         skipline = False
-        lines = orig.split('\n')
         ext = os.path.splitext(fname)[1][1:]
+
         if ext == 'sh' and lines[0][:2] == '#!':
             skipline = True
         elif ext == 'xml' and lines[0][:2] == '<?':
             skipline = True
 
         if skipline:
-            outfile.write(lines[0] + "\n")
-            outfile.write(header + "\n\n")
-            outfile.write("\n".join(lines[1:]))
-            outfile.write(header + "\n\n")
-            outfile.write(orig)
+            outfile.write(lines[0])
+            if not has_asf_header:
+                outfile.write(header + "\n\n")
+            outfile.write("".join(lines[1:]))
         else:
-            outfile.write(header + "\n\n")
-            outfile.write(orig)
-    print("Add header to %s" % fname)
-
+            if not has_asf_header:
+                outfile.write(header + "\n\n")
+            outfile.write("".join(lines))
+    if not has_asf_header:
+        print("Add header to %s" % fname)
+    if has_copyright:
+        print("Removed copyright line from %s" % fname)
 
 def main(args):
     if len(args) != 2:
         print("Usage: python add_asf_header.py <file_list>")
 
     for l in open(args[1]):
-        if l.startswith("-----"):
+        if l.startswith("---"):
             continue
         if l.find("File:") != -1:
             l = l.split(":")[-1]
         fname = l.strip()
+        if len(fname) == 0:
+            continue
         suffix = fname.split(".")[-1]
         if suffix in FMT_MAP:
             add_header(fname, FMT_MAP[suffix])

--- a/tests/lint/add_asf_header.py
+++ b/tests/lint/add_asf_header.py
@@ -131,16 +131,22 @@ FMT_MAP = {
     "rs" : header_cstyle,
     "md" : header_mdstyle,
     "cmake" : header_pystyle,
+    "mk" : header_pystyle,
     "rst" : header_rststyle,
     "gradle" : header_groovystyle,
-    "xml": header_mdstyle,
     "tcl": header_pystyle,
+    "xml": header_mdstyle,
+    "storyboard": header_mdstyle,
+    "pbxproj": header_cstyle,
+    "plist": header_mdstyle,
+    "xcworkspacedata": header_mdstyle,
+    "html": header_mdstyle,
 }
 
 
 def copyright_line(line):
     # Following two items are intentionally break apart
-    # so that the copyright detector won't detect the file itself.
+    # so that the copyright detector won"t detect the file itself.
     if line.find("Copyright " + "(c)") != -1:
         return True
     if (line.find("Copyright") != -1 and
@@ -176,10 +182,14 @@ def add_header(fname, header):
         skipline = False
         ext = os.path.splitext(fname)[1][1:]
 
-        if ext == 'sh' and lines[0][:2] == '#!':
+        if lines[0][:2] == "#!":
             skipline = True
-        elif ext == 'xml' and lines[0][:2] == '<?':
+        elif lines[0][:2] == "<?":
             skipline = True
+        elif lines[0].startswith("<html>"):
+            skipline = True
+        elif lines[0].startswith("// !$"):
+            skipline =True
 
         if skipline:
             outfile.write(lines[0])
@@ -210,8 +220,8 @@ def main(args):
         suffix = fname.split(".")[-1]
         if suffix in FMT_MAP:
             add_header(fname, FMT_MAP[suffix])
-        elif os.path.basename(fname) == 'gradle.properties':
-            add_header(fname, FMT_MAP['h'])
+        elif os.path.basename(fname) == "gradle.properties":
+            add_header(fname, FMT_MAP["h"])
         else:
             print("Cannot handle %s ..." % fname)
 

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -215,8 +215,9 @@ def main():
         report += "------Found %d files that has ASF header with copyright message----\n" % len(asf_copyright_list)
         report += "--- Files with ASF header do not need Copyright lines.\n"
         report += "--- Contributors retain copyright to their contribution by default.\n"
+        report += "--- If a file comes with a different license, consider put it under the 3rdparty folder instead.\n"
         report += "---\n"
-        report += "--- Use the following steps to remove the copyright lines\n"
+        report += "--- You can use the following steps to remove the copyright lines\n"
         report += "--- Create file_list.txt in your text editor\n"
         report += "--- Copy paste the above content in file-list into file_list.txt\n"
         report += "--- python3 tests/lint/add_asf_header.py file_list.txt\n"

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -146,6 +146,38 @@ def filename_allowed(name):
 
     return False
 
+
+def copyright_line(line):
+    # Following two items are intentionally break apart
+    # so that the copyright detector won't detect the file itself.
+    if line.find("Copyright " + "(c)") != -1:
+        return True
+    if (line.find("Copyright") != -1 and
+        line.find(" by") != -1):
+        return True
+    return False
+
+
+def check_asf_copyright(fname):
+    if fname.endswith(".png"):
+        return True
+    if not os.path.isfile(fname):
+        return True
+    has_asf_header = False
+    has_copyright = False
+    try:
+        for line in open(fname):
+            if line.find("Licensed to the Apache Software Foundation") != -1:
+                has_asf_header = True
+            if copyright_line(line):
+                has_copyright = True
+            if has_asf_header and has_copyright:
+                return False
+    except UnicodeDecodeError:
+        pass
+    return True
+
+
 def main():
     cmd = ["git", "ls-files"]
     proc = subprocess.Popen(
@@ -153,20 +185,41 @@ def main():
     (out, _) = proc.communicate()
     assert proc.returncode == 0
     res = out.decode("utf-8")
-
+    flist = res.split()
     error_list = []
 
-    for fname in res.split():
+    for fname in flist:
         if not filename_allowed(fname):
             error_list.append(fname)
 
     if error_list:
-        report = "====File type check report=====\n"
+        report = "------File type check report----\n"
         report += "\n".join(error_list)
         report += "\nFound %d files that are now allowed\n" % len(error_list)
         report += ("We do not check in binary files into the repo.\n"
                    "If necessary, please discuss with committers and"
                    "modify tests/lint/check_file_type.py to enable the file you need.\n")
+        sys.stderr.write(report)
+        sys.stderr.flush()
+        sys.exit(-1)
+
+    asf_copyright_list = []
+
+    for fname in res.split():
+        if not check_asf_copyright(fname):
+            asf_copyright_list.append(fname)
+
+    if asf_copyright_list:
+        report = "------File type check report----\n"
+        report += "\n".join(asf_copyright_list) + "\n"
+        report += "------Found %d files that has ASF header with copyright message----\n" % len(asf_copyright_list)
+        report += "--- Files with ASF header do not need Copyright lines.\n"
+        report += "--- Contributors retain copyright to their contribution by default.\n"
+        report += "---\n"
+        report += "--- Use the following steps to remove the copyright lines\n"
+        report += "--- Create file_list.txt in your text editor\n"
+        report += "--- Copy paste the above content in file-list into file_list.txt\n"
+        report += "--- python3 tests/lint/add_asf_header.py file_list.txt\n"
         sys.stderr.write(report)
         sys.stderr.flush()
         sys.exit(-1)

--- a/tests/lint/rat-excludes
+++ b/tests/lint/rat-excludes
@@ -3,25 +3,19 @@
 .github
 
 # Binary or data files
-.*\.css
 .*\.ipynb
-.*\.html
 .*\.pyc
 .*\.so
 .*\.json
 .*\.txt
 .*\.svg
 .*\.lst
-.*\.xcodeproj
-.*\.lproj
-.*\.plist
 .*\.lds
 .*\.in
 .*\.diff
 .*\.edl
 .*\.md5
 .*\.csv
-.*\.mk
 .*\.log
 .*\.interp
 .*\.tokens

--- a/tests/scripts/packages.mk
+++ b/tests/scripts/packages.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # rules for gtest
 .PHONY: iverilog
 

--- a/tests/webgl/test_static_webgl_library.html
+++ b/tests/webgl/test_static_webgl_library.html
@@ -1,4 +1,21 @@
 <html>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
 
 <head>
   <meta charset="UTF-8">

--- a/topi/include/topi/broadcast.h
+++ b/topi/include/topi/broadcast.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Broadcast op constructions
  * \file topi/broadcast.h
  */

--- a/topi/include/topi/contrib/rocblas.h
+++ b/topi/include/topi/contrib/rocblas.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief External function interface to rocBLAS libraries
  * \file tags.h
  */

--- a/topi/include/topi/detail/broadcast.h
+++ b/topi/include/topi/detail/broadcast.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Detail broadcast.
  * \file topi/detail/broadcast.h
  */

--- a/topi/include/topi/detail/pad_utils.h
+++ b/topi/include/topi/detail/pad_utils.h
@@ -18,7 +18,6 @@
  */
 
 /*!
-*  Copyright (c) 2017 by Contributors
 * \file pad_utils.h
 * \brief Padding helpers
 */

--- a/topi/include/topi/detail/ravel_unravel.h
+++ b/topi/include/topi/detail/ravel_unravel.h
@@ -18,7 +18,6 @@
  */
 
 /*!
-*  Copyright (c) 2017 by Contributors
 * \file ravel_unravel.h
 * \brief Index ravel and unraval operations
 */

--- a/topi/include/topi/elemwise.h
+++ b/topi/include/topi/elemwise.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file elemwise.h
  * \brief Elementwise op constructions
  */

--- a/topi/include/topi/nn.h
+++ b/topi/include/topi/nn.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief NN op constructions
  * \file topi/nn.h
  */

--- a/topi/include/topi/nn/batch_matmul.h
+++ b/topi/include/topi/nn/batch_matmul.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \brief Batch matmul op constructions
  * \file nn/batch_matmul.h
  */

--- a/topi/include/topi/nn/bias_add.h
+++ b/topi/include/topi/nn/bias_add.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief bias_add op constructions
  * \file nn/bias_add.h
  */

--- a/topi/include/topi/nn/dense.h
+++ b/topi/include/topi/nn/dense.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Dense op constructions
  * \file nn/dense.h
  */

--- a/topi/include/topi/nn/dilate.h
+++ b/topi/include/topi/nn/dilate.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Dilate op constructions
  * \file nn/dilate.h
  */

--- a/topi/include/topi/nn/flatten.h
+++ b/topi/include/topi/nn/flatten.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Softmax op constructions
  * \file nn/flatten.h
  */

--- a/topi/include/topi/nn/pooling.h
+++ b/topi/include/topi/nn/pooling.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Pooling op constructions
  * \file nn/pooling.h
  */

--- a/topi/include/topi/nn/softmax.h
+++ b/topi/include/topi/nn/softmax.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Softmax op constructions
  * \file nn/softmax.h
  */

--- a/topi/include/topi/nn/upsampling.h
+++ b/topi/include/topi/nn/upsampling.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file topi/nn/upsampling.h
  * \brief upsampling op constructors
  */

--- a/topi/include/topi/reduction.h
+++ b/topi/include/topi/reduction.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file topi/reduction.h
  * \brief Reduction op constructors
  */

--- a/topi/include/topi/tags.h
+++ b/topi/include/topi/tags.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \brief Tag definitions
  * \file tags.h
  */

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file topi/transform.h
  * \brief Transform op constructors
  */

--- a/topi/include/topi/vision/reorg.h
+++ b/topi/include/topi/vision/reorg.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \brief Reorg op constructions
  * \file vision/reorg.h
  */

--- a/topi/src/topi.cc
+++ b/topi/src/topi.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
-*  Copyright (c) 2017 by Contributors
 * \brief Registration of TVM operators and schedules
 * \file topi.cc
 */

--- a/vta/hardware/xilinx/scripts/hsi.tcl
+++ b/vta/hardware/xilinx/scripts/hsi.tcl
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-#  Copyright (c) 2018 by Contributors
 #  file: hsi.tcl
 #  brief: Driver generation script for ARMv7 driver libraries.
 #

--- a/vta/hardware/xilinx/sim/vta_test.cc
+++ b/vta/hardware/xilinx/sim/vta_test.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file vta_test.cpp
  * \brief Simulation tests for the VTA design.
  */

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file driver.h
  * \brief Driver interface that is used by runtime.
  *

--- a/vta/include/vta/runtime.h
+++ b/vta/include/vta/runtime.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file runtime.h
  * \brief VTA runtime library.
  */

--- a/vta/include/vta/sim_tlpp.h
+++ b/vta/include/vta/sim_tlpp.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file sim_tlpp.h
  * \brief TVM VTA multiple thread simulator header file.
  */

--- a/vta/src/de10nano/cma_api.cc
+++ b/vta/src/de10nano/cma_api.cc
@@ -25,7 +25,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file cma_api.cc
  * \brief Application layer implementation for contigous memory allocation.
  */

--- a/vta/src/device_api.cc
+++ b/vta/src/device_api.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file device_api.cc
  * \brief TVM device API for VTA
  */

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file runtime.cc
  * \brief Generic VTA runtime in C++11.
  *

--- a/vta/src/sim/sim_driver.cc
+++ b/vta/src/sim/sim_driver.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file sim_driver.cc
  * \brief VTA driver for simulated backend.
  */

--- a/vta/src/sim/sim_tlpp.cc
+++ b/vta/src/sim/sim_tlpp.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file sim_tlpp.cc
  * \brief simulate core level pipe line parallism logic.
  */

--- a/vta/src/vmem/virtual_memory.cc
+++ b/vta/src/vmem/virtual_memory.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file virtual_memory.cc
  * \brief Thread-safe virtal memory manager
  */

--- a/vta/src/vmem/virtual_memory.h
+++ b/vta/src/vmem/virtual_memory.h
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file virtual_memory.h
  * \brief The virtual memory manager for device simulation
  */

--- a/vta/tests/hardware/metal_test/metal_test.cc
+++ b/vta/tests/hardware/metal_test/metal_test.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2018 by Contributors
  * \file metal_test.cpp
  * \brief Bare-metal test to test driver and VTA design.
  */

--- a/web/example_rpc.html
+++ b/web/example_rpc.html
@@ -1,4 +1,21 @@
 <html>
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
  <head><title> TVM RPC Test Page </title></head>
  <script src="libtvm_web_runtime.js"></script>
  <script src="tvm_runtime.js"></script>

--- a/web/web_runtime.cc
+++ b/web/web_runtime.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2017 by Contributors
  * \file web_runtime.cc
  */
 #include <sys/stat.h>


### PR DESCRIPTION
- Improve the check tool to handle ASF copyright message.
-  Remove unnecessary copyright message as per ASF requirement.