### PR TITLE
[VTA] Fixed a crash issue in TSIM driver

### DIFF
--- a/vta/src/tsim/tsim_driver.cc
+++ b/vta/src/tsim/tsim_driver.cc
@@ -188,25 +188,23 @@ TVM_REGISTER_GLOBAL("vta.tsim.profiler_status")
 }  // namespace vta
 
 void* VTAMemAlloc(size_t size, int cached) {
-  void * addr = vta::vmem::VirtualMemoryManager::Global()->Alloc(size);
-  return reinterpret_cast<void*>(vta::vmem::VirtualMemoryManager::Global()->GetPhyAddr(addr));
+  return vta::vmem::VirtualMemoryManager::Global()->Alloc(size);
 }
 
 void VTAMemFree(void* buf) {
-  void * addr = vta::vmem::VirtualMemoryManager::Global()->GetAddr(reinterpret_cast<uint64_t>(buf));
-  vta::vmem::VirtualMemoryManager::Global()->Free(addr);
+  vta::vmem::VirtualMemoryManager::Global()->Free(buf);
 }
 
 vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
-  return reinterpret_cast<uint64_t>(reinterpret_cast<uint64_t*>(buf));
+  return vta::vmem::VirtualMemoryManager::Global()->GetPhyAddr(buf);
 }
 
 void VTAMemCopyFromHost(void* dst, const void* src, size_t size) {
-  vta::vmem::VirtualMemoryManager::Global()->MemCopyFromHost(dst, src, size);
+  memcpy(dst, src, size);
 }
 
 void VTAMemCopyToHost(void* dst, const void* src, size_t size) {
-  vta::vmem::VirtualMemoryManager::Global()->MemCopyToHost(dst, src, size);
+  memcpy(dst, src, size);
 }
 
 void VTAFlushCache(void* vir_addr, vta_phy_addr_t phy_addr, int size) {


### PR DESCRIPTION
This PR fixed a crash issue in running an end-to-end task with TSIM backend.

It takes around 57 M cycles to run resnet18 inference with current Chisel VTA. In addition, because of the multi-threading support (#4491) in simulating Chisel VTA, it only takes 5 min to perform the cycle-accurate simulation on my laptop computer.

@vegaluisjose @tmoreau89 Please review.