### PR TITLE
[RUNTIME][RPC] Update RPC runtime to allow remote module as arg

### DIFF
--- a/python/tvm/contrib/debugger/debug_runtime.py
+++ b/python/tvm/contrib/debugger/debug_runtime.py
@@ -23,7 +23,6 @@ from tvm._ffi.base import string_types
 from tvm._ffi.function import get_global_func
 from tvm.contrib import graph_runtime
 from tvm.ndarray import array
-from tvm.rpc import base as rpc_base
 from . import debug_result
 
 _DUMP_ROOT_PREFIX = "tvmdbg_"

--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -51,11 +51,10 @@ def create(graph_json_str, libmod, ctx):
     ctx, num_rpc_ctx, device_type_id = get_device_ctx(libmod, ctx)
 
     if num_rpc_ctx == len(ctx):
-        hmod = rpc_base._ModuleHandle(libmod)
-        fcreate = ctx[0]._rpc_sess.get_function("tvm.graph_runtime.remote_create")
-        return GraphModule(fcreate(graph_json_str, hmod, *device_type_id))
+        fcreate = ctx[0]._rpc_sess.get_function("tvm.graph_runtime.create")
+    else:
+        fcreate = get_global_func("tvm.graph_runtime.create")
 
-    fcreate = get_global_func("tvm.graph_runtime.create")
     return GraphModule(fcreate(graph_json_str, libmod, *device_type_id))
 
 def get_device_ctx(libmod, ctx):

--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -27,7 +27,6 @@
 #include <chrono>
 #include <sstream>
 #include "../graph_runtime.h"
-#include "../../object_internal.h"
 
 namespace tvm {
 namespace runtime {
@@ -220,19 +219,5 @@ TVM_REGISTER_GLOBAL("tvm.graph_runtime_debug.create")
         << args.num_args;
     *rv = GraphRuntimeDebugCreate(args[0], args[1], GetAllContext(args));
   });
-
-TVM_REGISTER_GLOBAL("tvm.graph_runtime_debug.remote_create")
-.set_body([](TVMArgs args, TVMRetValue* rv) {
-    CHECK_GE(args.num_args, 4) << "The expected number of arguments for "
-                                  "graph_runtime.remote_create is "
-                                  "at least 4, but it has "
-                               << args.num_args;
-    void* mhandle = args[1];
-    ModuleNode* mnode = ObjectInternal::GetModuleNode(mhandle);
-    const auto& contexts = GetAllContext(args);
-    *rv = GraphRuntimeDebugCreate(
-        args[0], GetRef<Module>(mnode), contexts);
-  });
-
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -36,7 +36,6 @@
 #include <vector>
 
 #include "graph_runtime.h"
-#include "../object_internal.h"
 
 namespace tvm {
 namespace runtime {
@@ -510,20 +509,6 @@ TVM_REGISTER_GLOBAL("tvm.graph_runtime.create")
         << args.num_args;
     const auto& contexts = GetAllContext(args);
     *rv = GraphRuntimeCreate(args[0], args[1], contexts);
-  });
-
-TVM_REGISTER_GLOBAL("tvm.graph_runtime.remote_create")
-.set_body([](TVMArgs args, TVMRetValue* rv) {
-    CHECK_GE(args.num_args, 4) << "The expected number of arguments for "
-                                  "graph_runtime.remote_create is "
-                                  "at least 4, but it has "
-                               << args.num_args;
-    void* mhandle = args[1];
-    ModuleNode* mnode = ObjectInternal::GetModuleNode(mhandle);
-
-    const auto& contexts = GetAllContext(args);
-    *rv = GraphRuntimeCreate(
-        args[0], GetRef<Module>(mnode), contexts);
   });
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -91,6 +91,16 @@ enum class RPCCode : int {
 };
 
 /*!
+ * \brief Function that unwraps a remote object to its handle.
+ * \param rpc_sess_table_index RPC session table index for validation.
+ * \param obj Handle to the object argument.
+ * \return The corresponding handle.
+ */
+typedef void* (*FUnwrapRemoteObject)(
+    int rpc_sess_table_index,
+    const TVMArgValue& obj);
+
+/*!
  * \brief Abstract channel interface used to create RPCSession.
  */
 class RPCChannel {
@@ -144,11 +154,13 @@ class RPCSession {
    * \param handle The function handle
    * \param args The arguments
    * \param rv The return value.
+   * \param funpwrap Function that takes a remote object and returns the raw handle.
    * \param fwrap Wrapper function to turn Function/Module handle into real return.
    */
   void CallFunc(RPCFuncHandle handle,
                 TVMArgs args,
                 TVMRetValue* rv,
+                FUnwrapRemoteObject funwrap,
                 const PackedFunc* fwrap);
   /*!
    * \brief Copy bytes into remote array content.


### PR DESCRIPTION
Previously the RPC function does not allow directly passing a remote module as an argument. As a result, we will need to use special functions such as ```graph_runtime.remote_create``` to handle the remote module creation.

This PR adds the support. We also updated the graph runtime implementation to simply use the create function(instead of the remote_create function).

NOTE: this change will require the upgrade of both RPC server and client side.