### PR TITLE
[FIX][TOPI][X86] schedule dense pack

### DIFF
--- a/topi/python/topi/x86/dense.py
+++ b/topi/python/topi/x86/dense.py
@@ -59,8 +59,8 @@ def _declaration_dense_pack(cfg, data, weight, bias=None, out_dtype=None):
     M, K = get_const_tuple(data.shape) # batch, in_dim
     N, _ = get_const_tuple(weight.shape) # out_dim
     # create tuning space
-    cfg.define_split("tile_y", 32 if isinstance(M, tvm.expr.Var) else M, num_outputs=2)
-    cfg.define_split("tile_x", 32 if isinstance(N, tvm.expr.Var) else N, num_outputs=2)
+    cfg.define_split("tile_y", 32 if isinstance(M, tvm.expr.Var) else M, num_outputs=3)
+    cfg.define_split("tile_x", 32 if isinstance(N, tvm.expr.Var) else N, num_outputs=3)
     cfg.define_split("tile_k", 32 if isinstance(K, tvm.expr.Var) else K, num_outputs=2)
     if cfg.is_fallback:
         _default_dense_pack_config(cfg, M, N, K)


### PR DESCRIPTION
Fix bug for topi x86 dense schedule `_declaration_dense_nopack` function.  It's in topi/python/x86/dense.py. The original config defined in this function says the `tile_y` and `tile_x` have `num_outputs`=2, but at line 174 in the same file, the `_schedule_dense_pack_template` function needs 'tile_y' and 'tile_x' knobs to provide three split parts. I fixed the `num_outputs` to 3 and it works.