### PR TITLE
[VTA][HotFix] Relay->VTA quantization fix

### DIFF
--- a/vta/scripts/tune_resnet.py
+++ b/vta/scripts/tune_resnet.py
@@ -125,9 +125,11 @@ def compile_network(opt, env, target):
     dtype_dict.update({k: str(v.dtype) for k, v in params.items()})
 
     # Perform quantization in Relay
-    with relay.quantize.qconfig(global_scale=8.0,
-                                skip_conv_layers=[0]):
-        relay_prog = relay.quantize.quantize(mod["main"], params=params)
+    # Note: We set opt_level to 3 in order to fold batch norm
+    with relay.build_config(opt_level=3):
+        with relay.quantize.qconfig(global_scale=8.0,
+                                    skip_conv_layers=[0]):
+            relay_prog = relay.quantize.quantize(mod["main"], params=params)
 
     # Perform graph packing and constant folding for VTA target
     if target.device_name == "vta":

--- a/vta/tutorials/autotvm/tune_relay_vta.py
+++ b/vta/tutorials/autotvm/tune_relay_vta.py
@@ -91,13 +91,13 @@ def compile_network(env, target, model, start_pack, stop_pack):
     # Perform quantization in Relay
     with relay.quantize.qconfig(global_scale=8.0,
                                 skip_conv_layers=[0]):
-        relay_prog = relay.quantize.quantize(mod["main"], params=params)
+        mod = relay.quantize.quantize(mod, params=params)
 
     # Perform graph packing and constant folding for VTA target
     if target.device_name == "vta":
         assert env.BLOCK_IN == env.BLOCK_OUT
         relay_prog = graph_pack(
-            relay_prog,
+            mod["main"],
             env.BATCH,
             env.BLOCK_OUT,
             env.WGT_WIDTH,

--- a/vta/tutorials/autotvm/tune_relay_vta.py
+++ b/vta/tutorials/autotvm/tune_relay_vta.py
@@ -89,9 +89,11 @@ def compile_network(env, target, model, start_pack, stop_pack):
     dtype_dict.update({k: str(v.dtype) for k, v in params.items()})
 
     # Perform quantization in Relay
-    with relay.quantize.qconfig(global_scale=8.0,
-                                skip_conv_layers=[0]):
-        mod = relay.quantize.quantize(mod, params=params)
+    # Note: We set opt_level to 3 in order to fold batch norm
+    with relay.build_config(opt_level=3):
+        with relay.quantize.qconfig(global_scale=8.0,
+                                    skip_conv_layers=[0]):
+            mod = relay.quantize.quantize(mod, params=params)
 
     # Perform graph packing and constant folding for VTA target
     if target.device_name == "vta":

--- a/vta/tutorials/frontend/deploy_vision_on_vta.py
+++ b/vta/tutorials/frontend/deploy_vision_on_vta.py
@@ -168,18 +168,20 @@ with autotvm.tophub.context(target):
 
     if target.device_name == "vta":
         # Perform quantization in Relay
-        with relay.quantize.qconfig(global_scale=8.0,
-                                    skip_conv_layers=[0]):
-            mod = relay.quantize.quantize(mod, params=params)
-        # Perform graph packing and constant folding for VTA target
-        assert env.BLOCK_IN == env.BLOCK_OUT
-        relay_prog = graph_pack(
-            mod["main"],
-            env.BATCH,
-            env.BLOCK_OUT,
-            env.WGT_WIDTH,
-            start_name=pack_dict[model][0],
-            stop_name=pack_dict[model][1])
+        # Note: We set opt_level to 3 in order to fold batch norm
+        with relay.build_config(opt_level=3):
+            with relay.quantize.qconfig(global_scale=8.0,
+                                        skip_conv_layers=[0]):
+                mod = relay.quantize.quantize(mod, params=params)
+            # Perform graph packing and constant folding for VTA target
+            assert env.BLOCK_IN == env.BLOCK_OUT
+            relay_prog = graph_pack(
+                mod["main"],
+                env.BATCH,
+                env.BLOCK_OUT,
+                env.WGT_WIDTH,
+                start_name=pack_dict[model][0],
+                stop_name=pack_dict[model][1])
     else:
         relay_prog = mod["main"]
 

--- a/vta/tutorials/frontend/deploy_vision_on_vta.py
+++ b/vta/tutorials/frontend/deploy_vision_on_vta.py
@@ -170,11 +170,11 @@ with autotvm.tophub.context(target):
         # Perform quantization in Relay
         with relay.quantize.qconfig(global_scale=8.0,
                                     skip_conv_layers=[0]):
-            relay_prog = relay.quantize.quantize(mod["main"], params=params)
+            mod = relay.quantize.quantize(mod, params=params)
         # Perform graph packing and constant folding for VTA target
         assert env.BLOCK_IN == env.BLOCK_OUT
         relay_prog = graph_pack(
-            relay_prog,
+            mod["main"],
             env.BATCH,
             env.BLOCK_OUT,
             env.WGT_WIDTH,


### PR DESCRIPTION
This addresses a compilation bug introduced by: https://github.com/apache/incubator-tvm/pull/4295

Other than interface changes to quantization pass (graph vs. module) it appears that this has broken quantization pass for VTA by inserting multiplication at the end of the layer when multiplication is not supported by VTA (and instead must rely on shift and add).

Investigation in progress.

@vinx13 @ZihengJiang 