### PR TITLE
[DOCS] Mention Ninja build system in install/from_source.rst

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -107,7 +107,7 @@ The configuration of TVM can be modified by `config.cmake`.
       cmake ..
       make -j4
 
-  - You can also use Ninja build system instead of Unix Makefiles. It is said that Ninja runs faster than Makefiles.
+  - You can also use Ninja build system instead of Unix Makefiles. It can be faster to build than using Makefiles.
 
   .. code:: bash
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -107,6 +107,14 @@ The configuration of TVM can be modified by `config.cmake`.
       cmake ..
       make -j4
 
+  - You can also use Ninja build system instead of Unix Makefiles. It is said that Ninja runs faster than Makefiles.
+
+  .. code:: bash
+
+      cd build
+      cmake .. -G Ninja
+      ninja
+
 If everything goes well, we can go to :ref:`python-package-installation`
 
 Building on Windows


### PR DESCRIPTION
In the current doc, only `make` is mentioned in the build instruction.
https://docs.tvm.ai/install/from_source.html#build-the-shared-library
```bash
cd build
cmake ..
make -j4
```
I think it's worth mentioning that we can also use Ninja which is said to run faster than Makefiles.