### PR TITLE
[Runtime] Fix NDArray SaveDLTensor declaration and implementation signature different

### DIFF
--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -228,7 +228,7 @@ struct array_type_info<NDArray> {
  * \param strm The outpu stream
  * \param tensor The tensor to be saved.
  */
-inline bool SaveDLTensor(dmlc::Stream* strm, const DLTensor* tensor);
+inline bool SaveDLTensor(dmlc::Stream* strm, DLTensor* tensor);
 
 /*!
  * \brief Reference counted Container object used to back NDArray.


### PR DESCRIPTION
`SaveDLTensor` function declaration is `const DLTensor* tensor`, but implementation is `DLTensor*`, if we pass `const DLTensor*`, we could compile successfully. However, when we run tvm, we will meet symbol can not find. We need to unify the interface and implementation so that we could avoid this runtime error.

@zhiics @tqchen please help to review
