### PR TITLE
[NODE][Serialization]fix serialization precision loss in float

### DIFF
--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -168,7 +168,7 @@ class JSONAttrGetter : public AttrVisitor {
 
   void Visit(const char* key, double* value) final {
     std::ostringstream s;
-    // Type <double> have approximately 16 decimal digits 
+    // Type <double> have approximately 16 decimal digits
     s.precision(16);
     s << (*value);
     node_->attrs[key] = s.str();

--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -167,7 +167,11 @@ class JSONAttrGetter : public AttrVisitor {
   ReflectionVTable* reflection_ = ReflectionVTable::Global();
 
   void Visit(const char* key, double* value) final {
-    node_->attrs[key] = std::to_string(*value);
+    std::ostringstream s;
+    // Type <double> have approximately 16 decimal digits 
+    s.precision(16);
+    s << (*value);
+    node_->attrs[key] = s.str();
   }
   void Visit(const char* key, int64_t* value) final {
     node_->attrs[key] = std::to_string(*value);


### PR DESCRIPTION
When we want to serialize(such as pickle.dumps) a tvm.tensor object， we will get a precision loss caused by std::to_string()。
For example, a2.value will be 0.0 while a.value=0.00000001 in the following: 
    import tvm
    import pickle
    a = tvm.const(0.00000001, 'float32')
    a2 = pickle.loads(pickle.dumps(a))

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
