### PR TITLE
Fix compilaton of bfloat16 on Windows

### DIFF
--- a/3rdparty/bfloat16/bfloat16.cc
+++ b/3rdparty/bfloat16/bfloat16.cc
@@ -60,19 +60,23 @@ void BFloat16Add(const uint16_t* a, const uint16_t* b, uint16_t* dst,
 }
 
 extern "C" {
-TVM_DLL TVM_DLL uint16_t FloatToBFloat16_wrapper(float in) {
+TVM_DLL uint16_t FloatToBFloat16_wrapper(float in);
+TVM_DLL float BFloat16ToFloat_wrapper(uint16_t in);
+TVM_DLL uint16_t BFloat16Add_wrapper(uint16_t a, uint16_t b);
+
+uint16_t FloatToBFloat16_wrapper(float in) {
   uint16_t out;
   FloatToBFloat16(&in, &out, 1);
   return out;
 }
 
-TVM_DLL float BFloat16ToFloat_wrapper(uint16_t in) {
+float BFloat16ToFloat_wrapper(uint16_t in) {
   float out;
   BFloat16ToFloat(&in, &out, 1);
   return out;
 }
 
-TVM_DLL uint16_t BFloat16Add_wrapper(uint16_t a, uint16_t b) {
+uint16_t BFloat16Add_wrapper(uint16_t a, uint16_t b) {
   uint16_t out;
   BFloat16Add(&a, &b, &out, 1);
   return out;


### PR DESCRIPTION
`__declspec(dllexport)` should not be part of a function definition. So move `TVM_DLL` macro to function declaration instead.