### PR TITLE
[RUNTIME] Remove Extension VTable in favor of Unified Object system.

### DIFF
--- a/apps/extension/Makefile
+++ b/apps/extension/Makefile
@@ -20,8 +20,7 @@ TVM_ROOT=$(shell cd ../..; pwd)
 PKG_CFLAGS = -std=c++11 -O2 -fPIC\
 	-I${TVM_ROOT}/include\
 	-I${TVM_ROOT}/3rdparty/dmlc-core/include\
-	-I${TVM_ROOT}/3rdparty/dlpack/include\
-	-I${TVM_ROOT}/3rdparty/HalideIR/src
+	-I${TVM_ROOT}/3rdparty/dlpack/include
 
 PKG_LDFLAGS =-L${TVM_ROOT}/build
 UNAME_S := $(shell uname -s)

--- a/apps/extension/python/tvm_ext/__init__.py
+++ b/apps/extension/python/tvm_ext/__init__.py
@@ -38,27 +38,15 @@ sym_add = tvm.get_global_func("tvm_ext.sym_add")
 ivec_create = tvm.get_global_func("tvm_ext.ivec_create")
 ivec_get = tvm.get_global_func("tvm_ext.ivec_get")
 
-class IntVec(object):
+@tvm.register_object("tvm_ext.IntVector")
+class IntVec(tvm.Object):
     """Example for using extension class in c++ """
-    _tvm_tcode = 17
-
-    def __init__(self, handle):
-        self.handle = handle
-
-    def __del__(self):
-        # You can also call your own customized
-        # deleter if you can free it via your own FFI.
-        tvm.nd.free_extension_handle(self.handle, self.__class__._tvm_tcode)
-
     @property
     def _tvm_handle(self):
         return self.handle.value
 
     def __getitem__(self, idx):
         return ivec_get(self, idx)
-
-# Register IntVec extension on python side.
-tvm.register_extension(IntVec, IntVec)
 
 
 nd_create = tvm.get_global_func("tvm_ext.nd_create")

--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -235,14 +235,6 @@ TVM_DLL int TVMModGetFunction(TVMModuleHandle mod,
                               TVMFunctionHandle *out);
 
 /*!
- * \brief Free front-end extension type resource.
- * \param handle The extension handle.
- * \param type_code The type of of the extension type.
- * \return 0 when success, -1 when failure happens
- */
-TVM_DLL int TVMExtTypeFree(void* handle, int type_code);
-
-/*!
  * \brief Free the Module
  * \param mod The module to be freed.
  *

--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -311,15 +311,6 @@ class Registry {
   TVM_STR_CONCAT(TVM_FUNC_REG_VAR_DEF, __COUNTER__) =            \
       ::tvm::runtime::Registry::Register(OpName)
 
-/*!
- * \brief Macro to register extension type.
- *  This must be registered in a cc file
- *  after the trait extension_type_info is defined.
- */
-#define TVM_REGISTER_EXT_TYPE(T)                                 \
-  TVM_STR_CONCAT(TVM_TYPE_REG_VAR_DEF, __COUNTER__) =            \
-      ::tvm::runtime::ExtTypeVTable::Register_<T>()
-
 }  // namespace runtime
 }  // namespace tvm
 #endif  // TVM_RUNTIME_REGISTRY_H_

--- a/python/tvm/_ffi/ndarray.py
+++ b/python/tvm/_ffi/ndarray.py
@@ -299,20 +299,6 @@ class NDArrayBase(_NDArrayBase):
         raise ValueError("Unsupported target type %s" % str(type(target)))
 
 
-def free_extension_handle(handle, type_code):
-    """Free c++ extension type handle
-
-    Parameters
-    ----------
-    handle : ctypes.c_void_p
-        The handle to the extension type.
-
-    type_code : int
-         The tyoe code
-    """
-    check_call(_LIB.TVMExtTypeFree(handle, ctypes.c_int(type_code)))
-
-
 def register_extension(cls, fcreate=None):
     """Register a extension class to TVM.
 

--- a/python/tvm/ndarray.py
+++ b/python/tvm/ndarray.py
@@ -26,7 +26,7 @@ import numpy as _np
 from ._ffi.ndarray import TVMContext, TVMType, NDArrayBase
 from ._ffi.ndarray import context, empty, from_dlpack
 from ._ffi.ndarray import _set_class_ndarray
-from ._ffi.ndarray import register_extension, free_extension_handle
+from ._ffi.ndarray import register_extension
 
 class NDArray(NDArrayBase):
     """Lightweight NDArray class of TVM runtime.


### PR DESCRIPTION
Before the unified object protocol, we support pass
additional extension objects around by declaring a type as an extension type.
The old extension mechanism requires the types to register their
constructor and deleter to a VTable and does not enjoy the benefit of the
self-contained deletion property of the new Object system.

This PR upgrades the extension example to make use of the new object system
and removed the old Extension VTable.

Note that the register_extension funtion in the python side continues to work
when the passed argument does not require explicit container copy/deletion,
which covers the current usecases of the extension mechanism.
