### PR TITLE
[Bugfix][Frontend][TF] Fix incorrect calculations in tf SLICE

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -639,7 +639,7 @@ def _slice():
         end = size
         for i in range(data_dim):
             if size[i] == -1:
-                end[i] = data_shape[i] - begin[i]
+                end[i] = data_shape[i]
             else:
                 end[i] += begin[i]
         return _op.strided_slice(inputs[0], begin=begin, end=end)

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -2209,14 +2209,15 @@ def _test_forward_slice_operation_input(input_value, begin_value, size_value):
     with tf.Graph().as_default():
         input_tensor = tf.placeholder(
             shape=input_data.shape, dtype=input_data.dtype, name="input")
-        begin_tensor = tf.expand_dims(begin_value, axis=0)
-        size_tensor = tf.expand_dims(size_value, axis=0)
-        slice_tensor = tf.slice(input_tensor, begin_tensor, size_tensor, name='slice_output')
+        tf.slice(input_tensor, begin_value, size_value, name='slice_output')
         compare_tf_with_tvm([input_data], ['input:0'], 'slice_output:0')
 
 
 def test_forward_slice():
-    _test_forward_slice_operation_input([1, 1], 0, 2)
+    _test_forward_slice_operation_input([1, 1], [0], [2])
+    _test_forward_slice_operation_input([0, 1, 2, 3], [3], [-1])
+    _test_forward_slice_operation_input([[0, 1, 2, 3], [4, 5, 6, 7]],
+                                        begin_value=[0, 1], size_value=[-1, -1])
 
 def test_forward_ceil():
     ishape = (1, 3, 10, 10)


### PR DESCRIPTION
* fix formula for calculating end indices when size[i] == -1. 
* add a test case for size[i] == -1
* discard expanding dimension of begin_value & end_value since
  it is needed only if you pass them as scalars, not as tensors. #4372 
* discard 'slice_tensor' variable so that implementation matches with
  the TF parser pattern
