### PR TITLE
[Quantization] Make calibration faster and more memory usage friendly

### DIFF
--- a/python/tvm/relay/quantize/_calibrate.py
+++ b/python/tvm/relay/quantize/_calibrate.py
@@ -52,7 +52,6 @@ def _kl_scale(mod, dataset, split_by=-1):
 
     scales = []
     split_by = num_outputs if split_by == -1 else split_by
-    print("split_by:", split_by)
     import time
     t1 = time.time()
     for i in range(0, num_outputs, split_by):
@@ -61,7 +60,7 @@ def _kl_scale(mod, dataset, split_by=-1):
             runtime.set_input(**batch)
             runtime.run()
             for j in range(i, min(i+split_by, num_outputs)):
-                outputs[j-i].append(runtime.get_output(i).asnumpy())
+                outputs[j-i].append(runtime.get_output(j).asnumpy())
         samples = [np.concatenate(output).reshape(-1) for output in outputs]
 
         with mp.Pool() as pool:
@@ -91,13 +90,13 @@ def _kl_scale(mod, dataset, split_by=-1):
             print(scales2)
             np.save("scales2.npy", scales2)
 
-    def fun(_):
+    def func(_):
         scale = scales[func.scale_idx]
-        fun.scale_idx += 1
+        func.scale_idx += 1
         return scale
-    fun.scale_idx = 0
+    func.scale_idx = 0
 
-    return fun
+    return func
 
 
 def _set_params(mod, input_scale_func, weight_scale_func):

--- a/python/tvm/relay/quantize/_calibrate.py
+++ b/python/tvm/relay/quantize/_calibrate.py
@@ -52,8 +52,6 @@ def _kl_scale(mod, dataset, split_by=-1):
 
     scales = []
     split_by = num_outputs if split_by == -1 else split_by
-    import time
-    t1 = time.time()
     for i in range(0, num_outputs, split_by):
         outputs = [[] for i in range(min(split_by, num_outputs - i))]
         for batch in dataset:
@@ -66,29 +64,6 @@ def _kl_scale(mod, dataset, split_by=-1):
         with mp.Pool() as pool:
             logging.info("finding threshold with kl for calibration...")
             scales += list(pool.map(_find_scale_by_kl, samples))
-
-    print("Elapsed:", time.time() - t1)
-    print(scales)
-    np.save("scales1.npy", scales)
-
-    if False:
-        t1 = time.time()
-        outputs = [[] for i in range(num_outputs)]
-        for batch in dataset:
-            runtime.set_input(**batch)
-            runtime.run()
-            for i in range(num_outputs):
-                output = runtime.get_output(i).asnumpy()
-                outputs[i].append(output)
-        for i in range(num_outputs):
-            outputs[i] = np.concatenate(outputs[i]).reshape(-1)
-
-        with mp.Pool() as pool:
-            logging.info("finding threshold with kl for calibration...")
-            scales2 = list(pool.map(_find_scale_by_kl, outputs))
-            print("Elapsed:", time.time() - t1)
-            print(scales2)
-            np.save("scales2.npy", scales2)
 
     def func(_):
         scale = scales[func.scale_idx]

--- a/python/tvm/relay/quantize/_calibrate.py
+++ b/python/tvm/relay/quantize/_calibrate.py
@@ -71,7 +71,7 @@ def _kl_scale(mod, dataset, split_by=-1):
     print(scales)
     np.save("scales1.npy", scales)
 
-    if True:
+    if False:
         t1 = time.time()
         outputs = [[] for i in range(num_outputs)]
         for batch in dataset:

--- a/python/tvm/relay/quantize/kl_divergence.py
+++ b/python/tvm/relay/quantize/kl_divergence.py
@@ -45,7 +45,7 @@ def _find_scale_by_kl(arr, quantized_dtype='int8',
         return ctypes.cast(ptr, ctypes.c_void_p)
 
     hist, hist_edges = np.histogram(arr, bins=num_bins, range=(-thres, thres))
-    hist_ptr = get_pointer(hist, ctypes.c_int64)
+    hist_ptr = get_pointer(hist.astype(np.int32), ctypes.c_int)
     hist_edges_ptr = get_pointer(hist_edges, ctypes.c_float)
 
     return _quantize.FindScaleByKLMinimization(hist_ptr, hist_edges_ptr,

--- a/python/tvm/relay/quantize/kl_divergence.py
+++ b/python/tvm/relay/quantize/kl_divergence.py
@@ -16,42 +16,12 @@
 # under the License.
 """Find optimal scale for quantization by minimizing KL-divergence"""
 
-try:
-    from scipy import stats
-except ImportError:
-    stats = None
-
-import numpy as np
 import ctypes
+import numpy as np
 
 from . import _quantize
 
-def _get_pointer(arr, ctypes_type):
-    ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes_type))
-    return ctypes.cast(ptr, ctypes.c_void_p)
 
