### PR TITLE
[CONV] Asymmetric padding

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -67,7 +67,10 @@ struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
         .describe("Specifies the strides of the convolution.");
     TVM_ATTR_FIELD(padding).set_default(Array<IndexExpr>({0, 0}))
         .describe("If padding is non-zero, then the input is implicitly zero-padded"
-                  "on both sides for padding number of points");
+                  "Padding support both symmetric and asymmetric as"
+                  "one int : same padding used on all sides"
+                  "two int : bottom, right will use same padding as top, left"
+                  "four int : padding width in the order of (top, left, bottom, right)");
     TVM_ATTR_FIELD(dilation).set_default(Array<IndexExpr>({1, 1}))
         .describe("Specifies the dilation rate to use for dilated convolution.");
     TVM_ATTR_FIELD(groups).set_default(1)
@@ -138,7 +141,10 @@ struct Conv2DWinogradAttrs : public tvm::AttrsNode<Conv2DWinogradAttrs> {
         .describe("Specifies the strides of the convolution.");
     TVM_ATTR_FIELD(padding).set_default(Array<IndexExpr>({0, 0}))
         .describe("If padding is non-zero, then the input is implicitly zero-padded"
-                  "on both sides for padding number of points");
+                  "Padding support both symmetric and asymmetric as"
+                  "one int : same padding used on all sides"
+                  "two int : bottom, right will use same padding as top, left"
+                  "four int : padding width in the order of (top, left, bottom, right)");
     TVM_ATTR_FIELD(dilation).set_default(Array<IndexExpr>({1, 1}))
         .describe("Specifies the dilation rate to use for dilated convolution.");
     TVM_ATTR_FIELD(groups).set_default(1)
@@ -288,10 +294,17 @@ struct Conv2DTransposeAttrs : public tvm::AttrsNode<Conv2DTransposeAttrs> {
     TVM_ATTR_FIELD(strides).set_default(Array<IndexExpr>({1, 1}))
       .describe("The strides of the convolution.");
     TVM_ATTR_FIELD(output_padding).set_default(Array<IndexExpr>({0, 0}))
-      .describe("Zero-padding added to one side of the output.");
+      .describe("Zero-padding added to one side of the output."
+                "Padding support both symmetric and asymmetric as"
+                "one int : same padding used on all sides"
+                "two int : bottom, right will use same padding as top, left"
+                "four int : padding width in the order of (top, left, bottom, right)");
     TVM_ATTR_FIELD(padding).set_default(Array<IndexExpr>({0, 0}))
       .describe("If padding is non-zero, then the input is implicitly zero-padded"
-                "on both sides for padding number of points");
+                "Padding support both symmetric and asymmetric as"
+                "one int : same padding used on all sides"
+                "two int : bottom, right will use same padding as top, left"
+                "four int : padding width in the order of (top, left, bottom, right)");
     TVM_ATTR_FIELD(dilation).set_default(Array<IndexExpr>({1, 1}))
       .describe("Specifies the dilation rate to use for dilated convolution.");
     TVM_ATTR_FIELD(groups).set_default(1)
@@ -817,7 +830,10 @@ struct DeformableConv2DAttrs : public tvm::AttrsNode<DeformableConv2DAttrs> {
         .describe("Specifies the strides of the convolution.");
     TVM_ATTR_FIELD(padding).set_default(Array<IndexExpr>({0, 0}))
         .describe("If padding is non-zero, then the input is implicitly zero-padded"
-                  "on both sides for padding number of points");
+                  "Padding support both symmetric and asymmetric as"
+                  "one int : same padding used on all sides"
+                  "two int : bottom, right will use same padding as top, left"
+                  "four int : padding width in the order of (top, left, bottom, right)");
     TVM_ATTR_FIELD(dilation).set_default(Array<IndexExpr>({1, 1}))
         .describe("Specifies the dilation rate to use for dilated convolution.");
     TVM_ATTR_FIELD(deformable_groups).set_default(1)

