### PR TITLE
[Relay][Convert Layout] Handling batch norm layout change.

### DIFF
--- a/src/relay/pass/convert_layout.cc
+++ b/src/relay/pass/convert_layout.cc
@@ -134,7 +134,7 @@ Pass ConvertLayout(const std::string& desired_layout) {
       };
   return CreateFunctionPass(
       pass_func, 3, "ConvertLayout",
-      {ir::StringImm::make("InferType"), ir::StringImm::make("SimplifyInference"),
+      {ir::StringImm::make("InferType"),
        ir::StringImm::make("CanonicalizeOps")});
 }
 


### PR DESCRIPTION
@yzhliu @trevor-m 

Convert Layout pass was earlier using SimplifyInference pass as a pre-requisite to expand batch norm to simpler ops. However, @trevor-m told that TRT offloading of Relay graph works better if we keep batch norm intact in Relay. This caused a problem with Convert Layout pass that inserts layout transforms with batch norm.

This PR propagates the new layout through batch norm, preventing the insertion of layout transforms.
