### PR TITLE
[fix] Disable copy constructor for external codegen

### DIFF
--- a/src/relay/backend/contrib/codegen_c/codegen.cc
+++ b/src/relay/backend/contrib/codegen_c/codegen.cc
@@ -147,7 +147,7 @@ class CSourceCodegen : public CSourceModuleCodegenBase {
     // Record the external symbol for runtime lookup.
     auto sid = GetExtSymbol(func);
 
-    auto builder = CodegenC(sid);
+    CodegenC builder(sid);
     builder.VisitExpr(func->body);
     code_stream_ << builder.JIT();
   }

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -238,7 +238,7 @@ class DNNLModuleCodegen : public CSourceModuleCodegenBase {
     // Record the external symbol for runtime lookup.
     auto sid = GetExtSymbol(func);
 
-    auto builder = CodegenDNNL(sid);
+    CodegenDNNL builder(sid);
     builder.VisitExpr(func->body);
     code_stream_ << builder.JIT();
   }


### PR DESCRIPTION
This fixes #4596 

CC @comaniac @tqchen @kevinyuan