### PR TITLE
[codegen][Build] it's more readable to move the if condition out of the loop

### DIFF
--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -41,8 +41,8 @@ runtime::Module Build(const Array<LoweredFunc>& funcs,
     mode = mode.substr(0, pos);
   }
   Array<LoweredFunc> transformed_funcs;
-  for (const auto& x : funcs) {
-    if (BuildConfig::Current()->disable_assert) {
+  if (BuildConfig::Current()->disable_assert) {
+    for (const auto& x : funcs) {
       auto func = ir::SkipAssert(x);
       transformed_funcs.push_back(func);
     }


### PR DESCRIPTION
In the Build function of the codegen module,  it's more readable to move the if condition out of the loop.