### PR TITLE
Fix MSVC build error with container.h

### DIFF
--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -198,6 +198,7 @@ class ADTObj : public Object, public InplaceArrayBase<ADTObj, ObjectRef> {
   }
 
   friend class ADT;
+  template <typename ArrayType, typename ElemType>
   friend class InplaceArrayBase;
 };
 

--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -198,8 +198,7 @@ class ADTObj : public Object, public InplaceArrayBase<ADTObj, ObjectRef> {
   }
 
   friend class ADT;
-  template <typename ArrayType, typename ElemType>
-  friend class InplaceArrayBase;
+  friend InplaceArrayBase<ADTObj, ObjectRef>;
 };
 
 /*! \brief reference to algebraic data type objects. */


### PR DESCRIPTION
The PR [4346 ](https://github.com/apache/incubator-tvm/pull/4346)introduced a breaking change in MSVC builds. 

In container.h, 'non-class template has already been declared as a class template' on line 201.

This change fixes the builds on MSVC (2019 toolset v14.2), but have not tried on any other compiler.
