### PR TITLE
document full PYTHONPATH in setup

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -163,7 +163,7 @@ Method 1
    .. code:: bash
 
        export TVM_HOME=/path/to/tvm
-       export PYTHONPATH=$TVM_HOME/python:$TVM_HOME/topi/python:${PYTHONPATH}
+       export PYTHONPATH=$TVM_HOME/python:$TVM_HOME/topi/python:$TVM_HOME/nnvm/python:$TVM_HOME/vta/python:${PYTHONPATH}
 
 
 Method 2


### PR DESCRIPTION
Add the complete set of python directories to PYTHONPATH.
Without this one can't `import tvm`.

