### PR TITLE
[Chisel][VTA] Fix multiple transfer issue in LoadUop module

### DIFF
--- a/vta/hardware/chisel/src/main/scala/core/LoadUop.scala
+++ b/vta/hardware/chisel/src/main/scala/core/LoadUop.scala
@@ -173,7 +173,7 @@ class LoadUop(debug: Boolean = false)(implicit p: Parameters) extends Module {
         }
       }
       .elsewhen(io.vme_rd.data.fire()) {
-        when(xcnt === xlen - 1.U) {
+        when((xcnt === xlen - 1.U) && (xrem === 0.U)) {
           wmask := "b_01".U.asTypeOf(wmask)
         }.otherwise {
           wmask := "b_11".U.asTypeOf(wmask)
@@ -183,7 +183,7 @@ class LoadUop(debug: Boolean = false)(implicit p: Parameters) extends Module {
     when(io.vme_rd.cmd.fire()) {
       wmask := "b_10".U.asTypeOf(wmask)
     }.elsewhen(io.vme_rd.data.fire()) {
-      when(sizeIsEven && xcnt === xlen - 1.U) {
+      when(sizeIsEven && (xcnt === xlen - 1.U) && (xrem === 0.U)) {
         wmask := "b_01".U.asTypeOf(wmask)
       }.otherwise {
         wmask := "b_11".U.asTypeOf(wmask)


### PR DESCRIPTION
This PR intends to fix an issue in the LoadUop module.

Problem:
When the instruction request to transfer multiple uop that is larger than a single burst length, previous implement fail to update the write mask register `wmask` accordingly.

Solution:
Set write mask register `wmask` to `"b11".U` when xrem is not `0.U`.

@vegaluisjose @tmoreau89 Please review.