--- a/python/tvm/contrib/pickle_memoize.py
+++ b/python/tvm/contrib/pickle_memoize.py
@@ -84,7 +84,7 @@ def memoize(key, save_at_exit=False):
     """
     def _register(f):
         """Registration function"""
-        allow_types = (string_types, int, float)
+        allow_types = (string_types, int, float, tuple)
         fkey = key + "." + f.__name__ + ".pkl"
         if fkey not in Cache.cache_by_key:
             Cache.cache_by_key[fkey] = Cache(fkey, save_at_exit)

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -372,24 +372,7 @@ def _conv(opname):
             pad_v = _get_pad_pair(in_h, dilated_kernel_h, stride_h)
             pad_h = _get_pad_pair(in_w, dilated_kernel_w, stride_w)
 
-            if opname != 'conv_transpose':
-                if attr['data_format'] == 'NHWC':
-                    inputs_data = _op.nn.pad(data=inputs_data,
-                                             pad_width=((0, 0),
-                                                        (pad_v[0], pad_v[1]),
-                                                        (pad_h[0], pad_h[1]),
-                                                        (0, 0)))
-                else:
-                    inputs_data = _op.nn.pad(data=inputs_data,
-                                             pad_width=((0, 0),
-                                                        (0, 0),
-                                                        (pad_v[0], pad_v[1]),
-                                                        (pad_h[0], pad_h[1])))
-
-                attr['padding'] = [0, 0]
-            else:
-                attr['padding'] = [pad_v[0], pad_h[0], pad_v[1], pad_h[1]]
-
+            attr['padding'] = [pad_v[0], pad_h[0], pad_v[1], pad_h[1]]
         else:
             msg = 'Value {} in attribute "padding" of operator Conv is not ' \
                   'valid.'

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -26,6 +26,8 @@
 #include <tvm/relay/attrs/bitserial.h>
 #include <tvm/relay/op.h>
 
+#include "../op_common.h"
+#include "../../pass/alter_op_layout.h"
 #include "../../pass/infer_layout_util.h"
 
 namespace tvm {
@@ -134,10 +136,12 @@ bool BinaryConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attr
   CHECK(param->channels.defined());
   CHECK(param->kernel_size.defined());
   Array<IndexExpr> oshape({dshape_nchw[0], param->channels, 0, 0});
+  IndexExpr pad_h, pad_w;
+  GetPaddingHeightWidth(param->padding, &pad_h, &pad_w);
   oshape.Set(
-      2, (dshape_nchw[2] + param->padding[0] * 2 - param->kernel_size[0]) / param->strides[0] + 1);
+      2, (dshape_nchw[2] + pad_h - param->kernel_size[0]) / param->strides[0] + 1);
   oshape.Set(
-      3, (dshape_nchw[3] + param->padding[1] * 2 - param->kernel_size[1]) / param->strides[1] + 1);
+      3, (dshape_nchw[3] + pad_w - param->kernel_size[1]) / param->strides[1] + 1);
   DataType out_dtype = param->out_dtype;
   oshape = trans_in_layout.BackwardShape(oshape);
   // assign output type

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -27,7 +27,6 @@
 #include <tvm/relay/op.h>
 
 #include "../op_common.h"
-#include "../../pass/alter_op_layout.h"
 #include "../../pass/infer_layout_util.h"
 
 namespace tvm {

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -166,7 +166,6 @@ with the layer input to produce a tensor of outputs.
 .add_type_rel("Conv3D", Conv3DRel<Conv3DAttrs>)
 .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv3DAttrs>);
 
-
 // relay.nn.conv2d_transpose
 TVM_REGISTER_NODE_TYPE(Conv2DTransposeAttrs);
 
@@ -250,18 +249,8 @@ bool Conv2DTransposeRel(const Array<Type>& types,
   }
   // dilation
   Array<IndexExpr> oshape({dshape_nchw[0], channels, 0, 0});
-  auto pad_h = param->padding[0];
-  auto pad_w = param->padding[1];
-  if (param->padding.size() == 2) {
-    pad_h *= 2;
-    pad_w *= 2;
-  } else if (param->padding.size() == 4) {
-    pad_h += param->padding[2];
-    pad_w += param->padding[3];
-  } else {
-    CHECK_EQ(param->padding.size(), 4) << " Padding should be 2 or 4, but got "
-        << param->padding.size();
-  }
+  IndexExpr pad_h, pad_w;
+  GetPaddingHeightWidth(param->padding, &pad_h, &pad_w);
   oshape.Set(2, (param->strides[0] * (dshape_nchw[2] - 1) + dilated_ksize_y -
                  pad_h + param->output_padding[0]));
   oshape.Set(3, (param->strides[1] * (dshape_nchw[3] - 1) + dilated_ksize_x -
@@ -557,14 +546,16 @@ bool Conv2DWinogradRel(const Array<Type>& types,
   // dilation
   Array<IndexExpr> oshape({dshape_nchw[0], channels, 0, 0});
 
+  IndexExpr pad_h, pad_w;
+  GetPaddingHeightWidth(param->padding, &pad_h, &pad_w);
   if (!dshape_nchw[2].as<ir::Any>()) {
-    oshape.Set(2, (dshape_nchw[2] + param->padding[0] * 2
+    oshape.Set(2, (dshape_nchw[2] + pad_h
                    - dilated_ksize_y) / param->strides[0] + 1);
   } else {
     oshape.Set(2, dshape_nchw[2]);
   }
   if (!dshape_nchw[3].as<ir::Any>()) {
-    oshape.Set(3, (dshape_nchw[3] + param->padding[1] * 2
+    oshape.Set(3, (dshape_nchw[3] + pad_w
                    - dilated_ksize_x) / param->strides[1] + 1);
   } else {
     oshape.Set(3, dshape_nchw[3]);
@@ -1015,9 +1006,11 @@ bool DeformableConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& 
   // dilation
   Array<IndexExpr> oshape({data->shape[0], channels, 0, 0});
 
-  oshape.Set(2, indexdiv(data->shape[2] + param->padding[0] * 2 - dilated_ksize_y,
+  IndexExpr pad_h, pad_w;
+  GetPaddingHeightWidth(param->padding, &pad_h, &pad_w);
+  oshape.Set(2, indexdiv(data->shape[2] + pad_h - dilated_ksize_y,
                          param->strides[0]) + 1);
-  oshape.Set(3, indexdiv(data->shape[3] + param->padding[1] * 2 - dilated_ksize_x,
+  oshape.Set(3, indexdiv(data->shape[3] + pad_w - dilated_ksize_x,
                          param->strides[1]) + 1);
   DataType out_dtype = param->out_dtype;
 

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -117,15 +117,17 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   // dilation
   Array<IndexExpr> oshape({dshape_nchw[0], channels, 0, 0});
 
+  IndexExpr pad_h, pad_w;
+  GetPaddingHeightWidth(param->padding, &pad_h, &pad_w);
   if (!dshape_nchw[2].as<ir::Any>()) {
-    oshape.Set(2, indexdiv(dshape_nchw[2] + param->padding[0] * 2 - dilated_ksize_y,
+    oshape.Set(2, indexdiv(dshape_nchw[2] + pad_h - dilated_ksize_y,
                            param->strides[0]) + 1);
   } else {
     oshape.Set(2, dshape_nchw[2]);
   }
 
   if (!dshape_nchw[3].as<ir::Any>()) {
-    oshape.Set(3, indexdiv(dshape_nchw[3] + param->padding[1] * 2 - dilated_ksize_x,
+    oshape.Set(3, indexdiv(dshape_nchw[3] + pad_w - dilated_ksize_x,
                            param->strides[1]) + 1);
   } else {
     oshape.Set(3, dshape_nchw[3]);

--- a/tests/python/contrib/test_nnpack.py
+++ b/tests/python/contrib/test_nnpack.py
@@ -17,6 +17,7 @@
 import tvm
 import numpy as np
 import scipy.signal
+from topi.nn.util import get_pad_tuple
 from tvm.contrib import nnpack
 import pytest
 
@@ -59,17 +60,9 @@ def np_conv(na, nw, padding, stride=1):
     else:
         stride_h, stride_w = stride
 
-    if isinstance(padding, int):
-        pad_h = pad_w = padding * 2
-    else:
-        pad_h, pad_w = padding
-        pad_h *= 2
-        pad_w *= 2
-
-    pad_top = int(np.ceil(float(pad_h) / 2))
-    pad_bottom = pad_h - pad_top
-    pad_left = int(np.ceil(float(pad_w) / 2))
-    pad_right = pad_w - pad_left
+    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
+    pad_h = pad_top + pad_bottom
+    pad_w = pad_left + pad_right
 
     out_channel = num_filter
     out_height = (in_height - kernel_h + pad_h) // stride_h + 1

--- a/tests/python/contrib/test_nnpack.py
+++ b/tests/python/contrib/test_nnpack.py
@@ -71,9 +71,9 @@ def np_conv(na, nw, padding, stride=1):
     for n in range(batch):
         for f in range(out_channel):
             for c in range(in_channel):
-                if pad_h > 0:
+                if pad_h > 0 or pad_w > 0:
                     apad = np.zeros((in_height + pad_h, in_width + pad_w))
-                    apad[pad_top:-pad_bottom, pad_left:-pad_right] = na[n, c]
+                    apad[pad_top:pad_top + in_height, pad_left:pad_left + in_width] = na[n, c]
                 else:
                     apad = na[n, c]
                 out = scipy.signal.convolve2d(

--- a/topi/python/topi/arm_cpu/conv2d.py
+++ b/topi/python/topi/arm_cpu/conv2d.py
@@ -197,11 +197,11 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
         CO *= VC
         KH, KW = H_CAT - tile_size + 1, W_CAT - tile_size + 1
     HSTR, WSTR = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, kernel)
+    pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
 
     assert layout == 'NCHW'
     assert KH == 3 and KW == 3 and HSTR == 1 and WSTR == 1
-    data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
+    data_pad = pad(data, (0, 0, pt, pl), (0, 0, pb, pr), name="data_pad")
 
     idxd = tvm.indexdiv
     idxm = tvm.indexmod
@@ -214,8 +214,8 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
     K = CO
     C = CI
 
-    H = (IH + 2 * HPAD - 3) // HSTR + 1
-    W = (IW + 2 * WPAD - 3) // WSTR + 1
+    H = (IH + pt + pb - 3) // HSTR + 1
+    W = (IW + pl + pr - 3) // WSTR + 1
     nH, nW = (H + m-1) // m, (W + m-1) // m
     P = N * nH * nW
 
@@ -387,12 +387,13 @@ def conv2d_arm_cpu_winograd_nnpack(
     assert len(kernel.shape) == 4
     CO, _, KH, KW = get_const_tuple(kernel.shape)
     HSTR, WSTR = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, kernel)
+    pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
 
     assert layout == 'NCHW'
-    assert KH == 3 and KW == 3 and HPAD == 1 and WPAD == 1 and HSTR == 1 and WSTR == 1
-    H = (IH + 2 * HPAD - 3) // HSTR + 1
-    W = (IW + 2 * WPAD - 3) // WSTR + 1
+    assert KH == 3 and KW == 3 and pt == 1 and pb == 1 and pl == 1 and pr == 1 and HSTR == 1\
+        and WSTR == 1
+    H = (IH + pt + pb - 3) // HSTR + 1
+    W = (IW + pl + pr - 3) // WSTR + 1
 
     cfg.define_knob('winograd_nnpack_algorithm', [convolution_algorithm])
 
@@ -407,7 +408,7 @@ def conv2d_arm_cpu_winograd_nnpack(
         output = tvm.contrib.nnpack.convolution_inference_without_weight_transform(
             data, transformed_kernel,
             bias=None,
-            padding=[HPAD, HPAD, WPAD, WPAD],
+            padding=[pt, pb, pl, pr],
             stride=[HSTR, WSTR],
             algorithm=cfg['winograd_nnpack_algorithm'].val)
 
@@ -467,13 +468,14 @@ def conv2d_winograd_nnpack_ww(cfg, data, transformed_kernel, bias, strides,
     assert len(transformed_kernel.shape) == 4
     CO, _, _, _ = get_const_tuple(transformed_kernel.shape)
     HSTR, WSTR = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, (3, 3))
     KH, KW = 3, 3
+    pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
 
     assert layout == 'NCHW'
-    assert KH == 3 and KW == 3 and HPAD == 1 and WPAD == 1 and HSTR == 1 and WSTR == 1
-    H = (IH + 2 * HPAD - 3) // HSTR + 1
-    W = (IW + 2 * WPAD - 3) // WSTR + 1
+    assert KH == 3 and KW == 3 and pt == 1 and pb == 1 and pl == 1 and pr == 1 and HSTR == 1\
+        and WSTR == 1
+    H = (IH + pt + pb - 3) // HSTR + 1
+    W = (IW + pl + pr - 3) // WSTR + 1
 
     assert N == 1
     with tvm.tag_scope("winograd_nnpack_conv2d_output"):
@@ -481,7 +483,7 @@ def conv2d_winograd_nnpack_ww(cfg, data, transformed_kernel, bias, strides,
             data=data,
             transformed_kernel=transformed_kernel,
             bias=bias,
-            padding=[HPAD, HPAD, WPAD, WPAD],
+            padding=[pt, pb, pl, pr],
             stride=[HSTR, WSTR],
             algorithm=cfg['winograd_nnpack_algorithm'].val)
 

--- a/topi/python/topi/bifrost/conv2d.py
+++ b/topi/python/topi/bifrost/conv2d.py
@@ -276,11 +276,11 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
         H_CAT, W_CAT, CO, CI = get_const_tuple(kernel.shape)
         KH, KW = H_CAT - tile_size + 1, W_CAT - tile_size + 1
     HSTR, WSTR = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, kernel)
+    pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
 
     assert layout == 'NCHW'
     assert KH == 3 and KW == 3 and HSTR == 1 and WSTR == 1
-    data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
+    data_pad = pad(data, (0, 0, pt, pl), (0, 0, pb, pr), name="data_pad")
 
     r = KW
     m = tile_size
@@ -289,8 +289,8 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
 
     K = CO
     C = CI
-    H = (IH + 2 * HPAD - 3) // HSTR + 1
-    W = (IW + 2 * WPAD - 3) // WSTR + 1
+    H = (IH + pt + pb - 3) // HSTR + 1
+    W = (IW + pl + pr - 3) // WSTR + 1
     nH, nW = (H + m-1) // m, (W + m-1) // m
     P = N * nH * nW
 

--- a/topi/python/topi/cuda/conv2d_winograd.py
+++ b/topi/python/topi/cuda/conv2d_winograd.py
@@ -64,15 +64,15 @@ def winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dty
         KH = KW = alpha + 1 - tile_size
         assert HSTR == 1 and WSTR == 1 and dilation_h == 1 and dilation_w == 1
 
-    HPAD, WPAD, _, _ = nn.get_pad_tuple(padding, kernel)
-    data_pad = nn.pad(data, (0, 0, HPAD, WPAD), (0, 0, HPAD, WPAD), name="data_pad")
+    pt, pl, pb, pr = nn.get_pad_tuple(padding, (KH, KW))
+    data_pad = nn.pad(data, (0, 0, pt, pl), (0, 0, pb, pr), name="data_pad")
 
     r = KW
     m = tile_size
     A, B, G = winograd_transform_matrices(m, r, out_dtype)
 
-    H = (H + 2 * HPAD - KH) // HSTR + 1
-    W = (W + 2 * WPAD - KW) // WSTR + 1
+    H = (H + pt + pb - KH) // HSTR + 1
+    W = (W + pl + pr - KW) // WSTR + 1
     nH, nW = (H + m-1) // m, (W + m-1) // m
     P = N * nH * nW
 

--- a/topi/python/topi/intel_graphics/conv2d.py
+++ b/topi/python/topi/intel_graphics/conv2d.py
@@ -83,10 +83,10 @@ def _create_schedule_template(cfg, data, kernel, strides, padding, dilation, lay
     else:
         raise ValueError("Not support this layout {} with "
                          "schedule template.".format(layout))
-    ph, pw = padding if isinstance(padding, (tuple, list)) else (padding, padding)
+    pt, pl, pb, pr = get_pad_tuple(padding, kernel)
     sh, sw = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    oh = (h - kh + 2 * ph) // sh + 1
-    ow = (w - kw + 2 * pw) // sw + 1
+    oh = (h - kh + pt + pb) // sh + 1
+    ow = (w - kw + pl + pr) // sw + 1
     ic_bn_upper = 32
     oc_bn_upper = 64
     oc_bn_lower = min(oc, 8)

--- a/topi/python/topi/mali/conv2d.py
+++ b/topi/python/topi/mali/conv2d.py
@@ -226,19 +226,19 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
         CO *= VC
         KH, KW = H_CAT - tile_size + 1, W_CAT - tile_size + 1
     HSTR, WSTR = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, kernel)
+    pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
 
     assert layout == 'NCHW'
     assert KH == 3 and KW == 3 and HSTR == 1 and WSTR == 1
-    data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
+    data_pad = pad(data, (0, 0, pt, pl), (0, 0, pb, pr), name="data_pad")
 
     r = KW
     m = tile_size
     alpha = m + r - 1
     A, B, G = winograd_transform_matrices(m, r, out_dtype)
 
-    H = (IH + 2 * HPAD - 3) // HSTR + 1
-    W = (IW + 2 * WPAD - 3) // WSTR + 1
+    H = (IH + pt + pb - 3) // HSTR + 1
+    W = (IW + pl + pr - 3) // WSTR + 1
     nH, nW = (H + m-1) // m, (W + m-1) // m
     P = N * nH * nW
 

--- a/topi/python/topi/rocm/conv2d.py
+++ b/topi/python/topi/rocm/conv2d.py
@@ -23,6 +23,7 @@ from tvm.contrib import miopen
 from .. import nn, generic
 from ..util import get_const_tuple
 from ..cuda.conv2d import conv2d_cuda, schedule_conv2d_nchw_cuda
+from ..nn.util import get_pad_tuple
 
 @autotvm.register_topi_compute(nn.conv2d, 'rocm', ['direct', 'winograd'])
 def conv2d_rocm(cfg, data, kernel, strides, padding, dilation, layout='NCHW', out_dtype='float32'):
@@ -42,8 +43,10 @@ def conv2d_rocm(cfg, data, kernel, strides, padding, dilation, layout='NCHW', ou
     strides : int or a list/tuple of two ints
         stride size, or [stride_height, stride_width]
 
-    padding : int or a list/tuple of two ints
-        padding size, or [pad_height, pad_width]
+    padding : int or a list/tuple of 2 or 4 ints
+        padding size, or
+        [pad_height, pad_width] for 2 ints, or
+        [pad_top, pad_left, pad_bottom, pad_right] for 4 ints
 
     layout : str
         layout of data
@@ -62,7 +65,8 @@ def conv2d_rocm(cfg, data, kernel, strides, padding, dilation, layout='NCHW', ou
 
         # handle dilation
         stride_h, stride_w = (strides, strides) if isinstance(strides, int) else strides
-        pad_h, pad_w = (padding, padding) if isinstance(padding, int) else padding
+        pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
+        pad_h, pad_w = pt + pb, pl + pr
         dilation_h, dilation_w = (dilation, dilation) if isinstance(dilation, int) else dilation
 
         OH = (H + 2 * pad_h - KH) // stride_h + 1

--- a/topi/python/topi/testing/conv2d_hwcn_python.py
+++ b/topi/python/topi/testing/conv2d_hwcn_python.py
@@ -67,9 +67,9 @@ def conv2d_hwcn_python(a_np, w_np, stride, padding):
     for n in range(batch):
         for f in range(out_channel):
             for c in range(in_channel):
-                if pad_h > 0:
+                if pad_h > 0 or pad_w > 0:
                     apad = np.zeros((in_height + pad_h, in_width + pad_w))
-                    apad[pad_top:-pad_bottom, pad_left:-pad_right] = at[n, c]
+                    apad[pad_top:pad_top + in_height, pad_left:pad_left + in_width] = at[n, c]
                 else:
                     apad = at[n, c]
                 out = scipy.signal.convolve2d(

--- a/topi/python/topi/testing/conv2d_hwcn_python.py
+++ b/topi/python/topi/testing/conv2d_hwcn_python.py
@@ -36,7 +36,7 @@ def conv2d_hwcn_python(a_np, w_np, stride, padding):
         Stride size, or [stride_height, stride_width]
 
     padding : int or str or a list/tuple of 2 or 4 ints
-        Padding size, or ['VALID', 'SAME'], or 
+        Padding size, or ['VALID', 'SAME'], or
         [pad_height, pad_width] for 2 ints, or
         [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 

--- a/topi/python/topi/testing/conv2d_hwcn_python.py
+++ b/topi/python/topi/testing/conv2d_hwcn_python.py
@@ -18,6 +18,7 @@
 """Convolution in python"""
 import numpy as np
 import scipy.signal
+from topi.nn.util import get_pad_tuple
 
 
 def conv2d_hwcn_python(a_np, w_np, stride, padding):
@@ -34,8 +35,10 @@ def conv2d_hwcn_python(a_np, w_np, stride, padding):
     stride : int or a list/tuple of two ints
         Stride size, or [stride_height, stride_width]
 
-    padding : int or str
-        Padding size, or ['VALID', 'SAME']
+    padding : int or str or a list/tuple of 2 or 4 ints
+        Padding size, or ['VALID', 'SAME'], or 
+        [pad_height, pad_width] for 2 ints, or
+        [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
     Returns
     -------
@@ -48,18 +51,10 @@ def conv2d_hwcn_python(a_np, w_np, stride, padding):
         stride_h = stride_w = stride
     else:
         stride_h, stride_w = stride
-    if isinstance(padding, int):
-        pad_h = pad_w = padding * 2
-    elif padding == 'VALID':
-        pad_h = 0
-        pad_w = 0
-    else: # 'SAME'
-        pad_h = kernel_h - 1
-        pad_w = kernel_w - 1
-    pad_top = int(np.ceil(float(pad_h) / 2))
-    pad_bottom = pad_h - pad_top
-    pad_left = int(np.ceil(float(pad_w) / 2))
-    pad_right = pad_w - pad_left
+
+    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
+    pad_h = pad_top + pad_bottom
+    pad_w = pad_left + pad_right
     # compute the output shape
     out_channel = num_filter
     out_height = (in_height - kernel_h + pad_h) // stride_h + 1

--- a/topi/python/topi/testing/conv2d_nchw_python.py
+++ b/topi/python/topi/testing/conv2d_nchw_python.py
@@ -54,7 +54,6 @@ def _conv2d_nchw_python(a_np, w_np, stride, padding):
     pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
     pad_h = pad_top + pad_bottom
     pad_w = pad_left + pad_right
-
     # compute the output shape
     out_channel = num_filter
     out_height = (in_height - kernel_h + pad_h) // stride_h + 1
@@ -66,12 +65,7 @@ def _conv2d_nchw_python(a_np, w_np, stride, padding):
             for c in range(in_channel):
                 if pad_h > 0 or pad_w > 0:
                     apad = np.zeros((in_height + pad_h, in_width + pad_w))
-                    if pad_h == 0:
-                        apad[:, pad_left:-pad_right] = a_np[n, c]
-                    elif pad_w == 0:
-                        apad[pad_top:-pad_bottom, :] = a_np[n, c]
-                    else:
-                        apad[pad_top:-pad_bottom, pad_left:-pad_right] = a_np[n, c]
+                    apad[pad_top:pad_top + in_height, pad_left:pad_left + in_width] = a_np[n, c]
                 else:
                     apad = a_np[n, c]
                 out = scipy.signal.convolve2d(

--- a/topi/python/topi/testing/conv2d_nchw_python.py
+++ b/topi/python/topi/testing/conv2d_nchw_python.py
@@ -36,7 +36,7 @@ def _conv2d_nchw_python(a_np, w_np, stride, padding):
         Stride size, or [stride_height, stride_width]
 
     padding : int or str or a list/tuple of 2 or 4 ints
-        Padding size, or ['VALID', 'SAME'], or 
+        Padding size, or ['VALID', 'SAME'], or
         [pad_height, pad_width] for 2 ints, or
         [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
@@ -95,7 +95,7 @@ def conv2d_nchw_python(a_np, w_np, stride, padding, groups=1):
         Stride size, or [stride_height, stride_width]
 
     padding : int or str or a list/tuple of 2 or 4 ints
-        Padding size, or ['VALID', 'SAME'], or 
+        Padding size, or ['VALID', 'SAME'], or
         [pad_height, pad_width] for 2 ints, or
         [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 

--- a/topi/python/topi/testing/conv2d_nchw_python.py
+++ b/topi/python/topi/testing/conv2d_nchw_python.py
@@ -18,6 +18,7 @@
 """Convolution in python"""
 import numpy as np
 import scipy.signal
+from topi.nn.util import get_pad_tuple
 
 
 def _conv2d_nchw_python(a_np, w_np, stride, padding):
@@ -34,8 +35,10 @@ def _conv2d_nchw_python(a_np, w_np, stride, padding):
     stride : int or a list/tuple of two ints
         Stride size, or [stride_height, stride_width]
 
-    padding : int or str or a list/tuple of two ints
-        Padding size, or ['VALID', 'SAME'], or [pad_height, pad_width]
+    padding : int or str or a list/tuple of 2 or 4 ints
+        Padding size, or ['VALID', 'SAME'], or 
+        [pad_height, pad_width] for 2 ints, or
+        [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
     Returns
     -------
@@ -48,17 +51,10 @@ def _conv2d_nchw_python(a_np, w_np, stride, padding):
         stride_h = stride_w = stride
     else:
         stride_h, stride_w = stride
-    if isinstance(padding, int):
-        pad_h = pad_w = padding * 2
-    elif isinstance(padding, (list, tuple)):
-        pad_h, pad_w = padding[0] * 2, padding[1] * 2
-    else:
-        pad_h = 0 if padding == 'VALID' else kernel_h - 1
-        pad_w = 0 if padding == 'VALID' else kernel_w - 1
-    pad_top = int(np.ceil(float(pad_h) / 2))
-    pad_bottom = pad_h - pad_top
-    pad_left = int(np.ceil(float(pad_w) / 2))
-    pad_right = pad_w - pad_left
+    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
+    pad_h = pad_top + pad_bottom
+    pad_w = pad_left + pad_right
+
     # compute the output shape
     out_channel = num_filter
     out_height = (in_height - kernel_h + pad_h) // stride_h + 1
@@ -98,8 +94,10 @@ def conv2d_nchw_python(a_np, w_np, stride, padding, groups=1):
     stride : int or a list/tuple of two ints
         Stride size, or [stride_height, stride_width]
 
-    padding : int or str or a list/tuple of two ints
-        Padding size, or ['VALID', 'SAME'], or [pad_height, pad_width]
+    padding : int or str or a list/tuple of 2 or 4 ints
+        Padding size, or ['VALID', 'SAME'], or 
+        [pad_height, pad_width] for 2 ints, or
+        [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
     groups : int
         Number of groups

--- a/topi/python/topi/testing/conv2d_nhwc_python.py
+++ b/topi/python/topi/testing/conv2d_nhwc_python.py
@@ -18,6 +18,7 @@
 """Convolution in python"""
 import numpy as np
 import scipy.signal
+from topi.nn.util import get_pad_tuple
 
 
 def conv2d_nhwc_python(a_np, w_np, stride, padding):
@@ -34,8 +35,10 @@ def conv2d_nhwc_python(a_np, w_np, stride, padding):
     stride : int or a list/tuple of two ints
         Stride size, or [stride_height, stride_width]
 
-    padding : int or str
-        Padding size, or ['VALID', 'SAME']
+    padding : int or str or a list/tuple of 2 or 4 ints
+        Padding size, or ['VALID', 'SAME'], or 
+        [pad_height, pad_width] for 2 ints, or
+        [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
     Returns
     -------
@@ -48,18 +51,11 @@ def conv2d_nhwc_python(a_np, w_np, stride, padding):
         stride_h = stride_w = stride
     else:
         stride_h, stride_w = stride
-    if isinstance(padding, int):
-        pad_h = pad_w = padding * 2
-    elif padding == 'VALID':
-        pad_h = 0
-        pad_w = 0
-    else: # 'SAME'
-        pad_h = kernel_h - 1
-        pad_w = kernel_w - 1
-    pad_top = int(np.ceil(float(pad_h) / 2))
-    pad_bottom = pad_h - pad_top
-    pad_left = int(np.ceil(float(pad_w) / 2))
-    pad_right = pad_w - pad_left
+
+    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
+    pad_h = pad_top + pad_bottom
+    pad_w = pad_left + pad_right
+
     # compute the output shape
     out_channel = num_filter
     out_height = (in_height - kernel_h + pad_h) // stride_h + 1

--- a/topi/python/topi/testing/conv2d_nhwc_python.py
+++ b/topi/python/topi/testing/conv2d_nhwc_python.py
@@ -68,9 +68,9 @@ def conv2d_nhwc_python(a_np, w_np, stride, padding):
     for n in range(batch):
         for f in range(out_channel):
             for c in range(in_channel):
-                if pad_h > 0:
+                if pad_h > 0 or pad_w > 0:
                     apad = np.zeros((in_height + pad_h, in_width + pad_w))
-                    apad[pad_top:-pad_bottom, pad_left:-pad_right] = at[n, c]
+                    apad[pad_top:pad_top + in_height, pad_left:pad_left + in_width] = at[n, c]
                 else:
                     apad = at[n, c]
                 out = scipy.signal.convolve2d(

--- a/topi/python/topi/testing/conv2d_nhwc_python.py
+++ b/topi/python/topi/testing/conv2d_nhwc_python.py
@@ -36,7 +36,7 @@ def conv2d_nhwc_python(a_np, w_np, stride, padding):
         Stride size, or [stride_height, stride_width]
 
     padding : int or str or a list/tuple of 2 or 4 ints
-        Padding size, or ['VALID', 'SAME'], or 
+        Padding size, or ['VALID', 'SAME'], or
         [pad_height, pad_width] for 2 ints, or
         [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 

--- a/topi/python/topi/testing/deformable_conv2d_nchw_python.py
+++ b/topi/python/topi/testing/deformable_conv2d_nchw_python.py
@@ -18,7 +18,7 @@
 """Deformable convolution in python"""
 import itertools
 import numpy as np
-
+from topi.nn.util import get_pad_tuple
 
 def deformable_conv2d_nchw_python(a_np, offset_np, w_np, stride, padding, dilation,
                                   deformable_groups, groups):
@@ -39,8 +39,10 @@ def deformable_conv2d_nchw_python(a_np, offset_np, w_np, stride, padding, dilati
     stride : int or a list/tuple of two ints
         Stride size, or [stride_height, stride_width]
 
-    padding : int or str or a list/tuple of two ints
-        Padding size, or ['VALID', 'SAME'], or [pad_height, pad_width]
+    padding : int or str or a list/tuple of 2 or 4 ints
+        Padding size, or ['VALID', 'SAME'], or 
+        [pad_height, pad_width] for 2 ints, or
+        [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
     dilation : int or a list/tuple of two ints
         Dilation size, or [dilate_height, dilate_width]
@@ -67,15 +69,11 @@ def deformable_conv2d_nchw_python(a_np, offset_np, w_np, stride, padding, dilati
         stride_h = stride_w = stride
     else:
         stride_h, stride_w = stride
-    if isinstance(padding, int):
-        pad_h = pad_w = padding * 2
-    elif isinstance(padding, (list, tuple)):
-        pad_h, pad_w = padding[0] * 2, padding[1] * 2
-    else:
-        pad_h = 0 if padding == 'VALID' else kernel_h - 1
-        pad_w = 0 if padding == 'VALID' else kernel_w - 1
-    pad_top = int(np.ceil(float(pad_h) / 2))
-    pad_left = int(np.ceil(float(pad_w) / 2))
+
+    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
+    pad_h = pad_top + pad_bottom
+    pad_w = pad_left + pad_right
+
     if isinstance(dilation, int):
         dilation_h = dilation_w = dilation
     else:

--- a/topi/python/topi/testing/deformable_conv2d_nchw_python.py
+++ b/topi/python/topi/testing/deformable_conv2d_nchw_python.py
@@ -40,7 +40,7 @@ def deformable_conv2d_nchw_python(a_np, offset_np, w_np, stride, padding, dilati
         Stride size, or [stride_height, stride_width]
 
     padding : int or str or a list/tuple of 2 or 4 ints
-        Padding size, or ['VALID', 'SAME'], or 
+        Padding size, or ['VALID', 'SAME'], or
         [pad_height, pad_width] for 2 ints, or
         [pad_top, pad_left, pad_bottom, pad_right] for 2 ints
 
@@ -70,9 +70,7 @@ def deformable_conv2d_nchw_python(a_np, offset_np, w_np, stride, padding, dilati
     else:
         stride_h, stride_w = stride
 
-    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel_h, kernel_w))
-    pad_h = pad_top + pad_bottom
-    pad_w = pad_left + pad_right
+    pad_top, pad_left, _, _ = get_pad_tuple(padding, (kernel_h, kernel_w))
 
     if isinstance(dilation, int):
         dilation_h = dilation_w = dilation

--- a/topi/python/topi/x86/conv2d.py
+++ b/topi/python/topi/x86/conv2d.py
@@ -30,6 +30,7 @@ from ..nn.conv2d import conv2d, conv2d_NCHWc, \
     conv2d_infer_layout, _get_workload as _get_conv2d_workload
 from ..nn.depthwise_conv2d import _get_workload as _get_depthwise_conv2d_workload
 from ..nn.pad import pad
+from ..nn.util import get_pad_tuple
 from ..util import get_const_tuple
 
 from . import conv2d_avx_1x1, conv2d_avx_common
@@ -84,10 +85,10 @@ def _create_tuning_space(cfg, data, kernel, strides, padding, dilation, layout):
                          "schedule template.".format(layout))
 
     is_kernel_1x1 = kh == 1 and kw == 1
-    ph, pw = padding if isinstance(padding, (tuple, list)) else (padding, padding)
+    pt, pl, pb, pr = get_pad_tuple(padding, (kh, kw))
     sh, sw = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    oh = (h - kh + 2 * ph) // sh + 1
-    ow = (w - kw + 2 * pw) // sw + 1
+    oh = (h - kh + pt + pb) // sh + 1
+    ow = (w - kw + pl + pr) // sw + 1
 
     # Create schedule config
     cfg.define_split("tile_ic", ic, num_outputs=2)
@@ -102,7 +103,6 @@ def _create_tuning_space(cfg, data, kernel, strides, padding, dilation, layout):
 @autotvm.register_topi_compute(conv2d, 'cpu', ['direct'])
 def _declaration_conv(cfg, data, kernel, strides, padding, dilation, layout, out_dtype):
     out_dtype = data.dtype if out_dtype is None else out_dtype
-    padding = padding if isinstance(padding, (tuple, list)) else (padding, padding)
     strides = strides if isinstance(strides, (tuple, list)) else (strides, strides)
     dilation = dilation if isinstance(dilation, (tuple, list)) else (dilation, dilation)
 
@@ -141,24 +141,27 @@ def _declaration_conv_impl(cfg, data, kernel, strides, padding, dilation, layout
     else:
         dilation_h, dilation_w = dilation
 
-    HPAD, WPAD = padding
     HSTR, WSTR = strides
+    pad_top, pad_left, pad_down, pad_right = get_pad_tuple(padding, kernel)
+    pad_h = pad_top + pad_down
+    pad_w = pad_left + pad_right
 
     batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
     num_filter, _, kernel_height, kernel_width = get_const_tuple(kernel.shape)
 
-    pad_height = in_height + 2 * HPAD
-    pad_width = in_width + 2 * WPAD
+    pad_height = in_height + pad_h
+    pad_width = in_width + pad_w
 
     dilated_kernel_h = (kernel_height - 1) * dilation_h + 1
     dilated_kernel_w = (kernel_width - 1) * dilation_w + 1
-    out_height = (in_height + 2 * HPAD - dilated_kernel_h) // HSTR + 1
-    out_width = (in_width + 2 * WPAD - dilated_kernel_w) // WSTR + 1
+    out_height = (in_height + pad_h - dilated_kernel_h) // HSTR + 1
+    out_width = (in_width + pad_w - dilated_kernel_w) // WSTR + 1
 
     # pack data
-    DOPAD = (HPAD != 0 or WPAD != 0)
+    DOPAD = (pad_h != 0 or pad_w != 0)
     if DOPAD:
-        data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
+        data_pad = pad(data, (0, 0, pad_top, pad_left), (0, 0, pad_down, pad_right), \
+            name="data_pad")
     else:
         data_pad = data
 
@@ -353,8 +356,9 @@ def _conv2d_infer_layout(workload, cfg):
     out_channel, _, k_height, k_width = kernel[:-1]
     idxdiv = tvm.indexdiv
 
-    out_height = idxdiv(in_height + 2 * padding[0] - k_height, strides[0]) + 1
-    out_width = idxdiv(in_width + 2 * padding[1] - k_width, strides[1]) + 1
+    pt, pl, pb, pr = get_pad_tuple(padding, (k_height, k_width))
+    out_height = idxdiv(in_height + pt + pb - k_height, strides[0]) + 1
+    out_width = idxdiv(in_width + pl + pr - k_width, strides[1]) + 1
     tile_ic, tile_oc = cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1]
     in_shape = (batch_size, idxdiv(in_channel, tile_ic), in_height, in_width, tile_ic)
     in_layout = "NCHW%dc" % tile_ic

--- a/topi/python/topi/x86/conv2d.py
+++ b/topi/python/topi/x86/conv2d.py
@@ -142,12 +142,12 @@ def _declaration_conv_impl(cfg, data, kernel, strides, padding, dilation, layout
         dilation_h, dilation_w = dilation
 
     HSTR, WSTR = strides
-    pad_top, pad_left, pad_down, pad_right = get_pad_tuple(padding, kernel)
-    pad_h = pad_top + pad_down
-    pad_w = pad_left + pad_right
-
     batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
     num_filter, _, kernel_height, kernel_width = get_const_tuple(kernel.shape)
+
+    pad_top, pad_left, pad_down, pad_right = get_pad_tuple(padding, (kernel_height, kernel_width))
+    pad_h = pad_top + pad_down
+    pad_w = pad_left + pad_right
 
     pad_height = in_height + pad_h
     pad_width = in_width + pad_w

--- a/topi/python/topi/x86/conv2d_int8.py
+++ b/topi/python/topi/x86/conv2d_int8.py
@@ -25,6 +25,7 @@ from tvm.autotvm.task.topi_integration import deserialize_args
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 from .. import generic, tag
 from ..generic import conv2d as conv2d_generic
+from ..nn.util import get_pad_tuple
 from ..util import get_const_tuple
 from ..nn.conv2d import conv2d_NCHWc_int8
 from .. import nn
@@ -92,10 +93,10 @@ def _create_tuning_space_int8(cfg, data, kernel, strides, padding, dilation, lay
                          "schedule template.".format(layout))
 
     is_kernel_1x1 = kh == 1 and kw == 1
-    ph, pw = padding if isinstance(padding, (tuple, list)) else (padding, padding)
+    pt, pl, pb, pr = get_pad_tuple(padding, kernel)
     sh, sw = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    oh = (h - kh + 2 * ph) // sh + 1
-    ow = (w - kw + 2 * pw) // sw + 1
+    oh = (h - kh + pt + pb) // sh + 1
+    ow = (w - kw + pl + pr) // sw + 1
 
     # Create schedule config
     cfg.define_split('tile_ic', ic, num_outputs=2, filter=lambda y: y.size[-1] % 4 == 0)

--- a/topi/python/topi/x86/depthwise_conv2d.py
+++ b/topi/python/topi/x86/depthwise_conv2d.py
@@ -204,10 +204,10 @@ def _topi_nn_depthwise_conv2d_NCHWc(*args, **kwargs):
 
     batch, in_channel, height, width = get_const_tuple(data.shape)
     filter_channel, channel_multiplier, kh, kw = get_const_tuple(kernel.shape)
-    ph, pw = padding if isinstance(padding, (tuple, list)) else (padding, padding)
+    pt, pl, pb, pr = get_pad_tuple(padding, kernel)
     sh, sw = strides if isinstance(strides, (tuple, list)) else (strides, strides)
-    out_height = (height - kh + 2 * ph) // sh + 1
-    out_width = (width - kw + 2 * pw) // sw + 1
+    out_height = (height - kh + pt + pb) // sh + 1
+    out_width = (width - kw + pl + pr) // sw + 1
     out_channel = filter_channel * channel_multiplier
 
     # get config here

--- a/topi/tests/python/test_topi_conv2d_int8.py
+++ b/topi/tests/python/test_topi_conv2d_int8.py
@@ -23,6 +23,7 @@ from tvm.autotvm.task.space import FallbackConfigEntity
 import topi
 import topi.testing
 from tvm.contrib.pickle_memoize import memoize
+from topi.nn.util import get_pad_tuple
 from topi.util import get_const_tuple
 
 from common import get_all_backend, Int8Fallback
@@ -31,7 +32,9 @@ oc_block_factor = 4
 
 
 def verify_conv2d_NCHWc_int8(batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation=1, add_bias=False, add_relu=False):
-    print("Workload: (%d, %d, %d, %d, %d, %d, %d, %d)" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+    pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel, kernel))
+    padding_sum = pad_top + pad_left + pad_bottom + pad_right
+    print("Workload: (%d, %d, %d, %d, %d, %d, %d, %d)" % (batch, in_channel, in_size, num_filter, kernel, stride, padding_sum, dilation))
 
     in_height = in_width = in_size
 
@@ -79,7 +82,7 @@ def verify_conv2d_NCHWc_int8(batch, in_channel, in_size, num_filter, kernel, str
 
         print("Running on target: %s" % device)
         with tvm.target.create(device):
-            C = topi.nn.conv2d(A, W, (stride, stride), (padding, padding), (dilation, dilation),
+            C = topi.nn.conv2d(A, W, (stride, stride), padding, (dilation, dilation),
                                layout='NCHW', out_dtype=dtype)
             if add_bias:
                 C = topi.add(C, bias)
@@ -92,11 +95,11 @@ def verify_conv2d_NCHWc_int8(batch, in_channel, in_size, num_filter, kernel, str
         b = tvm.nd.array(b_np, ctx)
         c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), ctx)
         if add_bias:
-            tvm.build(s, [A, W, bias, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
-            func = tvm.build(s, [A, W, bias, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            tvm.build(s, [A, W, bias, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding_sum, dilation))
+            func = tvm.build(s, [A, W, bias, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding_sum, dilation))
             func(a, w, b, c)
         else:
-            func = tvm.build(s, [A, W, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func = tvm.build(s, [A, W, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding_sum, dilation))
             func(a, w, c)
         tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=1e-5)
 
@@ -183,6 +186,23 @@ def test_conv2d_nchw():
         verify_conv2d_NCHWc_int8(7,   32, 149,  32, 3, 1, 0)
         verify_conv2d_NCHWc_int8(8,   32, 149,  32, 3, 1, 0)
         verify_conv2d_NCHWc_int8(32,  32, 149,  32, 3, 1, 0)
+
+        # Asymmetric padding
+        verify_conv2d_NCHWc_int8(1,   3,  224,  64,  7, 2, (0, 0, 1, 1))
+        verify_conv2d_NCHWc_int8(1,  64,   56, 128,  3, 1, (3, 3, 2, 2))
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64,  1, 1, (1, 2, 2, 1))
+        verify_conv2d_NCHWc_int8(1,  64,  288, 192,  1, 1, (1, 2))
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64,  3, 1, (3, 1))
+        verify_conv2d_NCHWc_int8(1, 128,   56, 384,  3, 1, (0, 2))
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64,  1, 1, "VALID")
+        verify_conv2d_NCHWc_int8(1, 388,   56,  64,  3, 1, "VALID")
+        verify_conv2d_NCHWc_int8(1, 512,   19,  64,  1, 1, "SAME")
+        verify_conv2d_NCHWc_int8(1,  64, 2048,  32,  2, 1, "SAME")
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64,  3, 1, (1, 2, 2, 1), add_relu=True)
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64,  5, 2, (1, 3), add_bias=True)
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64,  3, 1, "VALID", add_bias=True, add_relu=True)
+        verify_conv2d_NCHWc_int8(1,  64,   56,  64, 24, 1, "SAME", add_bias=True, add_relu=True)
+
 
 if __name__ == "__main__":
     test_conv2d_nchw()

--- a/topi/tests/python/test_topi_conv2d_int8.py
+++ b/topi/tests/python/test_topi_conv2d_int8.py
@@ -188,7 +188,7 @@ def test_conv2d_nchw():
         verify_conv2d_NCHWc_int8(32,  32, 149,  32, 3, 1, 0)
 
         # Asymmetric padding
-        verify_conv2d_NCHWc_int8(1,   3,  224,  64,  7, 2, (0, 0, 1, 1))
+        verify_conv2d_NCHWc_int8(1,  32,  224,  64,  7, 2, (0, 0, 1, 1))
         verify_conv2d_NCHWc_int8(1,  64,   56, 128,  3, 1, (3, 3, 2, 2))
         verify_conv2d_NCHWc_int8(1,  64,   56,  64,  1, 1, (1, 2, 2, 1))
         verify_conv2d_NCHWc_int8(1,  64,  288, 192,  1, 1, (1, 2))

--- a/topi/tests/python/test_topi_conv2d_nchw.py
+++ b/topi/tests/python/test_topi_conv2d_nchw.py
@@ -185,18 +185,23 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1,  256,   3, 126, 3, 1, 1)
 
     # Asymmetric padding
-    verify_conv2d_nchw(1,   3, 224,  64, 7, 2, (0, 0, 1, 1))
-    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (3, 3, 2, 2))
-    verify_conv2d_nchw(1,  64,  56,  64, 1, 1, (1, 2, 2, 1))
-    verify_conv2d_nchw(1,  64,  56,  64, 1, 1, (1, 2))
-    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (3, 1))
-    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (0, 2))
-    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (1, 2), use_cudnn=True)
-    verify_conv2d_nchw(1,  64,  56,  64, 1, 1, "VALID")
-    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, "VALID")
-    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, "VALID", use_cudnn=True)
-    # Currnt not working
-    #verify_conv2d_nchw(1,  64,  56,  64, 1, 1, "SAME")
+    verify_conv2d_nchw(1,   3,  224,  64,  7, 2, (0, 0, 1, 1))
+    verify_conv2d_nchw(1,  64,   56, 128,  3, 1, (3, 3, 2, 2))
+    verify_conv2d_nchw(1,  64,   56,  64,  1, 1, (1, 2, 2, 1))
+    verify_conv2d_nchw(1,  64,  288, 192,  1, 1, (1, 2))
+    verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (3, 1))
+    verify_conv2d_nchw(1, 128,   56, 384,  3, 1, (0, 2))
+    verify_conv2d_nchw(1,  64,  384,  64,  3, 1, (1, 2), use_cudnn=True)
+    verify_conv2d_nchw(1,  64,   56,  64,  1, 1, "VALID")
+    verify_conv2d_nchw(1, 388,   56,  64,  3, 1, "VALID")
+    verify_conv2d_nchw(1,  64, 1280,  48,  3, 1, "VALID", use_cudnn=True)
+    verify_conv2d_nchw(1, 512,   19,  64,  1, 1, "SAME")
+    verify_conv2d_nchw(1,  64, 2048,  32,  2, 1, "SAME")
+    verify_conv2d_nchw(1,  64,    8,  64,  3, 1, "SAME", use_cudnn=True)
+    verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 2, 2, 1), add_relu=True)
+    verify_conv2d_nchw(1,  64,   56,  64,  5, 2, (1, 3), add_bias=True)
+    verify_conv2d_nchw(1,  64,   56,  64,  3, 1, "VALID", add_bias=True, add_relu=True)
+    verify_conv2d_nchw(1,  64,   56,  64, 24, 1, "SAME", add_bias=True, add_relu=True)
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv2d_nchw.py
+++ b/topi/tests/python/test_topi_conv2d_nchw.py
@@ -189,7 +189,7 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (0, 2))
     verify_conv2d_nchw(1,  64,  56,  64, 1, 1, "VALID")
     verify_conv2d_nchw(1,  64,  56,  64, 3, 1, "VALID")
-    # Currnt not working 
+    # Currnt not working
     #verify_conv2d_nchw(1,  64,  56,  64, 1, 1, "SAME")
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv2d_nchw.py
+++ b/topi/tests/python/test_topi_conv2d_nchw.py
@@ -27,7 +27,8 @@ from topi.util import get_const_tuple
 
 from common import get_all_backend
 
-def verify_conv2d_nchw(batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation=1, add_bias=False, add_relu=False):
+def verify_conv2d_nchw(batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation=1, add_bias=False, add_relu=False,\
+        use_cudnn=False):
 
     pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel, kernel))
     padding_sum = pad_top + pad_left + pad_bottom + pad_right
@@ -89,6 +90,9 @@ def verify_conv2d_nchw(batch, in_channel, in_size, num_filter, kernel, stride, p
     for device in get_all_backend():
         with autotvm.tophub.context(device):  # load tophub pre-tuned parameters
             check_device(device)
+
+    if use_cudnn:
+        check_device("cuda -model=unknown -libs=cudnn")
 
 
 def test_conv2d_nchw():
@@ -187,10 +191,13 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1,  64,  56,  64, 1, 1, (1, 2))
     verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (3, 1))
     verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (0, 2))
+    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, (1, 2), use_cudnn=True)
     verify_conv2d_nchw(1,  64,  56,  64, 1, 1, "VALID")
     verify_conv2d_nchw(1,  64,  56,  64, 3, 1, "VALID")
+    verify_conv2d_nchw(1,  64,  56,  64, 3, 1, "VALID", use_cudnn=True)
     # Currnt not working
     #verify_conv2d_nchw(1,  64,  56,  64, 1, 1, "SAME")
+
 
 if __name__ == "__main__":
     test_conv2d_nchw()

--- a/topi/tests/python/test_topi_conv2d_nhwc.py
+++ b/topi/tests/python/test_topi_conv2d_nhwc.py
@@ -71,8 +71,13 @@ def test_conv2d_nhwc():
     verify_conv2d_nhwc(1, 256, 32, 256, 3, 1, "VALID")
     verify_conv2d_nhwc(4, 128, 16, 128, 5, 2, "VALID")
     verify_conv2d_nhwc(4, 128, 16, 256, 5, 2, "VALID")
+    verify_conv2d_nhwc(1, 128, 16, 256, 3, 2, (0, 0, 1, 1))
+    verify_conv2d_nhwc(1, 128, 16, 256, 3, 2, (1, 1, 2, 2))
+    verify_conv2d_nhwc(1, 128, 16, 128, 5, 2, (3, 3, 2, 2))
+    verify_conv2d_nhwc(1, 128, 16, 256, 3, 2, (0, 1, 2, 3))
     # dilation = 2
     verify_conv2d_nhwc(1, 256, 32, 256, 3, 1, "SAME", dilation=2)
+    verify_conv2d_nhwc(1, 256, 32, 256, 3, 1, (1, 1, 2, 2), dilation=2)
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv2d_winograd.py
+++ b/topi/tests/python/test_topi_conv2d_winograd.py
@@ -86,7 +86,6 @@ def verify_conv2d_nchw(batch, in_channel, in_size, num_filter, kernel, stride, p
             func(a, w, c)
 
         rtol = 1e-3
-
         tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=rtol)
 
 
@@ -137,20 +136,18 @@ def test_conv2d_nchw():
         verify_conv2d_nchw(2, 13, 71, 59, 3, 1, 1)
 
         # Asymmetric padding
-        verify_conv2d_nchw(1,   3,  224,  64,  7, 2, (0, 0, 1, 1))
-        verify_conv2d_nchw(1,  64,   56, 128,  3, 1, (3, 3, 2, 2), devices=['cuda'])
-        verify_conv2d_nchw(1,  64,   56,  64,  1, 1, (1, 2, 2, 1))
-        verify_conv2d_nchw(1,  56,  288, 256,  1, 1, (1, 2))
+        verify_conv2d_nchw(1,  32,   19,  64,  3, 1, (0, 0, 1, 1))
+        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 0, 1, 1))
+        verify_conv2d_nchw(1, 256,   19, 256,  3, 1, (1, 1))
+        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 0))
+        verify_conv2d_nchw(1,  64,   19,  64,  3, 1, "SAME")
+        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 1, 0, 1), add_relu=True)
+        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 0), add_bias=True)
+        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, "SAME", add_bias=True, add_relu=True)
         verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (3, 1), devices=['cuda'])
-        verify_conv2d_nchw(1,  64,   56, 512,  3, 1, (0, 2))
-        verify_conv2d_nchw(1,  64,   56,  64,  1, 1, "VALID")
+        verify_conv2d_nchw(1,  64,   56, 128,  3, 1, (3, 3, 2, 2), devices=['cuda'])
         verify_conv2d_nchw(1,  56,   56,  64,  3, 1, "VALID", devices=['cuda'])
-        verify_conv2d_nchw(1,  64,   19,  64,  1, 1, "SAME")
-        verify_conv2d_nchw(1,  64,   56,  32,  2, 1, "SAME", devices=['cuda'])
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 2, 2, 1), add_relu=True)
-        verify_conv2d_nchw(1,  64,   56,  64,  5, 2, (1, 3), add_bias=True)
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, "VALID", add_bias=True, add_relu=True)
-        verify_conv2d_nchw(1,  64,   56,  64, 24, 1, "SAME", add_bias=True, add_relu=True)
+        verify_conv2d_nchw(1,  64,   56,  32,  5, 1, "SAME", devices=['cuda'])
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv2d_winograd.py
+++ b/topi/tests/python/test_topi_conv2d_winograd.py
@@ -136,18 +136,18 @@ def test_conv2d_nchw():
         verify_conv2d_nchw(2, 13, 71, 59, 3, 1, 1)
 
         # Asymmetric padding
-        verify_conv2d_nchw(1,  32,   19,  64,  3, 1, (0, 0, 1, 1))
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 0, 1, 1))
-        verify_conv2d_nchw(1, 256,   19, 256,  3, 1, (1, 1))
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 0))
-        verify_conv2d_nchw(1,  64,   19,  64,  3, 1, "SAME")
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 1, 0, 1), add_relu=True)
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (1, 0), add_bias=True)
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, "SAME", add_bias=True, add_relu=True)
-        verify_conv2d_nchw(1,  64,   56,  64,  3, 1, (3, 1), devices=['cuda'])
-        verify_conv2d_nchw(1,  64,   56, 128,  3, 1, (3, 3, 2, 2), devices=['cuda'])
-        verify_conv2d_nchw(1,  56,   56,  64,  3, 1, "VALID", devices=['cuda'])
-        verify_conv2d_nchw(1,  64,   56,  32,  5, 1, "SAME", devices=['cuda'])
+        verify_conv2d_nchw(1,  64, 56,  64, 3, 1, (1, 1, 1, 1))
+        verify_conv2d_nchw(1, 128, 28, 128, 3, 1, (1, 1, 1, 1))
+        verify_conv2d_nchw(1, 256, 14, 256, 3, 1, (1, 1))
+        verify_conv2d_nchw(1, 512,  7, 512, 3, 1, "SAME")
+        verify_conv2d_nchw(2, 13, 71, 59, 3, 1, (1, 1, 1, 1))
+        verify_conv2d_nchw(2,  64, 56,  64, 3, 1, (1, 1, 1, 1), add_bias=True)
+        verify_conv2d_nchw(2,  64, 56,  64, 3, 1, (1, 1), add_relu=True)
+        verify_conv2d_nchw(2,  64, 56,  64, 3, 1, "SAME", add_relu=True, add_bias=True)
+        verify_conv2d_nchw(1, 128, 17, 192, 7, 1, (3, 1), devices=['cuda'])
+        verify_conv2d_nchw(1, 128, 17, 128, 7, 1, (3, 3, 2, 2), devices=['cuda'])
+        verify_conv2d_nchw(1, 160, 17, 160, 7, 1, "SAME", devices=['cuda'])
+        verify_conv2d_nchw(1,  48, 35,  64, 5, 1, "VALID", devices=['cuda'])
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv3d_ncdhw.py
+++ b/topi/tests/python/test_topi_conv3d_ncdhw.py
@@ -90,7 +90,6 @@ def verify_conv3d_ncdhw(batch, in_channel, in_size, num_filter, kernel, stride, 
         with autotvm.tophub.context(device):  # load tophub pre-tuned parameters
             check_device(device)
 
-
 def test_conv3d_ncdhw():
     #3DCNN  workloads
     verify_conv3d_ncdhw(1, 32, 32, 5, 1, 1, 0)
@@ -121,7 +120,6 @@ def test_conv3d_ncdhw():
     verify_conv3d_ncdhw(1, 32, 32, 1, 1, 1, (2, 1, 0))
     verify_conv3d_ncdhw(1, 32, 32, 1, 3, 1, "VALID")
     verify_conv3d_ncdhw(1, 32, 32, 5, 1, 1, "VALID")
-
 
 if __name__ == "__main__":
     test_conv3d_ncdhw()


### PR DESCRIPTION
The PR is to implement the 1st item in issue #2682. 

I tried to find as more as possible the places where padding is handled as symmetric. But there may be some missing. Please comment is your find more.

The following module/file are kept using symmetic padding due to interface limitaion or I am not sure if changing to asymmetric would cause any trouble.

topi/python/topi/x86/conv2d_alter_op.py
topi/python/topi/rocm/conv2d.py
topi/include/topi/nn.h
convolution with  'cudnn' lib. 



 