### PR TITLE
[ONNX] Use int64 for Shape op dtype

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -687,8 +687,7 @@ class Shape(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        # TODO(@jroesch): use shape_of once it has been fixed)
-        return _op.shape_of(inputs[0])
+        return _op.shape_of(inputs[0], "int64")
 
 class Cast(OnnxOpConverter):
     """ Operator converter for Cast.


### PR DESCRIPTION
The output type of [the ONNX Shape op](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shape) is int64 , but [the default dtype](https://github.com/apache/incubator-tvm/blob/master/python/tvm/relay/op/tensor.py#L888) of Relay shape_of is int32. 

We need int64 here; Otherwise I get an error when converting ONNX Resize op which comes from PyTorch master (won't happen with v1.3). The explanation is boring, so I won't write it here. 

please review @icemelon9 @soiferj @jwfromm 