### PR TITLE
[Runtime] add necessary const qualifier for NDArray container of function parameters

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -136,7 +136,7 @@ typedef DLDataType TVMType;
 typedef DLContext TVMContext;
 
 /*!
- * \brief The tensor array stucture to TVM API.
+ * \brief The tensor array structure to TVM API.
  */
 typedef DLTensor TVMArray;
 

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -160,7 +160,7 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
   return NDArray(data);
 }
 
-void NDArray::CopyFromTo(DLTensor* from,
+void NDArray::CopyFromTo(const DLTensor* from,
                          DLTensor* to,
                          TVMStreamHandle stream) {
   size_t from_size = GetDataSize(*from);


### PR DESCRIPTION
Follow up of #4586 . Our API for input DLTensor doesn't restrict const, but in fact, we should do. This PR add the const qualifier for them.
@tqchen 