### PR TITLE
[CI] Update image version tags in Dockerfile comments

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -16,7 +16,7 @@
 # under the License.
 
 # CI docker CPU env
-# tag: v0.41
+# tag: v0.54
 FROM ubuntu:16.04
 
 RUN apt-get update --fix-missing

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -16,7 +16,7 @@
 # under the License.
 
 # CI docker GPU env
-# tag: v0.54
+# tag: v0.56
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
 # Base scripts

--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -16,7 +16,7 @@
 # under the License.
 
 # CI docker i386 env
-# tag: v0.50
+# tag: v0.53
 
 FROM ioft/i386-ubuntu:16.04
 

--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -17,6 +17,7 @@
 
 # For lint test
 # CI docker lint env
+# tag: v0.51
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y sudo wget


### PR DESCRIPTION
 * Fix typos on Docker image versions that we are currently running
   as part of CI
 * Add version comment in the same pattern for ci_lint image

cc @tqchen 