### PR TITLE
[VTA] Prevent Chisel VTA linter changing the Scala code

### DIFF
--- a/vta/hardware/chisel/Makefile
+++ b/vta/hardware/chisel/Makefile
@@ -112,7 +112,7 @@ endif
 default: lint lib
 
 lint:
-	sbt scalafmt
+	sbt scalafmt --test
 
 lib: $(lib_path)
 


### PR DESCRIPTION
Previous lint command "format all files in the current project" quietly. The `--test` argument "throw exception on mis-formatted files, won't write to files".

See `--help` section in https://scalameta.org/scalafmt/docs/installation.html#--help