### PR TITLE
[Topi]Allow empty tensor for reshape, tile and strided_slice

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -888,6 +888,7 @@ bool TakeRel(const Array<Type>& types,
   CHECK(data != nullptr);
   const auto* indices = types[1].as<TensorTypeNode>();
   CHECK(indices != nullptr);
+  CHECK(indices->dtype.is_int()) << "indices of take must be tensor of integer";
   const auto param = attrs.as<TakeAttrs>();
   CHECK(param != nullptr);
 
@@ -1648,6 +1649,9 @@ bool SqueezeRel(const Array<Type>& types,
   // if axes is None, squeeze all axes of dimension 1
   if (!param->axis.defined()) {
     for (const auto& e : data->shape) {
+      if (!e.as<IntImm>()) {
+        LOG(FATAL) << "axis needs to be defined for dynamic input.";
+      }
       const int64_t* axis_ptr = as_const_int(e);
       CHECK(axis_ptr != nullptr) << "the axes attribute must be concrete";
       if (*axis_ptr != 1) {

--- a/topi/include/topi/detail/tensor_utils.h
+++ b/topi/include/topi/detail/tensor_utils.h
@@ -30,24 +30,23 @@ namespace detail {
 using namespace tvm;
 
 /*!
- * \brief Check whether a tensor is an empty tensor
+ * \brief Check whether input shape has dimension of size 0;
  *
- * \param x Input tensor
+ * \param x Input shape
  *
- * \return True if the input tensor is empty.
+ * \return True if the input shape is empty.
  */
-inline bool is_empty_tensor(const Tensor& x) {
-  if (x->shape.size() == 0) return true;
-  bool is_empty_tensor = false;
-  for (const auto& dim : x->shape) {
+inline bool is_empty_shape(const Array<Expr>& x) {
+  bool is_empty = false;
+  for (const auto& dim : x) {
     if (auto int_dim = dim.as<IntImm>()) {
       if (int_dim->value == 0) {
-        is_empty_tensor = true;
+        is_empty = true;
         break;
       }
     }
   }
-  return is_empty_tensor;
+  return is_empty;
 }
 
 }  // namespace detail

--- a/topi/include/topi/detail/tensor_utils.h
+++ b/topi/include/topi/detail/tensor_utils.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tensor_utils.h
+ * \brief Utility functions for handling tensor
+ */
+#ifndef TOPI_DETAIL_TENSOR_UTILS_H_
+#define TOPI_DETAIL_TENSOR_UTILS_H_
+
+
+namespace topi {
+namespace detail {
+using namespace tvm;
+
+/*!
+ * \brief Check whether a tensor is an empty tensor
+ *
+ * \param x Input tensor
+ *
+ * \return True if the input tensor is empty.
+ */
+inline bool is_empty_tensor(const Tensor& x) {
+  if (x->shape.size() == 0) return true;
+  bool is_empty_tensor = false;
+  for (const auto& dim : x->shape) {
+    if (auto int_dim = dim.as<IntImm>()) {
+      if (int_dim->value == 0) {
+        is_empty_tensor = true;
+        break;
+      }
+    }
+  }
+  return is_empty_tensor;
+}
+
+}  // namespace detail
+}  // namespace topi
+#endif  // TOPI_DETAIL_TENSOR_UTILS_H_
+

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -218,7 +218,7 @@ inline Tensor reshape(const Tensor& x,
     }
   }
 
-  if (is_empty_tensor(x)) {
+  if (is_empty_shape(target_shape)) {
     return compute(target_shape,
                    [&](const Array<Var> &indices) { return tvm::cast(x->dtype, 0); },
                    name, tag);
@@ -951,7 +951,7 @@ inline Tensor tile(const Tensor& x,
   for (size_t i = 0; i < tdim; ++i)
     new_shape.push_back(data_shape[i] * reps_shape[i]);
 
-  if (is_empty_tensor(x)) {
+  if (is_empty_shape(new_shape)) {
     return compute(new_shape,
                    [&](const Array<Var>& indices) { return tvm::cast(x->dtype, 0);},
                    name, tag);

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -34,6 +34,7 @@
 #include "topi/tags.h"
 #include "topi/detail/ravel_unravel.h"
 #include "topi/detail/constant_utils.h"
+#include "topi/detail/tensor_utils.h"
 #include "tvm/operation.h"
 #include "tvm/expr_operator.h"
 #include "tvm/data_layout.h"
@@ -41,19 +42,6 @@
 namespace topi {
 using namespace tvm;
 using namespace topi::detail;
-
-bool is_empty_tensor(const Tensor& x) {
-  bool is_empty_tensor = false;
-  for (const auto& dim : x->shape) {
-    if (auto int_dim = dim.as<IntImm>()) {
-      if (int_dim->value == 0) {
-        is_empty_tensor = true;
-        break;
-      }
-    }
-  }
-  return is_empty_tensor;
-}
 
 /*!
 * \brief Creates an operation to insert new dimensions of length 1
@@ -232,7 +220,7 @@ inline Tensor reshape(const Tensor& x,
 
   if (is_empty_tensor(x)) {
     return compute(target_shape,
-                   [&](const Array<Var> &indices) { return cast(x->dtype, 0); },
+                   [&](const Array<Var> &indices) { return tvm::cast(x->dtype, 0); },
                    name, tag);
   } else {
     return compute(
@@ -965,7 +953,7 @@ inline Tensor tile(const Tensor& x,
 
   if (is_empty_tensor(x)) {
     return compute(new_shape,
-                   [&](const Array<Var>& indices) { return cast(x->dtype, 0);},
+                   [&](const Array<Var>& indices) { return tvm::cast(x->dtype, 0);},
                    name, tag);
   } else {
     return compute(

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -90,7 +90,7 @@ inline Tensor expand_dims(const Tensor& x,
         idx.push_back(indices[i]);
       }
       for (size_t i = axis + num_newaxis; i < indices.size(); ++i) {
-          idx.push_back(indices[i]);
+        idx.push_back(indices[i]);
       }
       return x(idx);
     }, name, tag);

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -42,6 +42,19 @@ namespace topi {
 using namespace tvm;
 using namespace topi::detail;
 
+bool is_empty_tensor(const Tensor& x) {
+  bool is_empty_tensor = false;
+  for (const auto& dim : x->shape) {
+    if (auto int_dim = dim.as<IntImm>()) {
+      if (int_dim->value == 0) {
+        is_empty_tensor = true;
+        break;
+      }
+    }
+  }
+  return is_empty_tensor;
+}
+
 /*!
 * \brief Creates an operation to insert new dimensions of length 1
 *
@@ -89,7 +102,7 @@ inline Tensor expand_dims(const Tensor& x,
         idx.push_back(indices[i]);
       }
       for (size_t i = axis + num_newaxis; i < indices.size(); ++i) {
-        idx.push_back(indices[i]);
+          idx.push_back(indices[i]);
       }
       return x(idx);
     }, name, tag);
@@ -207,16 +220,28 @@ inline Tensor reshape(const Tensor& x,
                       std::string name = "T_reshape",
                       std::string tag = kInjective) {
   auto x_shape = x->shape;
-  Array<Expr> newshape_int32;
+  Array<Expr> target_shape;
 
   for (const auto &ele : newshape) {
-    newshape_int32.push_back(cast(DataType::Int(32), ele));
+    if (ele.as<IntImm>()) {
+      target_shape.push_back(cast(DataType::Int(32), ele));
+    } else {
+      target_shape.push_back(ele);
+    }
   }
-  return compute(
-    newshape_int32, [&](const Array<Var>& indices) {
-      return x(UnravelIndex(RavelIndex(Array<Expr>{indices.begin(), indices.end()}, newshape_int32),
-                            x_shape));
-    }, name, tag);
+
+  if (is_empty_tensor(x)) {
+    return compute(target_shape,
+                   [&](const Array<Var> &indices) { return cast(x->dtype, 0); },
+                   name, tag);
+  } else {
+    return compute(
+      target_shape, [&](const Array<Var>& indices) {
+        return x(UnravelIndex(
+          RavelIndex(Array<Expr>{indices.begin(), indices.end()}, target_shape),
+          x_shape));
+      }, name, tag);
+  }
 }
 
 /*!
@@ -556,7 +581,7 @@ inline Tensor strided_slice(const Tensor& x,
     int interval = std::abs(end_i - begin_i);
     int slice_size = static_cast<int>((interval
                                      + std::abs(stride_vec[i]) - 1) / std::abs(stride_vec[i]));
-    CHECK(stride_vec[i] < 0 ? (end_i < begin_i) : (begin_i < end_i))
+    CHECK(stride_vec[i] < 0 ? (end_i <= begin_i) : (begin_i <= end_i))
       << ": Input [Begin=" << begin_vec[i] << ", End=" << end_vec[i]
       << "] is invalid for axis=" << i;
 
@@ -938,18 +963,24 @@ inline Tensor tile(const Tensor& x,
   for (size_t i = 0; i < tdim; ++i)
     new_shape.push_back(data_shape[i] * reps_shape[i]);
 
-  return compute(
-    new_shape, [&](const Array<Var>& indices) {
-      Array<Expr> idx;
-      if (ndim >= rdim) {
-        for (size_t i = 0; i < ndim; ++i)
-          idx.push_back(indexmod(indices[i], x->shape[i]));
-      } else {
-        for (size_t i = 0; i < ndim; ++i)
-          idx.push_back(indexmod(indices[rdim - ndim + i], x->shape[i]));
-      }
-      return x(idx);
-    }, name, tag);
+  if (is_empty_tensor(x)) {
+    return compute(new_shape,
+                   [&](const Array<Var>& indices) { return cast(x->dtype, 0);},
+                   name, tag);
+  } else {
+    return compute(
+      new_shape, [&](const Array<Var>& indices) {
+        Array<Expr> idx;
+        if (ndim >= rdim) {
+          for (size_t i = 0; i < ndim; ++i)
+            idx.push_back(indexmod(indices[i], x->shape[i]));
+        } else {
+          for (size_t i = 0; i < ndim; ++i)
+            idx.push_back(indexmod(indices[rdim - ndim + i], x->shape[i]));
+        }
+        return x(idx);
+      }, name, tag);
+  }
 }
 
 /*!

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -68,7 +68,10 @@ def schedule_injective(outs):
         (io, ii) = s[x].split(list(s[x].op.axis)[-1], 8)
         s[x].vectorize(ii)
     tvm.schedule.AutoInlineInjective(s)
-    schedule_injective_from_existing(s, x)
+
+    is_empty = all(dim != 0 for dim in x.shape)
+    if not is_empty:
+        schedule_injective_from_existing(s, x)
     return s
 
 @generic.schedule_concatenate.register(["arm_cpu"])

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -18,6 +18,7 @@
 """Schedule for pooling operators"""
 import tvm
 from .. import generic
+from ..util import is_empty_shape
 
 @generic.schedule_injective_from_existing.register(["arm_cpu"])
 def schedule_injective_from_existing(sch, out):
@@ -69,8 +70,7 @@ def schedule_injective(outs):
         s[x].vectorize(ii)
     tvm.schedule.AutoInlineInjective(s)
 
-    is_empty = all(dim != 0 for dim in x.shape)
-    if not is_empty:
+    if not is_empty_shape(x.shape):
         schedule_injective_from_existing(s, x)
     return s
 

--- a/topi/python/topi/cpp/util.py
+++ b/topi/python/topi/cpp/util.py
@@ -14,14 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""FFI for TOPI utility functions"""
 
-"""FFI for C++ TOPI ops and schedules"""
-from .impl import * #pylint: disable=wildcard-import
-from . import cuda
-from . import nn
-from . import vision
-from . import x86
-from . import generic
-from . import rocm
-from . import image
-from . import util
+from tvm._ffi.function import _init_api_prefix
+
+_init_api_prefix("topi.cpp.util", "topi.util")

--- a/topi/python/topi/cuda/injective.py
+++ b/topi/python/topi/cuda/injective.py
@@ -79,7 +79,9 @@ def schedule_injective(outs):
 
     tvm.schedule.AutoInlineInjective(s)
     for out in outs:
-        schedule_injective_from_existing(s, out)
+        is_empty = all(dim != 0 for dim in out.shape)
+        if not is_empty:
+            schedule_injective_from_existing(s, out)
     return s
 
 schedule_elemwise = schedule_injective

--- a/topi/python/topi/cuda/injective.py
+++ b/topi/python/topi/cuda/injective.py
@@ -18,6 +18,7 @@
 """Schedule for composition of injective operator"""
 import tvm
 from .. import generic, util
+from ..util import is_empty_shape
 
 @generic.schedule_injective_from_existing.register(["cuda", "gpu"])
 def schedule_injective_from_existing(sch, out):
@@ -79,8 +80,7 @@ def schedule_injective(outs):
 
     tvm.schedule.AutoInlineInjective(s)
     for out in outs:
-        is_empty = all(dim != 0 for dim in out.shape)
-        if not is_empty:
+        if not is_empty_shape(out.shape):
             schedule_injective_from_existing(s, out)
     return s
 

--- a/topi/python/topi/util.py
+++ b/topi/python/topi/util.py
@@ -21,7 +21,7 @@ from numbers import Integral
 
 import tvm
 from tvm.api import layout, bijective_layout
-from . import tag
+from . import tag, cpp
 
 class InvalidShapeError(ValueError):
     """Invalid shape for a topi function. i.e. call winograd template for non-3x3 kernel)"""
@@ -432,10 +432,4 @@ def is_empty_shape(shape):
     is_empty: bool
       Whether input shape is empty or has dimesion with size 0.
     """
-    is_empty = False
-    for dim in shape:
-        if isinstance(dim, tvm.expr.IntImm):
-            if dim.value == 0:
-                is_empty = True
-                break
-    return is_empty
+    return cpp.util.is_empty_shape(shape)

--- a/topi/python/topi/util.py
+++ b/topi/python/topi/util.py
@@ -439,4 +439,3 @@ def is_empty_shape(shape):
                 is_empty = True
                 break
     return is_empty
-

--- a/topi/python/topi/util.py
+++ b/topi/python/topi/util.py
@@ -417,3 +417,26 @@ def make_idx(b, e, s, z, i):
                           (b - i) // tvm.abs(s),
                           (i - b) // s)
     return tvm.if_then_else(tvm.expr.Or(bc, ec), 88, ss)
+
+
+def is_empty_shape(shape):
+    """Check whether an input shape has dimesion with size 0.
+
+    Parameter
+    ---------
+    shape : list of Expr
+      Input shape
+
+    Returns
+    -------
+    is_empty: bool
+      Whether input shape is empty or has dimesion with size 0.
+    """
+    is_empty = False
+    for dim in shape:
+        if isinstance(dim, tvm.expr.IntImm):
+            if dim.value == 0:
+                is_empty = True
+                break
+    return is_empty
+

--- a/topi/python/topi/x86/injective.py
+++ b/topi/python/topi/x86/injective.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import as _abs
 import tvm
 from .. import generic
+from ..util import is_empty_shape
 
 @generic.schedule_injective_from_existing.register(["cpu"])
 def schedule_injective_from_existing(sch, out):
@@ -66,8 +67,7 @@ def schedule_injective(outs):
     s = tvm.create_schedule([x.op for x in outs])
     tvm.schedule.AutoInlineInjective(s)
 
-    is_empty = all(dim != 0 for dim in x.shape)
-    if not is_empty:
+    if not is_empty_shape(x.shape):
         schedule_injective_from_existing(s, x)
     return s
 

--- a/topi/python/topi/x86/injective.py
+++ b/topi/python/topi/x86/injective.py
@@ -65,7 +65,10 @@ def schedule_injective(outs):
     x = outs[0]
     s = tvm.create_schedule([x.op for x in outs])
     tvm.schedule.AutoInlineInjective(s)
-    schedule_injective_from_existing(s, x)
+
+    is_empty = all(dim != 0 for dim in x.shape)
+    if not is_empty:
+        schedule_injective_from_existing(s, x)
     return s
 
 @generic.schedule_concatenate.register(["cpu"])

--- a/topi/src/topi.cc
+++ b/topi/src/topi.cc
@@ -72,6 +72,8 @@
 #include <topi/rocm/softmax.h>
 #include <topi/rocm/normalization.h>
 
+#include <topi/detail/tensor_utils.h>
+
 namespace topi {
 
 using namespace tvm;
@@ -738,6 +740,12 @@ TVM_REGISTER_GLOBAL("topi.cuda.schedule_lrn")
 TVM_REGISTER_GLOBAL("topi.cuda.schedule_l2_normalize")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
   *rv = topi::cuda::schedule_l2_normalize(args[0], args[1]);
+  });
+
+/* Utility functions */
+TVM_REGISTER_GLOBAL("topi.util.is_empty_shape")
+.set_body([](TVMArgs args, TVMRetValue *rv) {
+  *rv = topi::detail::is_empty_shape(args[0]);
   });
 
 /*! \brief Builder function for instantiating schedules. */

--- a/topi/tests/python/test_topi_transform.py
+++ b/topi/tests/python/test_topi_transform.py
@@ -555,6 +555,7 @@ def test_strided_slice():
     verify_strided_slice((3, 4, 3), [1, 0, 0], [2, 2, 3], [1, 1, 2])
     verify_strided_slice((3, 4, 3), [1, -1, 0], [2, -3, 3], [1, -1, 1])
     verify_strided_slice((3, 4, 3), [1, 1, 0], [4, 4, 3])
+    verify_strided_slice((3, 4, 3), [0, 2, 0], [1, 2, 3])
 
 def test_strided_set():
     verify_strided_set((3, 4, 3), (3, 2, 2), [0, 3, 0], [4, 1, 4], [1, -1, 2])
@@ -596,6 +597,7 @@ def test_reshape():
     verify_reshape((4, 2, 3, 4), (2, 4, 12))
     verify_reshape((4, 2, 3, 4), (2, 48))
     verify_reshape((16, ), (2, 2, 2, 2))
+    verify_reshape((4, 0), (2, 0, 2))
 
 
 def test_where():
@@ -718,6 +720,7 @@ def test_tile():
     verify_tile((3, 2), (2, 3))
     verify_tile((3, 2, 5), (2,))
     verify_tile((3, ), (2, 3, 3))
+    verify_tile((4, 0), (5,))
 
 def test_layout_transform():
     in_shape = (1, 32, 8, 8)


### PR DESCRIPTION
Some reshape, tile and strided_slice ops can generate empty tensor(tensor shape such as (4, 0, 2)) in some tensorflow models. This PR adds support in topi.

@zhiics @yongwww 