### PR TITLE
[RUNTIME] Add cudnn conv3d

### DIFF
--- a/python/tvm/contrib/cudnn.py
+++ b/python/tvm/contrib/cudnn.py
@@ -148,31 +148,6 @@ def _get_np_int32_array_handle(arr):
     return ctypes.cast(ptr, ctypes.c_void_p)
 
 
-def conv2d_w_shape(in_channel,
-                   out_channel,
-                   filter_h,
-                   filter_w):
-    """Get weight shape for a 2D convolution
-
-    Parameters
-    ----------
-    in_channel: int
-        input channel
-    out_channel: int
-        output channel
-    filter_h: int
-        filter height
-    filter_w: int
-        filter width
-
-    Returns
-    -------
-    wshape: list
-        weight shape
-    """
-    return [out_channel, in_channel, filter_h, filter_w]
-
-
 def conv2d_output_shape(tensor_format,
                         pad_h,
                         pad_w,
@@ -412,33 +387,6 @@ def conv2d_forward(x,
             outs[0],
             conv_dtype), name="y")
 
-
-def conv3d_w_shape(in_channel,
-                   out_channel,
-                   filter_d,
-                   filter_h,
-                   filter_w):
-    """Get weight shape for a 3D convolution
-
-    Parameters
-    ----------
-    in_channel: int
-        input channel
-    out_channel: int
-        output channel
-    filter_d: int
-        filter depth
-    filter_h: int
-        filter height
-    filter_w: int
-        filter width
-
-    Returns
-    -------
-    wshape: list
-        weight shape
-    """
-    return [out_channel, in_channel, filter_d, filter_h, filter_w]
 
 def conv3d_output_shape(tensor_format,
                         pad_d,

--- a/python/tvm/contrib/cudnn.py
+++ b/python/tvm/contrib/cudnn.py
@@ -21,6 +21,7 @@ import numpy as np
 from .. import api as _api
 from .. import intrin as _intrin
 from .. import get_global_func as _get_global_func
+from ..api import convert
 
 # algos can be read from cudnn.h
 _FWD_ALGOS = [
@@ -360,8 +361,9 @@ def conv_forward(x,
                                   oshape,
                                   x.dtype,
                                   conv_dtype)
-    pad, stride, dilation, _, _ = \
-        _prepare_global_func_params(dims, pad, stride, dilation)
+    #pad = [convert(x) for x in pad]
+    #stride = [convert(x) for x in stride]
+    #dilation = [convert(x) for x in dilation]
 
     return _api.extern(
         oshape, [x, w],
@@ -371,9 +373,9 @@ def conv_forward(x,
             tensor_format,
             algo,
             dims,
-            _get_np_int32_array_handle(pad),
-            _get_np_int32_array_handle(stride),
-            _get_np_int32_array_handle(dilation),
+            convert(pad),
+            convert(stride),
+            convert(dilation),
             ins[0],
             ins[1],
             outs[0],

--- a/python/tvm/contrib/cudnn.py
+++ b/python/tvm/contrib/cudnn.py
@@ -147,19 +147,43 @@ def _get_np_int32_array_handle(arr):
     ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))
     return ctypes.cast(ptr, ctypes.c_void_p)
 
+def _prepare_global_func_params(dims,
+                                pad,
+                                stride,
+                                dilation,
+                                x_shape=None,
+                                w_shape=None):
+    full_dims = dims + 2
+    if x_shape:
+        assert isinstance(x_shape, list)
+        assert len(x_shape) == full_dims
+    if w_shape:
+        assert isinstance(w_shape, list)
+        assert len(w_shape) == full_dims
 
-def conv2d_output_shape(tensor_format,
-                        pad_h,
-                        pad_w,
-                        stride_h,
-                        stride_w,
-                        dilation_h,
-                        dilation_w,
-                        x_shape,
-                        w_shape,
-                        data_dtype,
-                        conv_dtype):
-    """Get output shape of 2D convolution
+    pad = np.full(dims, pad, dtype=np.int32) if isinstance(pad, int) \
+        else np.array(pad, dtype=np.int32)
+    stride = np.full(dims, stride, dtype=np.int32) if isinstance(stride, int) \
+        else np.array(stride, dtype=np.int32)
+    dilation = np.full(dims, dilation, dtype=np.int32) if isinstance(dilation, int) \
+        else np.array(dilation, dtype=np.int32)
+
+    xshape = np.array(x_shape, dtype=np.int32) if x_shape else None
+    wshape = np.array(w_shape, dtype=np.int32) if x_shape else None
+
+    return pad, stride, dilation, xshape, wshape
+
+
+def conv_output_shape(tensor_format,
+                      dims,
+                      pad,
+                      stride,
+                      dilation,
+                      x_shape,
+                      w_shape,
+                      data_dtype,
+                      conv_dtype):
+    """Get output shape of 2D or 3D convolution
 
     Paramters
     ---------
@@ -167,66 +191,55 @@ def conv2d_output_shape(tensor_format,
         0: CUDNN_TENSOR_NCHW
         1: CUDNN_TENSOR_NHWC
         2: CUDNN_TENSOR_NCHW_VECT_C
-    pad_h: int
-        height pad
-    pad_w: int
-        weight pad
-    stride_h: int
-        height stride
-    stride_w: int
-        width stride
-    dilation_h: int
-        height dilation
-    dilation_w: int
-        width dilation
+    dims: int
+        2 for 2D, 3 for 3D
+    pad: int or list
+        padding
+    stride: int or list
+        stride
+    dilation: int or list
+        dilation
     x_shape: list
         input shape
     w_shape: list
         weight shape
+    data_dtype: str
+        data type
+    conv_dtype: str
+        convolution type
 
     Returns
     -------
     oshape: list
         output shape
     """
-    assert isinstance(x_shape, list)
-    assert isinstance(w_shape, list)
-    assert len(x_shape) == 4
-    assert len(w_shape) == 4
+    pad, stride, dilation, xshape, wshape = \
+        _prepare_global_func_params(dims, pad, stride, dilation, x_shape, w_shape)
     oshape = np.zeros((len(x_shape)), dtype=np.int32)
-    func = _get_global_func("tvm.contrib.cudnn.conv2d.output_shape")
+    func = _get_global_func("tvm.contrib.cudnn.conv.output_shape")
     func(tensor_format,
-         pad_h,
-         pad_w,
-         stride_h,
-         stride_w,
-         dilation_h,
-         dilation_w,
-         x_shape[0].value,
-         x_shape[1].value,
-         x_shape[2].value,
-         x_shape[3].value,
-         w_shape[0].value,
-         w_shape[1].value,
-         w_shape[2].value,
-         w_shape[3].value,
+         dims,
+         _get_np_int32_array_handle(pad),
+         _get_np_int32_array_handle(stride),
+         _get_np_int32_array_handle(dilation),
+         _get_np_int32_array_handle(xshape),
+         _get_np_int32_array_handle(wshape),
          _get_np_int32_array_handle(oshape),
          data_dtype,
          conv_dtype)
     return list(oshape)
 
-def conv2d_find_algo(tensor_format,
-                     pad_h,
-                     pad_w,
-                     stride_h,
-                     stride_w,
-                     dilation_h,
-                     dilation_w,
-                     x_shape,
-                     w_shape,
-                     y_shape,
-                     data_dtype,
-                     conv_dtype):
+
+def conv_find_algo(tensor_format,
+                   dims,
+                   pad,
+                   stride,
+                   dilation,
+                   x_shape,
+                   w_shape,
+                   y_shape,
+                   data_dtype,
+                   conv_dtype):
     """Choose the best algo for the given input.
 
     Paramters
@@ -235,18 +248,14 @@ def conv2d_find_algo(tensor_format,
         0: CUDNN_TENSOR_NCHW
         1: CUDNN_TENSOR_NHWC
         2: CUDNN_TENSOR_NCHW_VECT_C
-    pad_h: int
-        height pad
-    pad_w: int
-        weight pad
-    stride_h: int
-        height stride
-    stride_w: int
-        width stride
-    dilation_h: int
-        height dilation
-    dilation_w: int
-        width dilation
+    dims: int
+        2 for 2D, 3 for 3D
+    pad: int or list
+        padding
+    stride: int or list
+        stride
+    dilation: int or list
+        dilation
     x_shape: list
         input shape
     w_shape: list
@@ -263,43 +272,33 @@ def conv2d_find_algo(tensor_format,
     algo: int
         algo chosen by CUDNN
     """
-    func = _get_global_func("tvm.contrib.cudnn.conv2d.find_algo")
+    pad, stride, dilation, xshape, wshape = \
+        _prepare_global_func_params(dims, pad, stride, dilation, x_shape, w_shape)
+    yshape = np.array(y_shape, dtype=np.int32)
+    func = _get_global_func("tvm.contrib.cudnn.conv.find_algo")
     return func(tensor_format,
-                pad_h,
-                pad_w,
-                stride_h,
-                stride_w,
-                dilation_h,
-                dilation_w,
-                x_shape[0].value,
-                x_shape[1].value,
-                x_shape[2].value,
-                x_shape[3].value,
-                w_shape[0].value,
-                w_shape[1].value,
-                w_shape[2].value,
-                w_shape[3].value,
-                int(y_shape[0]),
-                int(y_shape[1]),
-                int(y_shape[2]),
-                int(y_shape[3]),
+                dims,
+                _get_np_int32_array_handle(pad),
+                _get_np_int32_array_handle(stride),
+                _get_np_int32_array_handle(dilation),
+                _get_np_int32_array_handle(xshape),
+                _get_np_int32_array_handle(wshape),
+                _get_np_int32_array_handle(yshape),
                 data_dtype,
                 conv_dtype)
 
 
-def conv2d_forward(x,
-                   w,
-                   stride_h=1,
-                   stride_w=1,
-                   pad_h=0,
-                   pad_w=0,
-                   dilation_h=1,
-                   dilation_w=1,
-                   conv_mode=1,
-                   tensor_format=0,
-                   algo=-1,
-                   conv_dtype=None):
-    """Create an extern op that compute 2D convolution with CuDNN
+def conv_forward(x,
+                 w,
+                 dims,
+                 pad,
+                 stride,
+                 dilation,
+                 conv_mode,
+                 tensor_format,
+                 algo,
+                 conv_dtype):
+    """Create an extern op that compute 2D or 3D convolution with CuDNN
 
     Parameters
     ----------
@@ -307,18 +306,14 @@ def conv2d_forward(x,
         input feature map
     w: Tensor
         convolution weight
-    stride_h: int
-        height stride
-    stride_w: int
-        width stride
-    pad_h: int
-        height pad
-    pad_w: int
-        weight pad
-    dilation_h: int
-        height dilation
-    dilation_w: int
-        width dilation
+    dims: int
+        2 for 2D, 3 for 3D
+    pad: int or list
+        padding
+    stride: int or list
+        stride
+    dilation: int or list
+        dilation
     conv_mode: int
         0: CUDNN_CONVOLUTION
         1: CUDNN_CROSS_CORRELATION
@@ -339,302 +334,15 @@ def conv2d_forward(x,
     """
     conv_dtype = x.dtype if conv_dtype is None else conv_dtype
 
-    oshape = conv2d_output_shape(tensor_format,
-                                 pad_h,
-                                 pad_w,
-                                 stride_h,
-                                 stride_w,
-                                 dilation_h,
-                                 dilation_w,
-                                 list(x.shape),
-                                 list(w.shape),
-                                 x.dtype,
-                                 conv_dtype)
-    if algo == -1:
-        # For now if we try to call `cudnnFindConvolutionForwardAlgorithm` when
-        # using INT8 data type, CuDNN will crash down.
-        # On the other hand, CuDNN only support IMPLICIT_​PRECOMP_GEMM at NHWC format
-        if tensor_format == 1 and conv_dtype == "int32":
-            algo = 1
-        else:
-            algo = conv2d_find_algo(tensor_format,
-                                    pad_h,
-                                    pad_w,
-                                    stride_h,
-                                    stride_w,
-                                    dilation_h,
-                                    dilation_w,
-                                    list(x.shape),
-                                    list(w.shape),
-                                    oshape,
-                                    x.dtype,
-                                    conv_dtype)
-    return _api.extern(
-        oshape, [x, w],
-        lambda ins, outs: _intrin.call_packed(
-            "tvm.contrib.cudnn.conv2d.forward",
-            conv_mode,
-            tensor_format,
-            algo,
-            pad_h,
-            pad_w,
-            stride_h,
-            stride_w,
-            dilation_h,
-            dilation_w,
-            ins[0],
-            ins[1],
-            outs[0],
-            conv_dtype), name="y")
-
-
-def conv3d_output_shape(tensor_format,
-                        pad_d,
-                        pad_h,
-                        pad_w,
-                        stride_d,
-                        stride_h,
-                        stride_w,
-                        dilation_d,
-                        dilation_h,
-                        dilation_w,
-                        x_shape,
-                        w_shape,
-                        data_dtype,
-                        conv_dtype):
-    """Get output shape of 3D convolution
-
-    Paramters
-    ---------
-    tensor_format: int
-        0: CUDNN_TENSOR_NCHW
-        1: CUDNN_TENSOR_NHWC
-        2: CUDNN_TENSOR_NCHW_VECT_C
-    pad_d: int
-        depth pad
-    pad_h: int
-        height pad
-    pad_w: int
-        weight pad
-    stride_d: int
-        depth stride
-    stride_h: int
-        height stride
-    stride_w: int
-        width stride
-    dilation_d: int
-        depth dilation
-    dilation_h: int
-        height dilation
-    dilation_w: int
-        width dilation
-    x_shape: list
-        input shape
-    w_shape: list
-        weight shape
-    data_dtype: str
-        data type
-    conv_dtype: str
-        convolution type
-
-    Returns
-    -------
-    oshape: list
-        output shape
-    """
-    assert isinstance(x_shape, list)
-    assert isinstance(w_shape, list)
-    assert len(x_shape) == 5
-    assert len(w_shape) == 5
-    oshape = np.zeros((len(x_shape)), dtype=np.int32)
-    func = _get_global_func("tvm.contrib.cudnn.conv3d.output_shape")
-    func(tensor_format,
-         pad_d,
-         pad_h,
-         pad_w,
-         stride_d,
-         stride_h,
-         stride_w,
-         dilation_d,
-         dilation_h,
-         dilation_w,
-         x_shape[0].value,
-         x_shape[1].value,
-         x_shape[2].value,
-         x_shape[3].value,
-         x_shape[4].value,
-         w_shape[0].value,
-         w_shape[1].value,
-         w_shape[2].value,
-         w_shape[3].value,
-         w_shape[4].value,
-         _get_np_int32_array_handle(oshape),
-         data_dtype,
-         conv_dtype)
-    return list(oshape)
-
-def conv3d_find_algo(tensor_format,
-                     pad_d,
-                     pad_h,
-                     pad_w,
-                     stride_d,
-                     stride_h,
-                     stride_w,
-                     dilation_d,
-                     dilation_h,
-                     dilation_w,
-                     x_shape,
-                     w_shape,
-                     y_shape,
-                     data_dtype,
-                     conv_dtype):
-    """Choose the best algo for the given input.
-
-    Paramters
-    ---------
-    tensor_format: int
-        0: CUDNN_TENSOR_NCHW
-        1: CUDNN_TENSOR_NHWC
-        2: CUDNN_TENSOR_NCHW_VECT_C
-    pad_d: int
-        depth pad
-    pad_h: int
-        height pad
-    pad_w: int
-        weight pad
-    stride_d: int
-        depth stride
-    stride_h: int
-        height stride
-    stride_w: int
-        width stride
-    dilation_d: int
-        depth dilation
-    dilation_h: int
-        height dilation
-    dilation_w: int
-        width dilation
-    x_shape: list
-        input shape
-    w_shape: list
-        weight shape
-    y_shape: list
-        output shape
-    data_dtype: str
-        data type
-    conv_dtype: str
-        convolution type
-
-    Returns
-    -------
-    algo: int
-        algo chosen by CUDNN
-    """
-    func = _get_global_func("tvm.contrib.cudnn.conv3d.find_algo")
-    return func(tensor_format,
-                pad_d,
-                pad_h,
-                pad_w,
-                stride_d,
-                stride_h,
-                stride_w,
-                dilation_d,
-                dilation_h,
-                dilation_w,
-                x_shape[0].value,
-                x_shape[1].value,
-                x_shape[2].value,
-                x_shape[3].value,
-                x_shape[4].value,
-                w_shape[0].value,
-                w_shape[1].value,
-                w_shape[2].value,
-                w_shape[3].value,
-                w_shape[4].value,
-                int(y_shape[0]),
-                int(y_shape[1]),
-                int(y_shape[2]),
-                int(y_shape[3]),
-                int(y_shape[4]),
-                data_dtype,
-                conv_dtype),
-
-
-def conv3d_forward(x,
-                   w,
-                   stride_d=1,
-                   stride_h=1,
-                   stride_w=1,
-                   pad_d=0,
-                   pad_h=0,
-                   pad_w=0,
-                   dilation_d=1,
-                   dilation_h=1,
-                   dilation_w=1,
-                   conv_mode=1,
-                   tensor_format=0,
-                   algo=-1,
-                   conv_dtype=None):
-    """Create an extern op that compute 2D convolution with CuDNN
-
-    Parameters
-    ----------
-    x: Tensor
-        input feature map
-    w: Tensor
-        convolution weight
-    stride_d: int
-        depth stride
-    stride_h: int
-        height stride
-    stride_w: int
-        width stride
-    pad_d: int
-        depth pad
-    pad_h: int
-        height pad
-    pad_w: int
-        weight pad
-    dilation_d: int
-        depth dilation
-    dilation_h: int
-        height dilation
-    dilation_w: int
-        width dilation
-    conv_mode: int
-        0: CUDNN_CONVOLUTION
-        1: CUDNN_CROSS_CORRELATION
-    tensor_format: int
-        0: CUDNN_TENSOR_NCHW
-        1: CUDNN_TENSOR_NHWC
-        2: CUDNN_TENSOR_NCHW_VECT_C
-    algo: int
-        Forward algorithm, get index from ```algo_to_index``` function
-        if algo == -1, the best algo will be chosen by CUDNN
-    conv_dtype: str
-        convolution type
-
-    Returns
-    -------
-    y: Tensor
-        The result tensor
-    """
-    conv_dtype = x.dtype if conv_dtype is None else conv_dtype
-
-    oshape = conv3d_output_shape(tensor_format,
-                                 pad_d,
-                                 pad_h,
-                                 pad_w,
-                                 stride_d,
-                                 stride_h,
-                                 stride_w,
-                                 dilation_d,
-                                 dilation_h,
-                                 dilation_w,
-                                 list(x.shape),
-                                 list(w.shape),
-                                 x.dtype,
-                                 conv_dtype)
+    oshape = conv_output_shape(tensor_format,
+                               dims,
+                               pad,
+                               stride,
+                               dilation,
+                               list(x.shape),
+                               list(w.shape),
+                               x.dtype,
+                               conv_dtype)
     if algo == -1:
         # For now if we try to call `cudnnFindConvolutionForwardAlgorithm` when
         # using INT8 data type, CuDNN will crash down.
@@ -642,40 +350,30 @@ def conv3d_forward(x,
         if tensor_format == 1 and conv_dtype == "int32":
             algo = 1
         else:
-            algo = conv3d_find_algo(tensor_format,
-                                    pad_d,
-                                    pad_h,
-                                    pad_w,
-                                    stride_d,
-                                    stride_h,
-                                    stride_w,
-                                    dilation_d,
-                                    dilation_h,
-                                    dilation_w,
-                                    list(x.shape),
-                                    list(w.shape),
-                                    oshape,
-                                    x.dtype,
-                                    conv_dtype)
-    if isinstance(algo, tuple):
-        algo = algo[0]
+            algo = conv_find_algo(tensor_format,
+                                  dims,
+                                  pad,
+                                  stride,
+                                  dilation,
+                                  list(x.shape),
+                                  list(w.shape),
+                                  oshape,
+                                  x.dtype,
+                                  conv_dtype)
+    pad, stride, dilation, _, _ = \
+        _prepare_global_func_params(dims, pad, stride, dilation)
 
     return _api.extern(
         oshape, [x, w],
         lambda ins, outs: _intrin.call_packed(
-            "tvm.contrib.cudnn.conv3d.forward",
+            "tvm.contrib.cudnn.conv.forward",
             conv_mode,
             tensor_format,
             algo,
-            pad_d,
-            pad_h,
-            pad_w,
-            stride_d,
-            stride_h,
-            stride_w,
-            dilation_d,
-            dilation_h,
-            dilation_w,
+            dims,
+            _get_np_int32_array_handle(pad),
+            _get_np_int32_array_handle(stride),
+            _get_np_int32_array_handle(dilation),
             ins[0],
             ins[1],
             outs[0],

--- a/src/runtime/contrib/cudnn/conv_forward.cc
+++ b/src/runtime/contrib/cudnn/conv_forward.cc
@@ -73,66 +73,43 @@ void ConvolutionForward(
                                                dilation_v[1],
                                                entry_ptr->conv_entry.mode,
                                                entry_ptr->conv_entry.data_type));
-
-    int wn, wc, wh, ww;
-    int xn, xc, xh, xw;
-    int yn, yc, yh, yw;
+    int ni, ci, hi, wi;
     if (entry_ptr->conv_entry.tensor_format ==  CUDNN_TENSOR_NHWC) {
-      wn = static_cast<int>(w->shape[0]);
-      wc = static_cast<int>(w->shape[3]);
-      wh = static_cast<int>(w->shape[1]);
-      ww = static_cast<int>(w->shape[2]);
-
-      xn = static_cast<int>(x->shape[0]);
-      xc = static_cast<int>(x->shape[3]);
-      xh = static_cast<int>(x->shape[1]);
-      xw = static_cast<int>(x->shape[2]);
-
-      yn = static_cast<int>(y->shape[0]);
-      yc = static_cast<int>(y->shape[3]);
-      yh = static_cast<int>(y->shape[1]);
-      yw = static_cast<int>(y->shape[2]);
+      ni = 0;
+      ci = 3;
+      hi = 1;
+      wi = 2;
     } else {
-      wn = static_cast<int>(w->shape[0]);
-      wc = static_cast<int>(w->shape[1]);
-      wh = static_cast<int>(w->shape[2]);
-      ww = static_cast<int>(w->shape[3]);
-
-      xn = static_cast<int>(x->shape[0]);
-      xc = static_cast<int>(x->shape[1]);
-      xh = static_cast<int>(x->shape[2]);
-      xw = static_cast<int>(x->shape[3]);
-
-      yn = static_cast<int>(y->shape[0]);
-      yc = static_cast<int>(y->shape[1]);
-      yh = static_cast<int>(y->shape[2]);
-      yw = static_cast<int>(y->shape[3]);
+      ni = 0;
+      ci = 1;
+      hi = 2;
+      wi = 3;
     }
 
     // Set Filter
     CUDNN_CALL(cudnnSetFilter4dDescriptor(entry_ptr->conv_entry.filter_desc,
                                           data_type,
                                           entry_ptr->conv_entry.tensor_format,
-                                          wn,
-                                          wc,
-                                          wh,
-                                          ww));
+                                          static_cast<int>(w->shape[ni]),
+                                          static_cast<int>(w->shape[ci]),
+                                          static_cast<int>(w->shape[hi]),
+                                          static_cast<int>(w->shape[wi])));
     // Set Input
     CUDNN_CALL(cudnnSetTensor4dDescriptor(entry_ptr->conv_entry.input_desc,
                                           entry_ptr->conv_entry.tensor_format,
                                           data_type,
-                                          xn,
-                                          xc,
-                                          xh,
-                                          xw));
+                                          static_cast<int>(x->shape[ni]),
+                                          static_cast<int>(x->shape[ci]),
+                                          static_cast<int>(x->shape[hi]),
+                                          static_cast<int>(x->shape[wi])));
     // Set Output
     CUDNN_CALL(cudnnSetTensor4dDescriptor(entry_ptr->conv_entry.output_desc,
                                           entry_ptr->conv_entry.tensor_format,
                                           data_type,
-                                          yn,
-                                          yc,
-                                          yh,
-                                          yw));
+                                          static_cast<int>(y->shape[ni]),
+                                          static_cast<int>(y->shape[ci]),
+                                          static_cast<int>(y->shape[hi]),
+                                          static_cast<int>(y->shape[wi])));
   } else {
     CUDNN_CALL(cudnnSetConvolutionNdDescriptor(entry_ptr->conv_entry.conv_desc,
                                                dims,
@@ -142,35 +119,35 @@ void ConvolutionForward(
                                                entry_ptr->conv_entry.mode,
                                                entry_ptr->conv_entry.data_type));
 
-  // Set Filter
-  for (int i = 0; i < full_dims; i++) {
-    dim_v[i] = static_cast<int>(w->shape[i]);
-  }
-  CUDNN_CALL(cudnnSetFilterNdDescriptor(entry_ptr->conv_entry.filter_desc,
-                                        data_type,
-                                        entry_ptr->conv_entry.tensor_format,
-                                        full_dims,
-                                        dim_v.data()));
-  // Set Input
-  for (int i = 0; i < full_dims; i++) {
-    dim_v[i] = static_cast<int>(x->shape[i]);
-  }
-  GetCudnnStride(full_dims, dim_v.data(), tensor_stride_v.data());
-  CUDNN_CALL(cudnnSetTensorNdDescriptor(entry_ptr->conv_entry.input_desc,
-                                        data_type,
-                                        full_dims,
-                                        dim_v.data(),
-                                        tensor_stride_v.data()));
-  // Set Output
-  for (int i = 0; i < full_dims; i++) {
-    dim_v[i] = static_cast<int>(y->shape[i]);
-  }
-  GetCudnnStride(full_dims, dim_v.data(), tensor_stride_v.data());
-  CUDNN_CALL(cudnnSetTensorNdDescriptor(entry_ptr->conv_entry.output_desc,
-                                        data_type,
-                                        full_dims,
-                                        dim_v.data(),
-                                        tensor_stride_v.data()));
+    // Set Filter
+    for (int i = 0; i < full_dims; i++) {
+      dim_v[i] = static_cast<int>(w->shape[i]);
+    }
+    CUDNN_CALL(cudnnSetFilterNdDescriptor(entry_ptr->conv_entry.filter_desc,
+                                          data_type,
+                                          entry_ptr->conv_entry.tensor_format,
+                                          full_dims,
+                                          dim_v.data()));
+    // Set Input
+    for (int i = 0; i < full_dims; i++) {
+      dim_v[i] = static_cast<int>(x->shape[i]);
+    }
+    GetCudnnStride(full_dims, dim_v.data(), tensor_stride_v.data());
+    CUDNN_CALL(cudnnSetTensorNdDescriptor(entry_ptr->conv_entry.input_desc,
+                                          data_type,
+                                          full_dims,
+                                          dim_v.data(),
+                                          tensor_stride_v.data()));
+    // Set Output
+    for (int i = 0; i < full_dims; i++) {
+      dim_v[i] = static_cast<int>(y->shape[i]);
+    }
+    GetCudnnStride(full_dims, dim_v.data(), tensor_stride_v.data());
+    CUDNN_CALL(cudnnSetTensorNdDescriptor(entry_ptr->conv_entry.output_desc,
+                                          data_type,
+                                          full_dims,
+                                          dim_v.data(),
+                                          tensor_stride_v.data()));
   }
 
   if (cudnnGetVersion() > 7000) {

--- a/src/runtime/contrib/cudnn/conv_forward.cc
+++ b/src/runtime/contrib/cudnn/conv_forward.cc
@@ -22,6 +22,8 @@
  */
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/util.h>
+#include <tvm/packed_func_ext.h>
+#include <tvm/ir.h>
 #include <tvm/runtime/device_api.h>
 #include "cudnn_utils.h"
 
@@ -29,6 +31,7 @@ namespace tvm {
 namespace contrib {
 
 using namespace runtime;
+using tvm::ir::IntImm;
 
 void ConvolutionForward(
   int mode,
@@ -377,8 +380,24 @@ TVM_REGISTER_GLOBAL("tvm.contrib.cudnn.conv.forward")
   int algo = args[2];
   int dims = args[3];
 
+  Array<Expr> pads =  args[4];
+  Array<Expr> strides =  args[5];
+  Array<Expr> dilations =  args[6];
+
+
   std::vector<int> pad_v(dims), stride_v(dims), dilation_v(dims);
-  PrepareCommonArgs(args, 4, dims, &pad_v, &stride_v, &dilation_v);
+  for (auto &pad : pads) {
+    int i = 0;
+    pad_v[i++] = pad.as<IntImm>()->value;
+  }
+  for (auto &stride : strides) {
+    int i = 0;
+    pad_v[i++] = strides.as<IntImm>()->value;
+  }
+  for (auto &dilation : dilations) {
+    int i = 0;
+    pad_v[i++] = dilations.as<IntImm>()->value;
+  }
 
   DLTensor* x = args[7];
   DLTensor* w = args[8];

--- a/src/runtime/contrib/cudnn/conv_forward.cc
+++ b/src/runtime/contrib/cudnn/conv_forward.cc
@@ -37,9 +37,9 @@ void ConvolutionForward(
   int mode,
   int format,
   int algo,
-  const std::vector<int> pad,
-  const std::vector<int> stride,
-  const std::vector<int> dilation,
+  const std::vector<int>& pad,
+  const std::vector<int>& stride,
+  const std::vector<int>& dilation,
   DLTensor* x,
   DLTensor* w,
   DLTensor* y,
@@ -185,11 +185,11 @@ void ConvolutionForward(
 
 void OutputShape(
   int format,
-  const std::vector<int> pad,
-  const std::vector<int> stride,
-  const std::vector<int> dilation,
-  const std::vector<int> x_dim,
-  const std::vector<int> w_dim,
+  const std::vector<int>& pad,
+  const std::vector<int>& stride,
+  const std::vector<int>& dilation,
+  const std::vector<int>& x_dim,
+  const std::vector<int>& w_dim,
   void *out_shape,
   const std::string& data_dtype,
   const std::string& conv_dtype) {
@@ -267,12 +267,12 @@ void OutputShape(
 
 void FindAlgo(
   int format,
-  const std::vector<int> pad,
-  const std::vector<int> stride,
-  const std::vector<int> dilation,
-  const std::vector<int> x_dim,
-  const std::vector<int> w_dim,
-  const std::vector<int> y_dim,
+  const std::vector<int>& pad,
+  const std::vector<int>& stride,
+  const std::vector<int>& dilation,
+  const std::vector<int>& x_dim,
+  const std::vector<int>& w_dim,
+  const std::vector<int>& y_dim,
   const std::string& data_dtype,
   const std::string& conv_dtype,
   TVMRetValue *ret) {

--- a/src/runtime/contrib/cudnn/conv_forward.cc
+++ b/src/runtime/contrib/cudnn/conv_forward.cc
@@ -22,8 +22,6 @@
  */
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/util.h>
-#include <tvm/packed_func_ext.h>
-#include <tvm/ir.h>
 #include <tvm/runtime/device_api.h>
 #include "cudnn_utils.h"
 
@@ -31,7 +29,6 @@ namespace tvm {
 namespace contrib {
 
 using namespace runtime;
-using tvm::ir::IntImm;
 
 void ConvolutionForward(
   int mode,

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -27,7 +27,6 @@
 #include <dmlc/logging.h>
 #include <cudnn.h>
 #include <tvm/runtime/device_api.h>
-#include <vector>
 #include "../../cuda/cuda_common.h"
 
 

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -56,11 +56,11 @@ inline void GetStride(int nbdim, const int *dims, int *strides) {
 }
 
 inline void GetCudnnStride(int nbdim,
-                           const std::vector<int>& dims,
-                           std::vector<int>* strides) {
+                           const int* dims,
+                           int* strides) {
   int mul = 1;
   for (int i = nbdim - 1; i >=0; --i) {
-    (*strides)[i] = mul;
+    strides[i] = mul;
     mul *= dims[i];
   }
 }

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -54,6 +54,13 @@ inline void GetStride(int nbdim, const int *dims, int *strides) {
   }
 }
 
+inline void GetCudnnStride(int nbdim, const int *dims, int *strides) {
+  int mul = 1;
+  for (int i = nbdim - 1; i >=0; --i) {
+    strides[i] = mul;
+    mul *= dims[i];
+  }
+}
 
 struct ConvEntry {
   cudnnConvolutionDescriptor_t conv_desc;

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -27,6 +27,7 @@
 #include <dmlc/logging.h>
 #include <cudnn.h>
 #include <tvm/runtime/device_api.h>
+#include <vector>
 #include "../../cuda/cuda_common.h"
 
 
@@ -54,10 +55,12 @@ inline void GetStride(int nbdim, const int *dims, int *strides) {
   }
 }
 
-inline void GetCudnnStride(int nbdim, const int *dims, int *strides) {
+inline void GetCudnnStride(int nbdim,
+                           const std::vector<int>& dims,
+                           std::vector<int>* strides) {
   int mul = 1;
   for (int i = nbdim - 1; i >=0; --i) {
-    strides[i] = mul;
+    (*strides)[i] = mul;
     mul *= dims[i];
   }
 }

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -43,10 +43,7 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0):
         return
     if tensor_format == 0:
         xshape = [batch, in_channel, height, weight]
-        wshape = cudnn.conv2d_w_shape(in_channel,
-                                      out_channel,
-                                      filter_h,
-                                      filter_w)
+        wshape = [out_channel, in_channel, filter_h, filter_w]
     else:
         xshape = [batch, height, weight, in_channel]
         wshape = [out_channel, filter_h, filter_w, in_channel]
@@ -92,7 +89,7 @@ def test_conv2d():
     verify_conv2d("float32", "float32", tensor_format=0)
     verify_conv2d("float16", "float32", tensor_format=1)
     #Not pass accuracy test, need check
-    #verify_conv2d("float16", "float16", tensor_format=0) 
+    #verify_conv2d("float16", "float16", tensor_format=0)
     verify_conv2d("int8", "int32", tensor_format=1)
 
 
@@ -124,12 +121,7 @@ def verify_conv3d(data_dtype, conv_dtype, tensor_format=0):
         return
 
     xshape = [batch, in_channel, depth, height, weight]
-    wshape = cudnn.conv3d_w_shape(in_channel,
-                          out_channel,
-                          filter_d,
-                          filter_h,
-                          filter_w)
-
+    wshape = [out_channel, in_channel, filter_d, filter_h, filter_w]
 
     X = tvm.placeholder(xshape, name='X', dtype=data_dtype)
     W = tvm.placeholder(wshape, name='W', dtype=data_dtype)

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -38,7 +38,7 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0):
     if not tvm.module.enabled("cuda"):
         print("skip because cuda is not enabled...")
         return
-    if not tvm.get_global_func("tvm.contrib.cudnn.conv2d.output_shape", True):
+    if not tvm.get_global_func("tvm.contrib.cudnn.conv.output_shape", True):
         print("skip because cudnn is not enabled...")
         return
     if tensor_format == 0:
@@ -50,18 +50,16 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0):
 
     X = tvm.placeholder(xshape, name='X', dtype=data_dtype)
     W = tvm.placeholder(wshape, name='W', dtype=data_dtype)
-    Y = cudnn.conv2d_forward(X,
-                             W,
-                             stride_h,
-                             stride_w,
-                             pad_h,
-                             pad_w,
-                             dilation_h,
-                             dilation_w,
-                             conv_mode=1,
-                             tensor_format=tensor_format,
-                             conv_dtype=conv_dtype,
-                             algo=-1)
+    Y = cudnn.conv_forward(X,
+                           W,
+                           2,
+                           [pad_h, pad_w],
+                           [stride_h, stride_w],
+                           [dilation_h, dilation_w],
+                           conv_mode=1,
+                           tensor_format=tensor_format,
+                           conv_dtype=conv_dtype,
+                           algo=-1)
     yshape = [x.value for x in Y.shape]
     s = tvm.create_schedule(Y.op)
 
@@ -116,7 +114,7 @@ def verify_conv3d(data_dtype, conv_dtype, tensor_format=0):
     if not tvm.module.enabled("cuda"):
         print("skip because cuda is not enabled...")
         return
-    if not tvm.get_global_func("tvm.contrib.cudnn.conv3d.output_shape", True):
+    if not tvm.get_global_func("tvm.contrib.cudnn.conv.output_shape", True):
         print("skip because cudnn is not enabled...")
         return
 
@@ -125,21 +123,16 @@ def verify_conv3d(data_dtype, conv_dtype, tensor_format=0):
 
     X = tvm.placeholder(xshape, name='X', dtype=data_dtype)
     W = tvm.placeholder(wshape, name='W', dtype=data_dtype)
-    Y = cudnn.conv3d_forward(X,
-                             W,
-                             stride_d,
-                             stride_h,
-                             stride_w,
-                             pad_d,
-                             pad_h,
-                             pad_w,
-                             dilation_d,
-                             dilation_h,
-                             dilation_w,
-                             conv_mode=1,
-                             tensor_format=tensor_format,
-                             algo=-1,
-                             conv_dtype=conv_dtype)
+    Y = cudnn.conv_forward(X,
+                           W,
+                           3,
+                           [pad_d, pad_h, pad_w],
+                           [stride_d, stride_h, stride_w],
+                           [dilation_d, dilation_h, dilation_w],
+                           conv_mode=1,
+                           tensor_format=tensor_format,
+                           algo=-1,
+                           conv_dtype=conv_dtype)
     yshape = [x.value for x in Y.shape]
     s = tvm.create_schedule(Y.op)
 

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -52,7 +52,6 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0):
     W = tvm.placeholder(wshape, name='W', dtype=data_dtype)
     Y = cudnn.conv_forward(X,
                            W,
-                           2,
                            [pad_h, pad_w],
                            [stride_h, stride_w],
                            [dilation_h, dilation_w],
@@ -125,7 +124,6 @@ def verify_conv3d(data_dtype, conv_dtype, tensor_format=0):
     W = tvm.placeholder(wshape, name='W', dtype=data_dtype)
     Y = cudnn.conv_forward(X,
                            W,
-                           3,
                            [pad_d, pad_h, pad_w],
                            [stride_d, stride_h, stride_w],
                            [dilation_d, dilation_h, dilation_w],

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -98,7 +98,6 @@ def conv2d_cuda(cfg, data, kernel, strides, padding, dilation, layout='NCHW', ou
 
         return cudnn.conv_forward(data,
                                   kernel,
-                                  2,
                                   [pad_h, pad_w],
                                   [stride_h, stride_w],
                                   [dilation_h, dilation_w],

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -96,18 +96,16 @@ def conv2d_cuda(cfg, data, kernel, strides, padding, dilation, layout='NCHW', ou
         else:
             dtype = data.dtype
 
-        return cudnn.conv2d_forward(data,
-                                    kernel,
-                                    stride_h,
-                                    stride_w,
-                                    pad_h,
-                                    pad_w,
-                                    dilation_h,
-                                    dilation_w,
-                                    conv_mode=1,
-                                    tensor_format=tensor_format,
-                                    algo=-1,         # let CUDNN choose the best algo
-                                    conv_dtype=dtype)
+        return cudnn.conv_forward(data,
+                                  kernel,
+                                  2,
+                                  [pad_h, pad_w],
+                                  [stride_h, stride_w],
+                                  [dilation_h, dilation_w],
+                                  conv_mode=1,
+                                  tensor_format=tensor_format,
+                                  algo=-1,         # let CUDNN choose the best algo
+                                  conv_dtype=dtype)
 
     if cfg.template_key == 'winograd':
         return winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dtype,

--- a/topi/python/topi/testing/__init__.py
+++ b/topi/python/topi/testing/__init__.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import as _abs
 from .conv2d_hwcn_python import conv2d_hwcn_python
 from .conv2d_nchw_python import conv2d_nchw_python
 from .conv2d_nhwc_python import conv2d_nhwc_python
+from .conv3d_ncdhw_python import conv3d_ncdhw_python
 from .conv2d_transpose_python import conv2d_transpose_nchw_python, conv2d_transpose_nhwc_python
 from .deformable_conv2d_nchw_python import deformable_conv2d_nchw_python
 from .depthwise_conv2d_python import depthwise_conv2d_python_nchw, depthwise_conv2d_python_nhwc

--- a/topi/python/topi/testing/conv3d_ncdhw_python.py
+++ b/topi/python/topi/testing/conv3d_ncdhw_python.py
@@ -15,33 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=invalid-name, line-too-long, unused-variable, too-many-locals, too-many-branches
-"""Convolution in python"""
+"""Convolution 3D in python"""
 import numpy as np
 import scipy.signal
 
 
 def _conv3d_ncdhw_python(a_np, w_np, stride, padding):
-    """Convolution operator in NCDHW layout.
-
-    Parameters
-    ----------
-    a_np : numpy.ndarray
-        5-D with shape [batch, in_channel, in_depth, in_height, in_width]
-
-    w_np : numpy.ndarray
-        5-D with shape [num_filter, in_channel, filter_depth, filter_height, filter_width]
-
-    stride : int or a list/tuple of three ints
-        Stride size, or [stride_depth, stride_height, stride_width]
-
-    padding : int or str or a list/tuple of three ints
-        Padding size, or ['VALID', 'SAME'], or [pad_depth, pad_height, pad_width]
-
-    Returns
-    -------
-    b_np : np.ndarray
-        5-D with shape [batch, out_channel, out_depth, out_height, out_width]
-    """
     batch, in_channel, in_depth, in_height, in_width = a_np.shape
     num_filter, _, kernel_d, kernel_h, kernel_w = w_np.shape
     if isinstance(stride, int):
@@ -96,7 +75,7 @@ def _conv3d_ncdhw_python(a_np, w_np, stride, padding):
 
 
 def conv3d_ncdhw_python(a_np, w_np, stride, padding, groups=1):
-    """Convolution operator in NCHW layout.
+    """Convolution operator in NCDHW layout.
 
     Parameters
     ----------

--- a/topi/python/topi/testing/conv3d_ncdhw_python.py
+++ b/topi/python/topi/testing/conv3d_ncdhw_python.py
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, line-too-long, unused-variable, too-many-locals, too-many-branches
+"""Convolution in python"""
+import numpy as np
+import scipy.signal
+
+
+def _conv3d_ncdhw_python(a_np, w_np, stride, padding):
+    """Convolution operator in NCDHW layout.
+
+    Parameters
+    ----------
+    a_np : numpy.ndarray
+        5-D with shape [batch, in_channel, in_depth, in_height, in_width]
+
+    w_np : numpy.ndarray
+        5-D with shape [num_filter, in_channel, filter_depth, filter_height, filter_width]
+
+    stride : int or a list/tuple of three ints
+        Stride size, or [stride_depth, stride_height, stride_width]
+
+    padding : int or str or a list/tuple of three ints
+        Padding size, or ['VALID', 'SAME'], or [pad_depth, pad_height, pad_width]
+
+    Returns
+    -------
+    b_np : np.ndarray
+        5-D with shape [batch, out_channel, out_depth, out_height, out_width]
+    """
+    batch, in_channel, in_depth, in_height, in_width = a_np.shape
+    num_filter, _, kernel_d, kernel_h, kernel_w = w_np.shape
+    if isinstance(stride, int):
+        stride_d = stride_h = stride_w = stride
+    else:
+        stride_d, stride_h, stride_w = stride
+    if isinstance(padding, int):
+        pad_d = pad_h = pad_w = padding * 2
+    elif isinstance(padding, (list, tuple)):
+        pad_d, pad_h, pad_w = padding[0] * 2, padding[1] * 2, padding[2] * 2
+    else:
+        pad_d = 0 if padding == 'VALID' else kernel_d - 1
+        pad_h = 0 if padding == 'VALID' else kernel_h - 1
+        pad_w = 0 if padding == 'VALID' else kernel_w - 1
+    pad_front = int(np.ceil(float(pad_d) / 2))
+    pad_back = pad_d - pad_front
+    pad_top = int(np.ceil(float(pad_h) / 2))
+    pad_bottom = pad_h - pad_top
+    pad_left = int(np.ceil(float(pad_w) / 2))
+    pad_right = pad_w - pad_left
+    # compute the output shape
+    out_channel = num_filter
+    out_depth = (in_depth - kernel_d + pad_d) // stride_d + 1
+    out_height = (in_height - kernel_h + pad_h) // stride_h + 1
+    out_width = (in_width - kernel_w + pad_w) // stride_w + 1
+    b_np = np.zeros((batch, out_channel, out_depth, out_height, out_width))
+    # computation
+    for n in range(batch):
+        for f in range(out_channel):
+            for c in range(in_channel):
+                if pad_d > 0 or pad_h > 0 or pad_w > 0:
+                    apad = np.zeros((in_depth + pad_d, in_height + pad_h, in_width + pad_w))
+                    if pad_d == 0 and pad_h == 0:
+                        apad[:, :, pad_left:-pad_right] = a_np[n, c]
+                    elif pad_d == 0 and pad_w == 0:
+                        apad[:, pad_top:-pad_bottom, :] = a_np[n, c]
+                    elif pad_d == 0 and pad_h != 0 and pad_w != 0:
+                        apad[:, pad_top:-pad_bottom, pad_left:-pad_right] = a_np[n, c]
+                    elif pad_d != 0 and pad_h == 0:
+                        apad[pad_front:-pad_back, :, pad_left:-pad_right] = a_np[n, c]
+                    elif pad_d != 0 and pad_w == 0:
+                        apad[pad_front:-pad_back, pad_top:-pad_bottom, :] = a_np[n, c]
+                    elif pad_d != 0 and pad_h != 0 and pad_w != 0:
+                        apad[pad_front:-pad_back, pad_top:-pad_bottom, pad_left:-pad_right] = a_np[n, c]
+
+                else:
+                    apad = a_np[n, c]
+                out = scipy.signal.convolve(
+                    apad, np.flip(w_np[f, c]), mode='valid')
+                b_np[n, f] += out[::stride_d, ::stride_h, ::stride_w]
+    return b_np
+
+
+def conv3d_ncdhw_python(a_np, w_np, stride, padding, groups=1):
+    """Convolution operator in NCHW layout.
+
+    Parameters
+    ----------
+    a_np : numpy.ndarray
+        5-D with shape [batch, in_channel, in_depth, in_height, in_width]
+
+    w_np : numpy.ndarray
+        5-D with shape [num_filter, in_channel, filter_depth, filter_height, filter_width]
+
+    stride : int or a list/tuple of three ints
+        Stride size, or [stride_depth, stride_height, stride_width]
+
+    padding : int or str or a list/tuple of three ints
+        Padding size, or ['VALID', 'SAME'], or [pad_depth, pad_height, pad_width]
+    groups : int
+        Number of groups
+
+    Returns
+    -------
+    b_np : np.ndarray
+        5-D with shape [batch, out_channel, out_depth, out_height, out_width]
+    """
+    a_slices = np.array_split(a_np, groups, axis=1)
+    w_slices = np.array_split(w_np, groups, axis=0)
+    b_slices = [_conv3d_ncdhw_python(a_slice, w_slice, stride, padding)
+                for a_slice, w_slice in zip(a_slices, w_slices)]
+    b_np = np.concatenate(b_slices, axis=1)
+    return b_np


### PR DESCRIPTION
This PR is to add cudnn conv3d in runtime module. And it also modified the existing conv2d to have them use a unified manner to be implemented. This could be the prerequisite of 3D convolution( #4400 ) implementation. 

@masahi 