-
-def _smooth_distribution(p, eps=0.0001):
-    """Given a discrete distribution (may have not been normalized to 1),
-    smooth it by replacing zeros with eps multiplied by a scaling factor and taking the
-    corresponding amount off the non-zero values.
-    Ref: http://hanj.cs.illinois.edu/cs412/bk3/KL-divergence.pdf
-    """
-    is_zeros = (p == 0).astype(np.float32)
-    is_nonzeros = (p != 0).astype(np.float32)
-    n_zeros = is_zeros.sum()
-    n_nonzeros = p.size - n_zeros
-    if not n_nonzeros:
-        raise ValueError('The discrete probability distribution is malformed. All entries are 0.')
-    eps1 = eps * float(n_zeros) / float(n_nonzeros)
-    assert eps1 < 1.0, 'n_zeros=%d, n_nonzeros=%d, eps1=%f' % (n_zeros, n_nonzeros, eps1)
-    hist = p.astype(np.float32)
-    hist += eps * is_zeros + (-eps1) * is_nonzeros
-    assert (hist <= 0).sum() == 0
-    return hist
-
-
-# pylint: disable=invalid-name
 def _find_scale_by_kl(arr, quantized_dtype='int8', num_bins=8001, num_quantized_bins=255):
     """Given a tensor, find the optimal threshold for quantizing it.
     The reference distribution is `q`, and the candidate distribution is `p`.
@@ -61,9 +31,6 @@ def _find_scale_by_kl(arr, quantized_dtype='int8', num_bins=8001, num_quantized_
     http://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf
     """
     assert isinstance(arr, np.ndarray)
-    assert stats is not None, "scipy needs to be installed for \
-    utilizing kl calibration during quantization"
-
     min_val = np.min(arr)
     max_val = np.max(arr)
     th = max(abs(min_val), abs(max_val))
@@ -72,75 +39,13 @@ def _find_scale_by_kl(arr, quantized_dtype='int8', num_bins=8001, num_quantized_
         # We need to move negative bins to positive bins to fit uint8 range.
         num_quantized_bins = num_quantized_bins * 2 + 1
 
+    def get_pointer(arr, ctypes_type):
+        ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes_type))
+        return ctypes.cast(ptr, ctypes.c_void_p)
+
     hist, hist_edges = np.histogram(arr, bins=num_bins, range=(-th, th))
-    hist_ptr = _get_pointer(hist, ctypes.c_int64)
-    hist_edges_ptr = _get_pointer(hist_edges, ctypes.c_float)
-    import time
-    t1 = time.time()
-    th_cpp = _quantize.FindScaleByKL(hist_ptr, hist_edges_ptr,
-                                 num_bins, num_quantized_bins)
-    elapsed_cpp = time.time() - t1
+    hist_ptr = get_pointer(hist, ctypes.c_int64)
+    hist_edges_ptr = get_pointer(hist_edges, ctypes.c_float)
 
