### PR TITLE
[ONNX] Remove unnecessary cast of constants to int32

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1414,8 +1414,6 @@ class GraphProto(object):
                 self._num_param += 1
                 # We should convert scalar integers to int32, to normalize.
                 array = self._parse_array(t_proto)
-                if len(array.shape) == 0 and array.dtype == 'int64':
-                    array = _nd.array(array.asnumpy().astype('int32'))
                 self._params[node.output[0]] = array
                 self._nodes[node.output[0]] = new_var(
                     node.output[0],


### PR DESCRIPTION
This cast was introduced in #3387, but it causes an error in the following segment of a graph because one of the inputs to the concat op is int64 while the other is int32. In ONNX, unsqueeze(-1) is supposed to be int64, but relay makes it int32. The output of Shape is int64, after the fix in #4528. 

I don't know the context where this cast was introduced, but since the tests are passing without cast I assume it is no longer necessary. Can you review? @zhiics @jroesch 

I can explain why the output of Shape needs to be int64 (#4528), if desired. 
  
 
![image](https://user-images.githubusercontent.com/1776403/71346473-5261d500-25ab-11ea-9e32-37e82f090d5b.png)
