### PR TITLE
[Relay][AlterLayout] Broadcast with scalar shape

### DIFF
--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -200,6 +200,28 @@ inline int64_t GetConv2DSuperChannelsDim(const CallNode* call) {
 }
 
 /*!
+ * \brief Is single value tensor (scalar).
+ * \param expr The expr.
+ * \return True if single value tensor.
+ */
+inline bool IsScalar(const Expr& expr) {
+  if (auto tensor_type = expr->checked_type().as<TensorTypeNode>()) {
+    for (auto dim_index_expr : tensor_type->shape) {
+      if (auto dim_index = dim_index_expr.as<IntImm>()) {
+        if (dim_index->value != 1) {
+          return false;
+        }
+      } else {
+        return false;
+      }
+    }
+  } else {
+    return false;
+  }
+  return true;
+}
+
+/*!
  * \brief Create a Constant with a scalar
  *
  * \param dtype The data type.

--- a/src/relay/pass/transform_layout.h
+++ b/src/relay/pass/transform_layout.h
@@ -119,6 +119,11 @@ class TransformMemorizer : public NodeRef {
     Expr input_expr = raw;
     Layout new_src_layout = src_layout;
     if (src_layout.ndim_primal() < dst_layout.ndim_primal()) {
+      // If scalar, then no need of layout transformation as scalar can be broadcasted easily even
+      // if the other operand has a transformed layout.
+      if (IsScalar(input_expr)) {
+        return raw;
+      }
       int num_new_axis = dst_layout.ndim_primal() - src_layout.ndim_primal();
       new_src_layout = src_layout.ExpandPrimal(dst_layout);
       input_expr = MakeExpandDims(input_expr, 0, num_new_axis);


### PR DESCRIPTION
Relevant Issue - https://github.com/apache/incubator-tvm/issues/4508

Preventing insertion of layout transform and expand dims when the broadcast tensor is of scalar type.

@yzhliu 
