### PR TITLE
[relay][vm_profiler] Sort VM stats by time

### DIFF
--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -38,8 +38,21 @@ class VirtualMachineProfiler(vm.VirtualMachine):
         self._set_input = self.mod["set_input"]
         self._reset = self.mod["reset"]
 
-    def get_stat(self):
-        return self._get_stat()
+    def get_stat(self, sort_by_time=True):
+        """Get the statistics of executed ops.
+
+        Parameters
+        ----------
+        sort_by_time: Optional[Boolean]
+           Set to indicate the returned results are sorted by execution time in
+           the descending order. It is printed in the random order if this
+           field is not set.
+
+        Returns
+        -------
+            The execution statistics in string.
+        """
+        return self._get_stat(sort_by_time)
 
     def reset(self):
         self._reset()

--- a/tests/python/unittest/test_runtime_vm_profiler.py
+++ b/tests/python/unittest/test_runtime_vm_profiler.py
@@ -35,6 +35,7 @@ def test_basic():
     data = np.random.rand(1, 3, 224, 224).astype('float32')
     res = vm.invoke("main", [data])
     print("\n{}".format(vm.get_stat()))
+    print("\n{}".format(vm.get_stat(False)))
 
 if __name__ == "__main__":
     test_basic()


### PR DESCRIPTION
To keep consistent to graph runtime profiler, this PR add `set_by_time=True` to let VM profiler to print statistics in descending order for easy visualization of op overhead.

CC @icemelon9 @wweic @jroesch @kevinthesun @yongwww 