-    zero_bin_idx = num_bins // 2
-    num_half_quantized_bins = num_quantized_bins // 2
-
-    t1 = time.time()
-    thresholds = np.zeros(num_bins // 2 + 1 - num_quantized_bins // 2)
-    divergence = np.zeros_like(thresholds)
-    quantized_bins = np.zeros(num_quantized_bins, dtype=np.int32)
-    # i means the number of bins on half axis excluding the zero bin.
-    for i in range(num_quantized_bins // 2,
-                   num_bins // 2 + 1):
-        p_bin_idx_start = zero_bin_idx - i
-        p_bin_idx_stop = zero_bin_idx + i + 1
-        thresholds[i - num_half_quantized_bins] = hist_edges[p_bin_idx_stop]
-        sliced_nd_hist = hist[p_bin_idx_start:p_bin_idx_stop]
-
-        # generate reference distribution p
-        p = sliced_nd_hist.copy()
-        assert p.size % 2 == 1
-        assert p.size >= num_quantized_bins
-        # put left outlier count in p[0]
-        left_outlier_count = np.sum(hist[0:p_bin_idx_start])
-        p[0] += left_outlier_count
-        # put right outlier count in p[-1]
-        right_outlier_count = np.sum(hist[p_bin_idx_stop:])
-        p[-1] += right_outlier_count
-        # is_nonzeros[k] indicates whether hist[k] is nonzero
-        is_nonzeros = (p != 0).astype(np.int32)
-
-        # calculate how many bins should be merged to generate quantized distribution q
-        num_merged_bins = sliced_nd_hist.size // num_quantized_bins
-        # merge hist into num_quantized_bins bins
-        for j in range(num_quantized_bins):
-            start = j * num_merged_bins
-            stop = start + num_merged_bins
-            quantized_bins[j] = sliced_nd_hist[start:stop].sum()
-        quantized_bins[-1] += sliced_nd_hist[num_quantized_bins * num_merged_bins:].sum()
-        # expand quantized_bins into p.size bins
-        q = np.zeros(sliced_nd_hist.size, dtype=np.float32)
-        for j in range(num_quantized_bins):
-            start = j * num_merged_bins
-            if j == num_quantized_bins - 1:
-                stop = len(is_nonzeros)
-            else:
-                stop = start + num_merged_bins
-            norm = is_nonzeros[start:stop].sum()
-            if norm != 0:
-                q[start:stop] = float(quantized_bins[j]) / float(norm)
-        q[p == 0] = 0
-        p = _smooth_distribution(p)
-        # There is a chance that q is an invalid probability distribution.
-        try:
-            q = _smooth_distribution(q)
-        except ValueError:
-            divergence[i - num_half_quantized_bins] = float("inf")
-        divergence[i - num_half_quantized_bins] = stats.entropy(p, q)
-
-    min_divergence_idx = np.argmin(divergence)
-    opt_th = thresholds[min_divergence_idx]
-    print("py elapsed:", time.time() - t1)
-    print("cpp elapsed:", elapsed_cpp)
-    print("py thres:", opt_th)
-    print("cpp thres:", th_cpp)
-    return opt_th
+    return _quantize.FindScaleByKLMinimization(hist_ptr, hist_edges_ptr,
+                                               num_bins, num_quantized_bins)

--- a/python/tvm/relay/quantize/kl_divergence.py
+++ b/python/tvm/relay/quantize/kl_divergence.py
@@ -34,7 +34,7 @@ def _find_scale_by_kl(arr, quantized_dtype='int8',
     assert isinstance(arr, np.ndarray)
     min_val = np.min(arr)
     max_val = np.max(arr)
-    th = max(abs(min_val), abs(max_val))
+    thres = max(abs(min_val), abs(max_val))
 
     if min_val >= 0 and quantized_dtype in ['uint8']:
         # We need to move negative bins to positive bins to fit uint8 range.
@@ -44,7 +44,7 @@ def _find_scale_by_kl(arr, quantized_dtype='int8',
         ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes_type))
         return ctypes.cast(ptr, ctypes.c_void_p)
 
-    hist, hist_edges = np.histogram(arr, bins=num_bins, range=(-th, th))
+    hist, hist_edges = np.histogram(arr, bins=num_bins, range=(-thres, thres))
     hist_ptr = get_pointer(hist, ctypes.c_int64)
     hist_edges_ptr = get_pointer(hist_edges, ctypes.c_float)
 

--- a/python/tvm/relay/quantize/kl_divergence.py
+++ b/python/tvm/relay/quantize/kl_divergence.py
@@ -22,7 +22,8 @@ import numpy as np
 from . import _quantize
 
 
-def _find_scale_by_kl(arr, quantized_dtype='int8', num_bins=8001, num_quantized_bins=255):
+def _find_scale_by_kl(arr, quantized_dtype='int8',
+                      num_bins=8001, num_quantized_bins=255):
     """Given a tensor, find the optimal threshold for quantizing it.
     The reference distribution is `q`, and the candidate distribution is `p`.
     `q` is a truncated version of the original distribution.

--- a/python/tvm/relay/quantize/kl_divergence.py
+++ b/python/tvm/relay/quantize/kl_divergence.py
@@ -22,6 +22,14 @@ except ImportError:
     stats = None
 
 import numpy as np
+import ctypes
+
+from . import _quantize
+
+def _get_pointer(arr, ctypes_type):
+    print(arr.dtype)
+    ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes_type))
+    return ctypes.cast(ptr, ctypes.c_void_p)
 
 
 def _smooth_distribution(p, eps=0.0001):
@@ -66,9 +74,19 @@ def _find_scale_by_kl(arr, quantized_dtype='int8', num_bins=8001, num_quantized_
         num_quantized_bins = num_quantized_bins * 2 + 1
 
     hist, hist_edges = np.histogram(arr, bins=num_bins, range=(-th, th))
+    print("arr.shape, hist.shape, hist_edges.shape:", arr.shape, hist.shape, hist_edges.shape)
+    hist_ptr = _get_pointer(hist, ctypes.c_int64)
+    hist_edges_ptr = _get_pointer(hist_edges, ctypes.c_float)
+    print(hist[:10])
+    print(hist_edges[:10])
+    th = _quantize.FindScaleByKL(hist_ptr, hist_edges_ptr,
+                                 num_bins, num_quantized_bins)
+    print("thres from c++:", th)
     zero_bin_idx = num_bins // 2
     num_half_quantized_bins = num_quantized_bins // 2
 
+    import time
+    t1 = time.time()
     thresholds = np.zeros(num_bins // 2 + 1 - num_quantized_bins // 2)
     divergence = np.zeros_like(thresholds)
     quantized_bins = np.zeros(num_quantized_bins, dtype=np.int32)
@@ -123,4 +141,5 @@ def _find_scale_by_kl(arr, quantized_dtype='int8', num_bins=8001, num_quantized_
 
     min_divergence_idx = np.argmin(divergence)
     opt_th = thresholds[min_divergence_idx]
+    print("KL elapsed:", time.time() - t1)
     return opt_th

--- a/python/tvm/relay/quantize/quantize.py
+++ b/python/tvm/relay/quantize/quantize.py
@@ -81,7 +81,8 @@ class QConfig(NodeBase):
         "do_simulation": False,
         "round_for_shift": True,
         "debug_enabled_ops": None,
-        "rounding": "UPWARD"
+        "rounding": "UPWARD",
+        "calibrate_split_by": -1,
     }
 
     # pylint: disable=no-member

--- a/python/tvm/relay/quantize/quantize.py
+++ b/python/tvm/relay/quantize/quantize.py
@@ -82,7 +82,7 @@ class QConfig(NodeBase):
         "round_for_shift": True,
         "debug_enabled_ops": None,
         "rounding": "UPWARD",
-        "calibrate_split_by": -1,
+        "calibrate_chunk_by": -1,
     }
 
     # pylint: disable=no-member

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -87,9 +87,9 @@ static float ComputeEntropy(std::vector<float>* p_ptr, std::vector<float>* q_ptr
 }
 
 float MinimizeKL(const std::vector<int64_t>& hist,
-		 const std::vector<float>& hist_edges,
-		 int num_bins,
-		 int num_quantized_bins) {
+                 const std::vector<float>& hist_edges,
+                 int num_bins,
+                 int num_quantized_bins) {
   const int zero_bin_idx = num_bins / 2;
   const int num_half_quantized_bins = num_quantized_bins / 2;
   std::vector<float> thresholds(num_bins / 2 + 1 - num_quantized_bins / 2, 0.f);

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -217,7 +217,7 @@ TVM_REGISTER_API("relay._quantize.CreateStatsCollector")
 .set_body_typed(CreateStatsCollector);
 
 
-TVM_REGISTER_API("relay._quantize.FindScaleByKL")
+TVM_REGISTER_API("relay._quantize.FindScaleByKLMinimization")
 .set_body([](TVMArgs args, TVMRetValue *ret) {
   int64_t* hist_ptr = static_cast<int64_t*>(static_cast<void*>(args[0]));
   float* hist_edges_ptr = static_cast<float*>(static_cast<void*>(args[1]));

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -77,7 +77,7 @@ static float ComputeEntropy(float* p, float* q, size_t size) {
   return ret;
 }
 
-float MinimizeKL(const std::vector<int64_t>& hist,
+float MinimizeKL(const std::vector<int>& hist,
                  const std::vector<float>& hist_edges,
                  int num_bins, int num_quantized_bins) {
   const int zero_bin_idx = num_bins / 2;
@@ -208,11 +208,11 @@ TVM_REGISTER_API("relay._quantize.CreateStatsCollector")
 
 TVM_REGISTER_API("relay._quantize.FindScaleByKLMinimization")
 .set_body([](TVMArgs args, TVMRetValue *ret) {
-  int64_t* hist_ptr = static_cast<int64_t*>(static_cast<void*>(args[0]));
+  int* hist_ptr = static_cast<int*>(static_cast<void*>(args[0]));
   float* hist_edges_ptr = static_cast<float*>(static_cast<void*>(args[1]));
   int num_bins = args[2];
   int num_quantized_bins = args[3];
-  std::vector<int64_t> hist(hist_ptr, hist_ptr + num_bins);
+  std::vector<int> hist(hist_ptr, hist_ptr + num_bins);
   std::vector<float> hist_edges(hist_edges_ptr, hist_edges_ptr + num_bins + 1);
   ret[0] = MinimizeKL(hist, hist_edges, num_bins, num_quantized_bins);
 });

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -23,6 +23,7 @@
  *
  * \brief Create profile graph and calibrate on dataset
  */
+#include <numeric>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/op.h>
@@ -31,6 +32,126 @@
 namespace tvm {
 namespace relay {
 namespace quantize {
+
+// KL divergence minimization code is adapted from MXNet.
+// The original one is in incubator-mxnet/src/operator/quantization/calibrate.cc
+static std::vector<float> SmoothDistribution(const std::vector<float>& p,
+					     const float eps = 0.0001) {
+  std::vector<size_t> is_zeros(p.size());
+  std::vector<size_t> is_nonzeros(p.size());
+  {
+    auto it = p.begin();
+    std::generate(is_zeros.begin(), is_zeros.end(),
+                  [&it]() { return static_cast<size_t>(*(it++) == 0.f); });
+  }
+  {
+    auto it = p.begin();
+    std::generate(is_nonzeros.begin(), is_nonzeros.end(),
+                  [&it]() { return static_cast<size_t>(*(it++) != 0.f); });
+  }
+
+  size_t n_zeros = std::accumulate(is_zeros.begin(), is_zeros.end(), 0);
+  size_t n_nonzeros = p.size() - n_zeros;
+  if (!n_nonzeros) {
+    // The discrete probability distribution is malformed. All entries are 0.
+    return std::vector<float>();
+  }
+  float eps1 = eps * static_cast<float>(n_zeros) / static_cast<float>(n_nonzeros);
+  if (eps1 >= 1.0) return std::vector<float>();
+  auto ret = p;
+  for (size_t i = 0; i < p.size(); i++) {
+    ret[i] += eps * is_zeros[i] - eps1 * is_nonzeros[i];
+  }
+  return ret;
+}
+
+static float ComputeEntropy(std::vector<float>* p_ptr, std::vector<float>* q_ptr) {
+  std::vector<float>& p = *p_ptr;
+  std::vector<float>& q = *q_ptr;
+  CHECK_EQ(p.size(), q.size());
+  float p_sum = std::accumulate(p.begin(), p.end(), 0.f);
+  float q_sum = std::accumulate(q.begin(), q.end(), 0.f);
+  for (auto& it : p) {
+    it = it / p_sum;
+  }
+
+  for (auto& it : q) {
+    it = it / q_sum;
+  }
+  float ret = 0;
+  for (size_t i = 0; i < p.size(); i++) {
+    CHECK(p[i] > 0 && q[i] > 0);
+    if (p[i] && q[i]) ret += p[i] * std::log(p[i] / q[i]);
+  }
+  return ret;
+}
+
+float MinimizeKL(const std::vector<int64_t>& hist,
+		 const std::vector<float>& hist_edges,
+		 int num_bins,
+		 int num_quantized_bins) {
+  const int zero_bin_idx = num_bins / 2;
+  const int num_half_quantized_bins = num_quantized_bins / 2;
+  std::vector<float> thresholds(num_bins / 2 + 1 - num_quantized_bins / 2, 0.f);
+  std::vector<float> divergence(thresholds.size(), 0.f);
+  std::vector<float> quantized_bins(num_quantized_bins, 0);
+  for (int i = num_quantized_bins / 2; i < zero_bin_idx + 1; ++i) {
+    const int p_bin_idx_start = zero_bin_idx - i;
+    const int p_bin_idx_stop = zero_bin_idx + i + 1;
+    thresholds[i - num_half_quantized_bins] = hist_edges[p_bin_idx_stop];
+
+    std::vector<int> sliced_nd_hist(p_bin_idx_stop - p_bin_idx_start);
+    std::vector<float> p(p_bin_idx_stop - p_bin_idx_start);
+    p[0] = 0;
+    p.back() = 0;
+    for (int j = 0; j < num_bins; j++) {
+      if (j <= p_bin_idx_start) {
+        p[0] += hist[j];
+      } else if (j >= p_bin_idx_stop) {
+        p.back() += hist[j];
+      } else {
+        sliced_nd_hist[j - p_bin_idx_start] = hist[j];
+        p[j - p_bin_idx_start] = hist[j];
+      }
+    }
+    // calculate how many bins should be merged to generate quantized distribution q
+    const auto num_merged_bins = sliced_nd_hist.size() / num_quantized_bins;
+    for (int j = 0; j < num_quantized_bins; j++) {
+      const int start = j * num_merged_bins;
+      const int stop = (j + 1) * num_merged_bins;
+      quantized_bins[j] =
+          std::accumulate(sliced_nd_hist.begin() + start, sliced_nd_hist.begin() + stop, 0);
+    }
+    quantized_bins.back() += std::accumulate(
+        sliced_nd_hist.begin() + static_cast<int>(num_quantized_bins * num_merged_bins),
+        sliced_nd_hist.end(), 0);
+    // expand quantized_bins into p.size bins
+    std::vector<float> q(sliced_nd_hist.size(), 0);
+    for (int j = 0; j < num_quantized_bins; j++) {
+      const int start = j * num_merged_bins;
+      const int stop = (j == num_quantized_bins - 1) ? q.size() : ((j + 1) * num_merged_bins);
+      int norm = std::count_if(sliced_nd_hist.begin() + start, sliced_nd_hist.begin() + stop,
+                               [](size_t i) { return i != 0; });
+      if (norm) {
+        for (int k = start; k < stop; k++) {
+          if (p[k]) q[k] = quantized_bins[j] / norm;
+        }
+      }
+    }
+    p = SmoothDistribution(p);
+    q = SmoothDistribution(q);
+
+    if (!q.size()) {
+      divergence[i - num_half_quantized_bins] = std::numeric_limits<float>::infinity();
+    } else {
+      divergence[i - num_half_quantized_bins] = ComputeEntropy(&p, &q);
+    }
+
+  }
+  auto min_divergence_idx = std::distance(std::min_element(divergence.begin(), divergence.end()),
+					  divergence.begin());
+  return thresholds[min_divergence_idx];;
+}
 
 class StatsCollector : private ExprMutator {
  public:
@@ -99,12 +220,12 @@ TVM_REGISTER_API("relay._quantize.CreateStatsCollector")
 TVM_REGISTER_API("relay._quantize.FindScaleByKL")
 .set_body([](TVMArgs args, TVMRetValue *ret) {
   int64_t* hist_ptr = static_cast<int64_t*>(static_cast<void*>(args[0]));
-  float* hist_edge_ptr = static_cast<float*>(static_cast<void*>(args[1]));
+  float* hist_edges_ptr = static_cast<float*>(static_cast<void*>(args[1]));
   int num_bins = args[2];
   int num_quantized_bins = args[3];
   std::vector<int64_t> hist(hist_ptr, hist_ptr + num_bins);
-  std::vector<float> hist_edge(hist_edge_ptr, hist_edge_ptr + num_bins + 1);
-  ret[0] = 0.5;
+  std::vector<float> hist_edges(hist_edges_ptr, hist_edges_ptr + num_bins + 1);
+  ret[0] = MinimizeKL(hist, hist_edges, num_bins, num_quantized_bins);
 });
 
 }  // namespace quantize

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -23,10 +23,10 @@
  *
  * \brief Create profile graph and calibrate on dataset
  */
-#include <numeric>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/op.h>
+#include <numeric>
 #include "./quantize.h"
 
 namespace tvm {
@@ -36,7 +36,7 @@ namespace quantize {
 // KL divergence minimization code is adapted from MXNet.
 // The original one is in incubator-mxnet/src/operator/quantization/calibrate.cc
 static std::vector<float> SmoothDistribution(const std::vector<float>& p,
-					     const float eps = 0.0001) {
+                                             const float eps = 0.0001) {
   std::vector<size_t> is_zeros(p.size());
   std::vector<size_t> is_nonzeros(p.size());
   {
@@ -49,7 +49,6 @@ static std::vector<float> SmoothDistribution(const std::vector<float>& p,
     std::generate(is_nonzeros.begin(), is_nonzeros.end(),
                   [&it]() { return static_cast<size_t>(*(it++) != 0.f); });
   }
-
   size_t n_zeros = std::accumulate(is_zeros.begin(), is_zeros.end(), 0);
   size_t n_nonzeros = p.size() - n_zeros;
   if (!n_nonzeros) {
@@ -74,7 +73,6 @@ static float ComputeEntropy(std::vector<float>* p_ptr, std::vector<float>* q_ptr
   for (auto& it : p) {
     it = it / p_sum;
   }
-
   for (auto& it : q) {
     it = it / q_sum;
   }
@@ -88,8 +86,7 @@ static float ComputeEntropy(std::vector<float>* p_ptr, std::vector<float>* q_ptr
 
 float MinimizeKL(const std::vector<int64_t>& hist,
                  const std::vector<float>& hist_edges,
-                 int num_bins,
-                 int num_quantized_bins) {
+                 int num_bins, int num_quantized_bins) {
   const int zero_bin_idx = num_bins / 2;
   const int num_half_quantized_bins = num_quantized_bins / 2;
   std::vector<float> thresholds(num_bins / 2 + 1 - num_quantized_bins / 2, 0.f);
@@ -146,10 +143,9 @@ float MinimizeKL(const std::vector<int64_t>& hist,
     } else {
       divergence[i - num_half_quantized_bins] = ComputeEntropy(&p, &q);
     }
-
   }
   auto min_divergence_idx = std::distance(divergence.begin(),
-					  std::min_element(divergence.begin(), divergence.end()));
+                                          std::min_element(divergence.begin(), divergence.end()));
   return thresholds[min_divergence_idx];;
 }
 

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -148,8 +148,8 @@ float MinimizeKL(const std::vector<int64_t>& hist,
     }
 
   }
-  auto min_divergence_idx = std::distance(std::min_element(divergence.begin(), divergence.end()),
-					  divergence.begin());
+  auto min_divergence_idx = std::distance(divergence.begin(),
+					  std::min_element(divergence.begin(), divergence.end()));
   return thresholds[min_divergence_idx];;
 }
 

--- a/src/relay/pass/quantize/calibrate.cc
+++ b/src/relay/pass/quantize/calibrate.cc
@@ -95,6 +95,18 @@ Expr CreateStatsCollector(const Expr& expr) {
 TVM_REGISTER_API("relay._quantize.CreateStatsCollector")
 .set_body_typed(CreateStatsCollector);
 
+
+TVM_REGISTER_API("relay._quantize.FindScaleByKL")
+.set_body([](TVMArgs args, TVMRetValue *ret) {
+  int64_t* hist_ptr = static_cast<int64_t*>(static_cast<void*>(args[0]));
+  float* hist_edge_ptr = static_cast<float*>(static_cast<void*>(args[1]));
+  int num_bins = args[2];
+  int num_quantized_bins = args[3];
+  std::vector<int64_t> hist(hist_ptr, hist_ptr + num_bins);
+  std::vector<float> hist_edge(hist_edge_ptr, hist_edge_ptr + num_bins + 1);
+  ret[0] = 0.5;
+});
+
 }  // namespace quantize
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/pass/quantize/quantize.h
+++ b/src/relay/pass/quantize/quantize.h
@@ -78,7 +78,7 @@ class QConfigNode : public Object {
   bool round_for_shift = true;
   Array<Expr> debug_enabled_ops = Array<Expr>(ObjectPtr<Object>(nullptr));
   std::string rounding = "UPWARD";
-  int calibrate_split_by = -1;
+  int calibrate_chunk_by = -1;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("nbit_input", &nbit_input);
@@ -95,7 +95,7 @@ class QConfigNode : public Object {
     v->Visit("round_for_shift", &round_for_shift);
     v->Visit("debug_enabled_ops", &debug_enabled_ops);
     v->Visit("rounding", &rounding);
-    v->Visit("calibrate_split_by", &calibrate_split_by);
+    v->Visit("calibrate_chunk_by", &calibrate_chunk_by);
   }
 
   static constexpr const char* _type_key = "relay.quantize.QConfig";

--- a/src/relay/pass/quantize/quantize.h
+++ b/src/relay/pass/quantize/quantize.h
@@ -78,6 +78,7 @@ class QConfigNode : public Object {
   bool round_for_shift = true;
   Array<Expr> debug_enabled_ops = Array<Expr>(ObjectPtr<Object>(nullptr));
   std::string rounding = "UPWARD";
+  int calibrate_split_by = -1;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("nbit_input", &nbit_input);
@@ -94,6 +95,7 @@ class QConfigNode : public Object {
     v->Visit("round_for_shift", &round_for_shift);
     v->Visit("debug_enabled_ops", &debug_enabled_ops);
     v->Visit("rounding", &rounding);
+    v->Visit("calibrate_split_by", &calibrate_split_by);
   }
 
   static constexpr const char* _type_key = "relay.quantize.QConfig";

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -72,7 +72,8 @@ def test_calibrate_memory_bound():
     dataset = get_calibration_dataset("data")
     import multiprocessing
     num_cpu = multiprocessing.cpu_count()
-    with relay.quantize.qconfig(calibrate_mode="kl_divergence", calibrate_split_by=num_cpu):
+    with relay.quantize.qconfig(calibrate_mode="kl_divergence",
+                                calibrate_chunk_by=num_cpu):
         relay.quantize.quantize(mod, params, dataset)
 
 

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -67,7 +67,17 @@ def test_calibrate_target(create_target=False):
             relay.quantize.quantize(mod, params, dataset)
 
 
+def test_calibrate_memory_bound():
+    mod, params = testing.resnet.get_workload(num_layers=18)
+    dataset = get_calibration_dataset("data")
+    import multiprocessing
+    num_cpu = multiprocessing.cpu_count()
+    with relay.quantize.qconfig(calibrate_mode="kl_divergence", calibrate_split_by=num_cpu):
+        relay.quantize.quantize(mod, params, dataset)
+
+
 if __name__ == "__main__":
-    test_mul_rewrite()
-    test_calibrate_target(False)
-    test_calibrate_target(True)
+    # test_mul_rewrite()
+    # test_calibrate_target(False)
+    # test_calibrate_target(True)
+    test_calibrate_memory_bound()

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -77,7 +77,7 @@ def test_calibrate_memory_bound():
 
 
 if __name__ == "__main__":
-    # test_mul_rewrite()
-    # test_calibrate_target(False)
-    # test_calibrate_target(True)
+    test_mul_rewrite()
+    test_calibrate_target(False)
+    test_calibrate_target(True)
     test_calibrate_memory_bound()


### PR DESCRIPTION
This PR improves the performance (not accuracy) of KL based calibration in two ways:

* Current implementation stores entire samples for all layers in one go, this quickly becomes intractable in terms of memory usage for image segmentation tasks, where there are more than a hundred of intermediate outputs and high-res inputs are common. I added "calibrate_chunk_by" parameter to qconfig, which enables chunk-by-chunk, interleaved profile generation and scale calculation. This adds some redundant computation, but it is a worthwhile trade off. In practice, using the cuda target for profile generation, I don't find noticeable slowdown. The default behavior is to use the number of intermediate outputs as chunk size, so there will be only one chunk and performance is the same as existing implementation.

* Port KL div minimization to C++. MXNet has [C++ implementation](https://github.com/apache/incubator-mxnet/blob/master/src/operator/quantization/calibrate.cc) now, so I replaced python one we have with that one. This turned out a big win, scale calculation is now 10-20x faster. Below is a log from running test_calibrate_chunk() that I added, showing elapsed seconds and found scales for python and cpp respectively. 

```
elapsed py: 4.980973720550537
elapsed cpp: 0.26279664039611816
scale py: 0.6268190741539001
scale cpp: 0.6268190741539001
elapsed py: 5.02645468711853
elapsed cpp: 0.27138352394104004
scale py: 0.5978888273239136
scale cpp: 0.5933241844177246
elapsed py: 5.484269857406616
elapsed cpp: 0.27078914642333984
scale py: 0.3622346520423889
scale cpp: 0.3667539358139038
elapsed py: 4.992680788040161
elapsed cpp: 0.27702999114990234
scale py: 0.6268190741539001
scale cpp: 0.6268190741539001
elapsed py: 5.395789861679077
elapsed cpp: 0.26751089096069336
scale py: 0.5125797390937805
scale cpp: 0.5124440789222717
elapsed py: 5.406205177307129
elapsed cpp: 0.26792263984680176
scale py: 0.7058634161949158
scale cpp: 0.7058634161949158
```

please review @vinx13 @ZihengJiang @tmoreau89 