### PR TITLE
[CI] Update docker image ci_lint to obtain Python 3.6 from ppa:deadsn…

### DIFF
--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -27,7 +27,7 @@ apt-get install -y python-dev
 # python 3.6
 apt-get install -y software-properties-common
 
-add-apt-repository ppa:jonathonf/python-3.6
+add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 apt-get install -y python-pip python-dev python3.6 python3.6-dev
 


### PR DESCRIPTION
This fixes #4505, moving the PPA repository from which we obtain Python 3.6 to `ppa:deadsnakes/ppa`.
