### PR TITLE
[Bugfix] fskip of EliminateCommonSubexpr cannot always return false

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -327,8 +327,9 @@ class RelayBuildModule : public runtime::ModuleNode {
             *rv = true;
           }
         }
+      } else {
+        *rv = false;
       }
-      *rv = false;
     });
     pass_seqs.push_back(transform::EliminateCommonSubexpr(fskip));
     pass_seqs.push_back(transform::CombineParallelConv2D(3));

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -318,6 +318,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     pass_seqs.push_back(transform::SimplifyInference());
     PackedFunc fskip = PackedFunc([](TVMArgs args, TVMRetValue* rv) {
       Expr expr = args[0];
+      *rv = false;
       if (expr.as<CallNode>()) {
         auto call_node = expr.as<CallNode>();
         auto op_node = call_node->op.as<OpNode>();
@@ -327,8 +328,6 @@ class RelayBuildModule : public runtime::ModuleNode {
             *rv = true;
           }
         }
-      } else {
-        *rv = false;
       }
     });
     pass_seqs.push_back(transform::EliminateCommonSubexpr(fskip));


### PR DESCRIPTION
Originally, fskip returns false at the end of PackedFunc, discards return true in 'cast' case
