### PR TITLE
[Relay/Topi][Op] Conv1D

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -54,6 +54,7 @@ struct Conv1DAttrs : public tvm::AttrsNode<Conv1DAttrs> {
   Array<IndexExpr> strides;
   Array<IndexExpr> padding;
   Array<IndexExpr> dilation;
+  int groups;
   IndexExpr channels;
   Array<IndexExpr> kernel_size;
   std::string data_layout;
@@ -69,6 +70,8 @@ struct Conv1DAttrs : public tvm::AttrsNode<Conv1DAttrs> {
                   "on both sides for padding number of points");
     TVM_ATTR_FIELD(dilation).set_default(Array<IndexExpr>({1, }))
         .describe("Specifies the dilation rate to use for dilated convolution.");
+    TVM_ATTR_FIELD(groups).set_default(1)
+        .describe("Currently unused but may be added in the future.");
     TVM_ATTR_FIELD(channels)
         .describe("The number of output channels in the convolution."
                   " If it is not set, inferred by shape of the weight.")

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -51,23 +51,23 @@ struct BiasAddAttrs : public tvm::AttrsNode<BiasAddAttrs> {
 
 /*! \brief Attributes used in 1D convolution operators */
 struct Conv1DAttrs : public tvm::AttrsNode<Conv1DAttrs> {
-  int stride;
+  Array<IndexExpr> strides;
   Array<IndexExpr> padding;
-  int dilation;
+  Array<IndexExpr> dilation;
   IndexExpr channels;
-  IndexExpr kernel_size;
+  Array<IndexExpr> kernel_size;
   std::string data_layout;
   std::string kernel_layout;
   std::string out_layout;
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Conv1DAttrs, "relay.attrs.Conv1DAttrs") {
-    TVM_ATTR_FIELD(stride).set_default(1)
+    TVM_ATTR_FIELD(strides).set_default(Array<IndexExpr>({1, }))
         .describe("Specifies the stride of the convolution.");
     TVM_ATTR_FIELD(padding).set_default(Array<IndexExpr>({0, 0}))
         .describe("If padding is non-zero, then the input is implicitly zero-padded"
                   "on both sides for padding number of points");
-    TVM_ATTR_FIELD(dilation).set_default(1)
+    TVM_ATTR_FIELD(dilation).set_default(Array<IndexExpr>({1, }))
         .describe("Specifies the dilation rate to use for dilated convolution.");
     TVM_ATTR_FIELD(channels)
         .describe("The number of output channels in the convolution."
@@ -75,7 +75,7 @@ struct Conv1DAttrs : public tvm::AttrsNode<Conv1DAttrs> {
         .set_default(NullValue<IndexExpr>());
     TVM_ATTR_FIELD(kernel_size)
         .describe("Specifies the dimensions of the convolution window.")
-        .set_default(NullValue<IndexExpr>());
+        .set_default(NullValue<Array<IndexExpr> >());
     TVM_ATTR_FIELD(data_layout).set_default("NCW")
         .describe("Dimension ordering of input data. Can be 'NCW', 'NWC', etc."
                   "'N', 'C', 'W' stands for batch, channel, and width"

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -49,6 +49,51 @@ struct BiasAddAttrs : public tvm::AttrsNode<BiasAddAttrs> {
 };
 
 
+/*! \brief Attributes used in 1D convolution operators */
+struct Conv1DAttrs : public tvm::AttrsNode<Conv1DAttrs> {
+  int stride;
+  Array<IndexExpr> padding;
+  int dilation;
+  IndexExpr channels;
+  IndexExpr kernel_size;
+  std::string data_layout;
+  std::string kernel_layout;
+  std::string out_layout;
+  DataType out_dtype;
+
+  TVM_DECLARE_ATTRS(Conv1DAttrs, "relay.attrs.Conv1DAttrs") {
+    TVM_ATTR_FIELD(stride).set_default(1)
+        .describe("Specifies the stride of the convolution.");
+    TVM_ATTR_FIELD(padding).set_default(Array<IndexExpr>({0, 0}))
+        .describe("If padding is non-zero, then the input is implicitly zero-padded"
+                  "on both sides for padding number of points");
+    TVM_ATTR_FIELD(dilation).set_default(1)
+        .describe("Specifies the dilation rate to use for dilated convolution.");
+    TVM_ATTR_FIELD(channels)
+        .describe("The number of output channels in the convolution."
+                  " If it is not set, inferred by shape of the weight.")
+        .set_default(NullValue<IndexExpr>());
+    TVM_ATTR_FIELD(kernel_size)
+        .describe("Specifies the dimensions of the convolution window.")
+        .set_default(NullValue<IndexExpr>());
+    TVM_ATTR_FIELD(data_layout).set_default("NCW")
+        .describe("Dimension ordering of input data. Can be 'NCW', 'NWC', etc."
+                  "'N', 'C', 'W' stands for batch, channel, and width"
+                  "dimensions respectively. Convolution is applied on the 'W'"
+                  "dimension.");
+    TVM_ATTR_FIELD(kernel_layout).set_default("OIW")
+        .describe("Dimension ordering of weight. Can be 'OIW', or 'WIO', etc."
+                  "'O', 'I', 'W' stands for num_filter, input_channel, and width"
+                  "dimensions respectively.");
+
+    // use 0 bits to indicate none.
+    TVM_ATTR_FIELD(out_dtype)
+        .set_default(NullValue<DataType>())
+        .describe("Output data type, set to explicit type under mixed precision setting");
+  }
+};
+
+
 /*! \brief Attributes used in convolution operators */
 struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
   Array<IndexExpr> strides;

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -307,13 +307,13 @@ class Conv(OnnxOpConverter):
             custom_check=None
         #Conv2D
         elif len(input_shape) == 4:
-            op_name=dimension_picker('conv')
-            transforms={
+            op_name = dimension_picker('conv')
+            transforms = {
                 'kernel_shape': 'kernel_size',
                 'dilations': ('dilation', (0, 0)),
                 'pads': ('padding', (0, 0), revert_caffe2_pad),
                 'group': ('groups', 1)}
-            custom_check=dimension_constraint()
+            custom_check = dimension_constraint()
         else:
             raise ValueError("Only 1D and 2D convolution currently supported.")
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -290,17 +290,17 @@ class Conv(OnnxOpConverter):
                 pass
             else:
                 msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
-                raise tvm.error.OpAttributeInvalid(
-                    msg.format(attr['auto_pad']))
+                raise tvm.error.OpAttributeInvalid(msg.format(attr['auto_pad']))
             attr.pop('auto_pad')
 
         out = AttrCvt(
             op_name=dimension_picker('conv'),
-            transforms = {
-            'kernel_shape': 'kernel_size',
-            'dilations': ('dilation', 1),
-            'pads': ('padding', 0),
-            'group': ('groups', 1)},
+            transforms={
+                'kernel_shape': 'kernel_size',
+                'dilations': ('dilation', 1),
+                'pads': ('padding', 0),
+                'group': ('groups', 1)
+            },
             custom_check=dimension_constraint())(inputs[:2], attr, params)
 
         use_bias = len(inputs) == 3
@@ -718,8 +718,8 @@ class Upsample(OnnxOpConverter):
         else:
             raise tvm.error.OpAttributeInvalid(
                 'Value {} in attribute "mode" of operator Upsample is not valid.'.format(mode))
-        attr = {'scale_h':scales[-2], 'scale_w':scales[-1], 'method':method,
-                'layout':'NCHW', 'align_corners':True}
+        attr = {'scale_h': scales[-2], 'scale_w': scales[-1], 'method': method,
+                'layout': 'NCHW', 'align_corners': True}
         return AttrCvt('upsampling')(inputs, attr)
 
 
@@ -853,7 +853,7 @@ class Gather(OnnxOpConverter):
     def _impl_v1(cls, inputs, attr, params):
         axis = attr.get('axis', 0)
         return AttrCvt('take',
-                       extras={'axis':axis})(inputs, {})
+                       extras={'axis': axis})(inputs, {})
 
 
 class Greater(OnnxOpConverter):
@@ -885,7 +885,7 @@ class LRN(OnnxOpConverter):
         beta = attr.get('beta', 0.75)
         bias = attr.get('bias', 1.0)
         nsize = attr.get('size')
-        attr = {'size':nsize, 'axis':axis, 'alpha':alpha, 'beta':beta, 'bias':bias}
+        attr = {'size': nsize, 'axis': axis, 'alpha': alpha, 'beta': beta, 'bias': bias}
         return AttrCvt('lrn')(inputs, attr)
 
 class Maximum(OnnxOpConverter):
@@ -931,7 +931,7 @@ class HardSigmoid(OnnxOpConverter):
         alpha = attr.get('alpha', 0.2)
         beta = attr.get('beta', 0.5)
         transformX = (inputs[0] * _expr.const(alpha)) + _expr.const(beta)
-        attr = {'a_min':0, 'a_max':1}
+        attr = {'a_min': 0, 'a_max': 1}
         return AttrCvt('clip')([transformX], attr)
 
 class Reduce(OnnxOpConverter):
@@ -945,7 +945,7 @@ class Reduce(OnnxOpConverter):
         else:
             axis_len = len(infer_shape(inputs[0]))
             axis = list(range(axis_len))
-        attr = {'axis':axis, 'keepdims':attr.get('keepdims', True)}
+        attr = {'axis': axis, 'keepdims': attr.get('keepdims', True)}
         return AttrCvt(cls.name)(inputs, attr)
 
 class ReduceMax(Reduce):
@@ -980,7 +980,7 @@ class ArgMax(OnnxOpConverter):
     def _impl_v1(cls, inputs, attr, params):
         axis = attr.get('axis', 0)
         keepdims = attr.get('keepdims', True)
-        attr = {'axis':axis, 'keepdims':keepdims}
+        attr = {'axis': axis, 'keepdims': keepdims}
         return AttrCvt('argmax')(inputs, attr)
 
 class ArgMin(OnnxOpConverter):
@@ -990,7 +990,7 @@ class ArgMin(OnnxOpConverter):
     def _impl_v1(cls, inputs, attr, params):
         axis = attr.get('axis', 0)
         keepdims = attr.get('keepdims', True)
-        attr = {'axis':axis, 'keepdims':keepdims}
+        attr = {'axis': axis, 'keepdims': keepdims}
         return AttrCvt('argmin')(inputs, attr)
 
 class Softmax(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -267,37 +267,70 @@ class Conv(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        # infer pads for auto_pad
-        if 'auto_pad' in attr:
-            attr['auto_pad'] = attr['auto_pad'].decode('utf-8')
-            if attr['auto_pad'] in ('SAME_UPPER', 'SAME_LOWER'):
-                input_shape = infer_shape(inputs[0])
-                in_h, in_w = input_shape[2], input_shape[3]
-                stride_h, stride_w = attr['strides']
-                kernel_h, kernel_w = attr['kernel_shape']
-                dilation_h, dilation_w = attr['dilations']
-                dilated_kernel_h = (kernel_h - 1) * dilation_h + 1
-                dilated_kernel_w = (kernel_w - 1) * dilation_w + 1
-                pad_v = get_pad_pair(in_h, dilated_kernel_h, stride_h)
-                pad_h = get_pad_pair(in_w, dilated_kernel_w, stride_w)
-                attr['pads'] = (pad_v[0], pad_h[0], pad_v[1], pad_h[1])
-            elif attr['auto_pad'] == 'VALID':
-                attr['pads'] = (0, 0)
-            elif attr['auto_pad'] == 'NOTSET':
-                pass
+        # Use shape of input to determine convolution type.
+        input_shape = infer_shape(inputs[0])
+        # If input shape is 3 dimensional then convert to conv1d.
+        if len(input_shape) == 3:
+            if 'strides' in attr:
+                stride = attr['strides'][0]
             else:
-                msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
-                raise tvm.error.OpAttributeInvalid(msg.format(attr['auto_pad']))
-            attr.pop('auto_pad')
+                stride = 1
+            if 'dilation' in attr:
+                dilation = attr['dilations'][0]
+            else:
+                dilation = 1
+            kernel_w = attr['kernel_shape'][0]
+            # infer pads for auto_pad
+            if 'auto_pad' in attr:
+                if attr['auto_pad'] in ('SAME_UPPER', 'SAME_LOWER'):
+                    in_w = input_shape[2]
+                    dilated_kernel = (kernel_w - 1) * dilation + 1
+                    padding = get_pad_pair(in_w, dilated_kernel, stride)
+                elif attr['auto_pad'] == 'VALID':
+                    padding = (0, 0)
+                elif attr['auto_pad'] == 'NOTSET':
+                    pass
+                else:
+                    msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
+                    raise tvm.error.OpAttributeInvalid(msg.format(attr['auto_pad']))
+            else:
+                padding = attr['pads']
 
-        out = AttrCvt(
-            op_name=dimension_picker('conv'),
-            transforms={
-                'kernel_shape': 'kernel_size',
-                'dilations': ('dilation', (0, 0)),
-                'pads': ('padding', (0, 0), revert_caffe2_pad),
-                'group': ('groups', 1)},
-            custom_check=dimension_constraint())(inputs[:2], attr, params)
+            out = _op.nn.conv1d(inputs[0], inputs[1], stride=stride, padding=padding, dilation=dilation, kernel_size=kernel_w)
+
+        # For now only other supported type is 2D
+        else:
+            if 'auto_pad' in attr:
+                attr['auto_pad'] = attr['auto_pad'].decode('utf-8')
+                if attr['auto_pad'] in ('SAME_UPPER', 'SAME_LOWER'):
+                    input_shape = infer_shape(inputs[0])
+                    in_h, in_w = input_shape[2], input_shape[3]
+                    stride_h, stride_w = attr['strides']
+                    kernel_h, kernel_w = attr['kernel_shape']
+                    dilation_h, dilation_w = attr['dilations']
+                    dilated_kernel_h = (kernel_h - 1) * dilation_h + 1
+                    dilated_kernel_w = (kernel_w - 1) * dilation_w + 1
+                    pad_v = get_pad_pair(in_h, dilated_kernel_h, stride_h)
+                    pad_h = get_pad_pair(in_w, dilated_kernel_w, stride_w)
+                    attr['pads'] = (pad_v[0], pad_h[0], pad_v[1], pad_h[1])
+                elif attr['auto_pad'] == 'VALID':
+                    attr['pads'] = (0, 0)
+                elif attr['auto_pad'] == 'NOTSET':
+                    pass
+                else:
+                    msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
+                    raise tvm.error.OpAttributeInvalid(msg.format(attr['auto_pad']))
+                attr.pop('auto_pad')
+
+            out = AttrCvt(
+                op_name=dimension_picker('conv'),
+                transforms={
+                    'kernel_shape': 'kernel_size',
+                    'dilations': ('dilation', (0, 0)),
+                    'pads': ('padding', (0, 0), revert_caffe2_pad),
+                    'group': ('groups', 1)},
+                custom_check=dimension_constraint())(inputs[:2], attr, params)
+
         use_bias = len(inputs) == 3
         if use_bias:
             out = _op.nn.bias_add(out, inputs[2])

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -305,6 +305,7 @@ class Conv(OnnxOpConverter):
                 'pads': ('padding', (0, 0)),
             }
             custom_check = None
+            ignores = ['group']
         #Conv2D
         elif len(input_shape) == 4:
             op_name = dimension_picker('conv')
@@ -314,13 +315,15 @@ class Conv(OnnxOpConverter):
                 'pads': ('padding', (0, 0), revert_caffe2_pad),
                 'group': ('groups', 1)}
             custom_check = dimension_constraint()
+            ignores = None
         else:
             raise ValueError("Only 1D and 2D convolution currently supported.")
 
         out = AttrCvt(
             op_name=op_name,
             transforms=transforms,
-            custom_check=custom_check)(inputs[:2], attr, params)
+            custom_check=custom_check,
+            ignores=ignores)(inputs[:2], attr, params)
 
         use_bias = len(inputs) == 3
         if use_bias:

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -292,11 +292,13 @@ class Conv(OnnxOpConverter):
                     pass
                 else:
                     msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
-                    raise tvm.error.OpAttributeInvalid(msg.format(attr['auto_pad']))
+                    raise tvm.error.OpAttributeInvalid(
+                        msg.format(attr['auto_pad']))
             else:
                 padding = attr['pads']
 
-            out = _op.nn.conv1d(inputs[0], inputs[1], stride=stride, padding=padding, dilation=dilation, kernel_size=kernel_w)
+            out = _op.nn.conv1d(inputs[0], inputs[1], stride=stride,
+                                padding=padding, dilation=dilation, kernel_size=kernel_w)
 
         # For now only other supported type is 2D
         else:
@@ -319,7 +321,8 @@ class Conv(OnnxOpConverter):
                     pass
                 else:
                     msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
-                    raise tvm.error.OpAttributeInvalid(msg.format(attr['auto_pad']))
+                    raise tvm.error.OpAttributeInvalid(
+                        msg.format(attr['auto_pad']))
                 attr.pop('auto_pad')
 
             out = AttrCvt(

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -304,7 +304,7 @@ class Conv(OnnxOpConverter):
                 'dilations': ('dilation', (1, )),
                 'pads': ('padding', (0, 0)),
             }
-            custom_check=None
+            custom_check = None
         #Conv2D
         elif len(input_shape) == 4:
             op_name = dimension_picker('conv')

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -273,7 +273,7 @@ class Conv(OnnxOpConverter):
         if 'auto_pad' in attr:
             attr['auto_pad'] = attr['auto_pad'].decode('utf-8')
             if attr['auto_pad'] in ('SAME_UPPER', 'SAME_LOWER'):
-                pad_tuple = ()
+                pad_tuple = []
                 for axis in range(len(input_shape) - 2):
                     axis_shape = input_shape[2 + axis]
                     stride = attr['strides'][axis]
@@ -281,8 +281,8 @@ class Conv(OnnxOpConverter):
                     dilation = attr['dilations'][axis]
                     dilated_kernel = (kernel - 1) * dilation + 1
                     pad = get_pad_pair(axis_shape, dilated_kernel, stride)
-                    for p in pad:
-                        pad_tuple += (p, )
+                    pad_tuple.append(pad)
+                pad_tuple = tuple([val for pair in zip(*pad_tuple) for val in pair])
                 attr['pads'] = pad_tuple
             elif attr['auto_pad'] == 'VALID':
                 attr['pads'] = tuple([0 for i in range(len(input_shape) - 2)])

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -294,36 +294,14 @@ class Conv(OnnxOpConverter):
                     msg.format(attr['auto_pad']))
             attr.pop('auto_pad')
 
-        # Handle attribute conversion for different convolution types
-
-        # Conv1D
-        if len(input_shape) == 3:
-            op_name = 'conv1d'
-            transforms = {
-                'kernel_shape': 'kernel_size',
-                'dilations': ('dilation', (1, )),
-                'pads': ('padding', (0, 0)),
-            }
-            custom_check = None
-            ignores = ['group']
-        #Conv2D
-        elif len(input_shape) == 4:
-            op_name = dimension_picker('conv')
-            transforms = {
-                'kernel_shape': 'kernel_size',
-                'dilations': ('dilation', (0, 0)),
-                'pads': ('padding', (0, 0), revert_caffe2_pad),
-                'group': ('groups', 1)}
-            custom_check = dimension_constraint()
-            ignores = None
-        else:
-            raise ValueError("Only 1D and 2D convolution currently supported.")
-
         out = AttrCvt(
-            op_name=op_name,
-            transforms=transforms,
-            custom_check=custom_check,
-            ignores=ignores)(inputs[:2], attr, params)
+            op_name=dimension_picker('conv'),
+            transforms = {
+            'kernel_shape': 'kernel_size',
+            'dilations': ('dilation', 1),
+            'pads': ('padding', 0),
+            'group': ('groups', 1)},
+            custom_check=dimension_constraint())(inputs[:2], attr, params)
 
         use_bias = len(inputs) == 3
         if use_bias:

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -140,7 +140,6 @@ def compute_conv1d(attrs, inputs, out_type, target):
     padding = get_const_tuple(attrs.padding)
     dilation = attrs.dilation
     layout = attrs.data_layout
-    kernel_layout = attrs.kernel_layout
     out_dtype = attrs.out_dtype
     out_dtype = (inputs[0].dtype if out_dtype in ("same", "")
                  else out_dtype)
@@ -156,7 +155,6 @@ def compute_conv1d(attrs, inputs, out_type, target):
 def schedule_conv1d(attrs, outs, target):
     """Schedule definition of conv1d"""
     layout = attrs.data_layout
-    kernel_layout = attrs.kernel_layout
 
     with target:
         if layout == "NCW":

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -131,6 +131,44 @@ def schedule_sparse_transpose(attrs, outputs, target):
 
 reg.register_pattern("nn.sparse_transpose", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 
+
+# Conv1D
+@reg.register_compute("nn.conv1d")
+def compute_conv1d(attrs, inputs, out_type, target):
+    """Compute definition of conv1d"""
+    stride = attrs.stride
+    padding = get_const_tuple(attrs.padding)
+    dilation = attrs.dilation
+    layout = attrs.data_layout
+    kernel_layout = attrs.kernel_layout
+    out_dtype = attrs.out_dtype
+    out_dtype = (inputs[0].dtype if out_dtype in ("same", "")
+                 else out_dtype)
+
+    assert layout in ["NCW", "NWC"]
+    if dilation < 1:
+        raise ValueError("dilation should be a positive value")
+
+    return [topi.nn.conv1d(inputs[0], inputs[1], stride, padding, dilation, layout, out_dtype)]
+
+
+@reg.register_schedule("nn.conv1d")
+def schedule_conv1d(attrs, outs, target):
+    """Schedule definition of conv1d"""
+    layout = attrs.data_layout
+    kernel_layout = attrs.kernel_layout
+
+    with target:
+        if layout == "NCW":
+            return topi.generic.schedule_conv1d_ncw(outs)
+        elif layout == "NCW":
+            return topi.generic.schedule_conv1d_nwc(outs)
+    raise ValueError("No compatible schedule")
+
+
+reg.register_pattern("nn.conv1d", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+
 # conv2d
 def _find_conv2d_op(op):
     """Find the op with conv2d in its tag by traversing."""

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -136,19 +136,19 @@ reg.register_pattern("nn.sparse_transpose", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 @reg.register_compute("nn.conv1d")
 def compute_conv1d(attrs, inputs, out_type, target):
     """Compute definition of conv1d"""
-    stride = attrs.stride
+    strides = get_const_tuple(attrs.strides)
     padding = get_const_tuple(attrs.padding)
-    dilation = attrs.dilation
+    dilation = get_const_tuple(attrs.dilation)
     layout = attrs.data_layout
     out_dtype = attrs.out_dtype
     out_dtype = (inputs[0].dtype if out_dtype in ("same", "")
                  else out_dtype)
 
     assert layout in ["NCW", "NWC"]
-    if dilation < 1:
+    if dilation[0] < 1:
         raise ValueError("dilation should be a positive value")
 
-    return [topi.nn.conv1d(inputs[0], inputs[1], stride, padding, dilation, layout, out_dtype)]
+    return [topi.nn.conv1d(inputs[0], inputs[1], strides, padding, dilation, layout, out_dtype)]
 
 
 @reg.register_schedule("nn.conv1d")

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -23,7 +23,7 @@ from . import _make
 
 def conv1d(data,
            weight,
-           stride=1,
+           strides=1,
            padding=(0, 0),
            dilation=1,
            channels=None,
@@ -47,7 +47,7 @@ def conv1d(data,
     .. math::
 
         \mbox{out}[b, c, w] = \sum_{dw, k}
-           \mbox{data}[b, k, \mbox{strides}[1] * w + dw] *
+           \mbox{data}[b, k, \mbox{strides}[0] * w + dw] *
            \mbox{weight}[c, k, dw]
 
     Padding and dilation are applied to data and weight respectively before the computation.
@@ -65,19 +65,19 @@ def conv1d(data,
     weight : tvm.relay.Expr
         The weight expressions.
 
-    stride : Optional[int]
+    strides : Optional[int, Tuple[int]]
         The strides of convolution.
 
     padding : Optional[Tuple[int]]
         The padding of convolution on both sides of the input before convolution.
 
-    dilation : Optional[int]
+    dilation : Optional[int, Tuple[int]]
         Specifies the dilation rate to be used for dilated convolution.
 
     channels : Optional[int]
         Number of output channels of this convolution.
 
-    kernel_size : Optional[int]
+    kernel_size : Optional[int, Tuple[int]]
         The spatial dimension of the convolution kernel.
 
     data_layout : Optional[str]
@@ -97,7 +97,13 @@ def conv1d(data,
     result : tvm.relay.Expr
         The computed result.
     """
-    return _make.conv1d(data, weight, stride, padding, dilation,
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, )
+    if isinstance(strides, int):
+        strides = (strides, )
+    if isinstance(dilation, int):
+        dilation = (dilation, )
+    return _make.conv1d(data, weight, strides, padding, dilation,
                         channels, kernel_size, data_layout,
                         kernel_layout, out_layout, out_dtype)
 

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -24,7 +24,7 @@ from . import _make
 def conv1d(data,
            weight,
            strides=1,
-           padding=(0, 0),
+           padding=0,
            dilation=1,
            groups=1,
            channels=None,
@@ -69,7 +69,7 @@ def conv1d(data,
     strides : Optional[int, Tuple[int]]
         The strides of convolution.
 
-    padding : Optional[Tuple[int]]
+    padding : Optional[int, Tuple[int]]
         The padding of convolution on both sides of the input before convolution.
 
     dilation : Optional[int, Tuple[int]]
@@ -107,6 +107,8 @@ def conv1d(data,
         strides = (strides, )
     if isinstance(dilation, int):
         dilation = (dilation, )
+    if isinstance(padding, int):
+        padding = (padding, padding)
     return _make.conv1d(data, weight, strides, padding, dilation,
                         groups, channels, kernel_size, data_layout,
                         kernel_layout, out_layout, out_dtype)
@@ -157,13 +159,13 @@ def conv2d(data,
     weight : tvm.relay.Expr
         The weight expressions.
 
-    strides : Optional[Tuple[int]]
+    strides : Optional[int, Tuple[int]]
         The strides of convolution.
 
-    padding : Optional[Tuple[int]]
+    padding : Optional[int, Tuple[int]]
         The padding of convolution on both sides of inputs before convolution.
 
-    dilation : Optional[Tuple[int]]
+    dilation : Optional[int, Tuple[int]]
         Specifies the dilation rate to be used for dilated convolution.
 
     groups : Optional[int]
@@ -172,7 +174,7 @@ def conv2d(data,
     channels : Optional[int]
         Number of output channels of this convolution.
 
-    kernel_size : Optional[Tuple[int]]
+    kernel_size : Optional[int, Tuple[int]]
         The spatial of the convolution kernel.
 
     data_layout : Optional[str]
@@ -192,6 +194,15 @@ def conv2d(data,
     result : tvm.relay.Expr
         The computed result.
     """
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if isinstance(strides, int):
+        strides = (strides, strides)
+    if isinstance(dilation, int):
+        dilation = (dilation, dilation)
+    if isinstance(padding, int):
+        padding = (padding, padding)
+
     return _make.conv2d(data, weight, strides, padding, dilation,
                         groups, channels, kernel_size, data_layout,
                         kernel_layout, out_layout, out_dtype)
@@ -245,10 +256,10 @@ def conv3d(data,
     strides : Optional[Tuple[int]]
         The strides of convolution.
 
-    padding : Optional[Tuple[int]]
+    padding : Optional[int, Tuple[int]]
         The padding of convolution on both sides of inputs before convolution.
 
-    dilation : Optional[Tuple[int]]
+    dilation : Optional[int, Tuple[int]]
         Specifies the dilation rate to be used for dilated convolution.
 
     groups : Optional[int]
@@ -257,7 +268,7 @@ def conv3d(data,
     channels : Optional[int]
         Number of output channels of this convolution.
 
-    kernel_size : Optional[Tuple[int]]
+    kernel_size : Optional[int, Tuple[int]]
         The spatial of the convolution kernel.
 
     data_layout : Optional[str]
@@ -277,6 +288,15 @@ def conv3d(data,
     result : tvm.relay.Expr
         The computed result.
     """
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size, kernel_size)
+    if isinstance(strides, int):
+        strides = (strides, strides, strides)
+    if isinstance(dilation, int):
+        dilation = (dilation, dilation, dilation)
+    if isinstance(padding, int):
+        padding = (padding, padding, padding)
+
     return _make.conv3d(data, weight, strides, padding, dilation,
                         groups, channels, kernel_size, data_layout,
                         kernel_layout, out_layout, out_dtype)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -21,6 +21,87 @@ from ...expr import TupleWrapper
 from . import _make
 
 
+def conv1d(data,
+           weight,
+           stride=1,
+           padding=(0, 0),
+           dilation=1,
+           channels=None,
+           kernel_size=None,
+           data_layout="NCW",
+           kernel_layout="OIW",
+           out_layout="",
+           out_dtype=""):
+    r"""1D convolution.
+
+    This operator takes the weight as the convolution kernel
+    and convolves it with data to produce an output.
+
+
+    In the default case, where the data_layout is `NCW`
+    and kernel_layout is `OIW`, conv1d takes in
+    a data Tensor with shape `(batch_size, in_channels, width)`,
+    and a weight Tensor with shape `(channels, in_channels, kernel_size)`
+    to produce an output Tensor with the following rule:
+
+    .. math::
+
+        \mbox{out}[b, c, w] = \sum_{dw, k}
+           \mbox{data}[b, k, \mbox{strides}[1] * w + dw] *
+           \mbox{weight}[c, k, dw]
+
+    Padding and dilation are applied to data and weight respectively before the computation.
+    This operator accepts data layout specification.
+    Semantically, the operator will convert the layout to the canonical layout
+    (`NCW` for data and `OIW` for weight), perform the computation,
+    then convert to the out_layout.
+
+
+    Parameters
+    ----------
+    data : tvm.relay.Expr
+        The input data to the operator.
+
+    weight : tvm.relay.Expr
+        The weight expressions.
+
+    stride : Optional[int]
+        The strides of convolution.
+
+    padding : Optional[Tuple[int]]
+        The padding of convolution on both sides of the input before convolution.
+
+    dilation : Optional[int]
+        Specifies the dilation rate to be used for dilated convolution.
+
+    channels : Optional[int]
+        Number of output channels of this convolution.
+
+    kernel_size : Optional[int]
+        The spatial dimension of the convolution kernel.
+
+    data_layout : Optional[str]
+        Layout of the input.
+
+    kernel_layout : Optional[str]
+        Layout of the weight.
+
+    out_layout : Optional[str]
+        Layout of the output, by default, out_layout is the same as data_layout
+
+    out_dtype : Optional[str]
+        Specifies the output data type for mixed precision conv2d.
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The computed result.
+    """
+    return _make.conv1d(data, weight, stride, padding, dilation,
+                        channels, kernel_size, data_layout,
+                        kernel_layout, out_layout, out_dtype)
+
+
 def conv2d(data,
            weight,
            strides=(1, 1),

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -26,6 +26,7 @@ def conv1d(data,
            strides=1,
            padding=(0, 0),
            dilation=1,
+           groups=1,
            channels=None,
            kernel_size=None,
            data_layout="NCW",
@@ -74,6 +75,9 @@ def conv1d(data,
     dilation : Optional[int, Tuple[int]]
         Specifies the dilation rate to be used for dilated convolution.
 
+    groups : Optional[int]
+        Currently unused for 1D convolution.
+
     channels : Optional[int]
         Number of output channels of this convolution.
 
@@ -104,7 +108,7 @@ def conv1d(data,
     if isinstance(dilation, int):
         dilation = (dilation, )
     return _make.conv1d(data, weight, strides, padding, dilation,
-                        channels, kernel_size, data_layout,
+                        groups, channels, kernel_size, data_layout,
                         kernel_layout, out_layout, out_dtype)
 
 

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -19,6 +19,12 @@
 from ...attrs import Attrs
 from ..base import register_relay_attr_node
 
+
+@register_relay_attr_node
+class Conv1DAttrs(Attrs):
+    """Attributes for nn.conv1d"""
+
+
 @register_relay_attr_node
 class Conv2DAttrs(Attrs):
     """Attributes for nn.conv2d"""

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -58,19 +58,19 @@ TVM_REGISTER_NODE_TYPE(Conv1DAttrs);
 // used by frontend FFI.
 Expr MakeConv1D(Expr data,
                 Expr weight,
-                int stride,
+                Array<IndexExpr> strides,
                 Array<IndexExpr> padding,
-                int dilation,
+                Array<IndexExpr> dilation,
                 IndexExpr channels,
-                IndexExpr kernel_size,
+                Array<IndexExpr> kernel_size,
                 std::string data_layout,
                 std::string kernel_layout,
                 std::string out_layout,
                 DataType out_dtype) {
   auto attrs = make_object<Conv1DAttrs>();
-  attrs->stride = stride;
+  attrs->strides = std::move(strides);
   attrs->padding = std::move(padding);
-  attrs->dilation = dilation;
+  attrs->dilation = std::move(dilation);
   attrs->channels = std::move(channels);
   attrs->kernel_size = std::move(kernel_size);
   attrs->data_layout = std::move(data_layout);

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -51,39 +51,57 @@ Array<Array<Layout> > ConvInferCorrectLayout(
 }
 
 
-// relay.nn.conv1d
-TVM_REGISTER_NODE_TYPE(Conv1DAttrs);
-
-// Positional relay function to create conv1d operator
-// used by frontend FFI.
-Expr MakeConv1D(Expr data,
-                Expr weight,
-                Array<IndexExpr> strides,
-                Array<IndexExpr> padding,
-                Array<IndexExpr> dilation,
-                IndexExpr channels,
-                Array<IndexExpr> kernel_size,
-                std::string data_layout,
-                std::string kernel_layout,
-                std::string out_layout,
-                DataType out_dtype) {
-  auto attrs = make_object<Conv1DAttrs>();
+template <typename T>
+Expr MakeConv(Expr data,
+              Expr weight,
+              Array<IndexExpr> strides,
+              Array<IndexExpr> padding,
+              Array<IndexExpr> dilation,
+              int groups,
+              IndexExpr channels,
+              Array<IndexExpr> kernel_size,
+              std::string data_layout,
+              std::string kernel_layout,
+              std::string out_layout,
+              DataType out_dtype,
+              std::string op_name) {
+  auto attrs = make_object<T>();
   attrs->strides = std::move(strides);
   attrs->padding = std::move(padding);
   attrs->dilation = std::move(dilation);
+  attrs->groups = groups;
   attrs->channels = std::move(channels);
   attrs->kernel_size = std::move(kernel_size);
   attrs->data_layout = std::move(data_layout);
   attrs->kernel_layout = std::move(kernel_layout);
   attrs->out_layout = std::move(out_layout);
   attrs->out_dtype = std::move(out_dtype);
-  static const Op& op = Op::Get("nn.conv1d");
+  static const Op& op = Op::Get(op_name);
   return CallNode::make(op, {data, weight}, Attrs(attrs), {});
 }
 
 
+// relay.nn.conv1d
+TVM_REGISTER_NODE_TYPE(Conv1DAttrs);
+
 TVM_REGISTER_GLOBAL("relay.op.nn._make.conv1d")
-.set_body_typed(MakeConv1D);
+.set_body_typed([](Expr data,
+                   Expr weight,
+                   Array<IndexExpr> strides,
+                   Array<IndexExpr> padding,
+                   Array<IndexExpr> dilation,
+                   int groups,
+                   IndexExpr channels,
+                   Array<IndexExpr> kernel_size,
+                   std::string data_layout,
+                   std::string kernel_layout,
+                   std::string out_layout,
+                   DataType out_dtype) {
+  return MakeConv<Conv1DAttrs>(
+    data, weight, strides, padding, dilation,
+    groups, channels, kernel_size, data_layout,
+    kernel_layout, out_layout, out_dtype, "nn.conv1d");
+});
 
 
 RELAY_REGISTER_OP("nn.conv1d")
@@ -111,38 +129,24 @@ with the layer input to produce a tensor of outputs.
 // relay.nn.conv2d
 TVM_REGISTER_NODE_TYPE(Conv2DAttrs);
 
-// Positional relay function to create conv2d operator
-// used by frontend FFI.
-Expr MakeConv2D(Expr data,
-                Expr weight,
-                Array<IndexExpr> strides,
-                Array<IndexExpr> padding,
-                Array<IndexExpr> dilation,
-                int groups,
-                IndexExpr channels,
-                Array<IndexExpr> kernel_size,
-                std::string data_layout,
-                std::string kernel_layout,
-                std::string out_layout,
-                DataType out_dtype) {
-  auto attrs = make_object<Conv2DAttrs>();
-  attrs->strides = std::move(strides);
-  attrs->padding = std::move(padding);
-  attrs->dilation = std::move(dilation);
-  attrs->groups = groups;
-  attrs->channels = std::move(channels);
-  attrs->kernel_size = std::move(kernel_size);
-  attrs->data_layout = std::move(data_layout);
-  attrs->kernel_layout = std::move(kernel_layout);
-  attrs->out_layout = std::move(out_layout);
-  attrs->out_dtype = std::move(out_dtype);
-  static const Op& op = Op::Get("nn.conv2d");
-  return CallNode::make(op, {data, weight}, Attrs(attrs), {});
-}
-
-
 TVM_REGISTER_GLOBAL("relay.op.nn._make.conv2d")
-.set_body_typed(MakeConv2D);
+.set_body_typed([](Expr data,
+                   Expr weight,
+                   Array<IndexExpr> strides,
+                   Array<IndexExpr> padding,
+                   Array<IndexExpr> dilation,
+                   int groups,
+                   IndexExpr channels,
+                   Array<IndexExpr> kernel_size,
+                   std::string data_layout,
+                   std::string kernel_layout,
+                   std::string out_layout,
+                   DataType out_dtype) {
+  return MakeConv<Conv2DAttrs>(
+    data, weight, strides, padding, dilation,
+    groups, channels, kernel_size, data_layout,
+    kernel_layout, out_layout, out_dtype, "nn.conv2d");
+});
 
 
 RELAY_REGISTER_OP("nn.conv2d")
@@ -169,38 +173,24 @@ with the layer input to produce a tensor of outputs.
 // relay.nn.conv3d
 TVM_REGISTER_NODE_TYPE(Conv3DAttrs);
 
-// Positional relay function to create conv3d operator
-// used by frontend FFI.
-Expr MakeConv3D(Expr data,
-                Expr weight,
-                Array<IndexExpr> strides,
-                Array<IndexExpr> padding,
-                Array<IndexExpr> dilation,
-                int groups,
-                IndexExpr channels,
-                Array<IndexExpr> kernel_size,
-                std::string data_layout,
-                std::string kernel_layout,
-                std::string out_layout,
-                DataType out_dtype) {
-  auto attrs = make_object<Conv3DAttrs>();
-  attrs->strides = std::move(strides);
-  attrs->padding = std::move(padding);
-  attrs->dilation = std::move(dilation);
-  attrs->groups = groups;
-  attrs->channels = std::move(channels);
-  attrs->kernel_size = std::move(kernel_size);
-  attrs->data_layout = std::move(data_layout);
-  attrs->kernel_layout = std::move(kernel_layout);
-  attrs->out_layout = std::move(out_layout);
-  attrs->out_dtype = std::move(out_dtype);
-  static const Op& op = Op::Get("nn.conv3d");
-  return CallNode::make(op, {data, weight}, Attrs(attrs), {});
-}
-
-
 TVM_REGISTER_GLOBAL("relay.op.nn._make.conv3d")
-.set_body_typed(MakeConv3D);
+.set_body_typed([](Expr data,
+                   Expr weight,
+                   Array<IndexExpr> strides,
+                   Array<IndexExpr> padding,
+                   Array<IndexExpr> dilation,
+                   int groups,
+                   IndexExpr channels,
+                   Array<IndexExpr> kernel_size,
+                   std::string data_layout,
+                   std::string kernel_layout,
+                   std::string out_layout,
+                   DataType out_dtype) {
+  return MakeConv<Conv3DAttrs>(
+    data, weight, strides, padding, dilation,
+    groups, channels, kernel_size, data_layout,
+    kernel_layout, out_layout, out_dtype, "nn.conv3d");
+});
 
 
 RELAY_REGISTER_OP("nn.conv3d")

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -82,7 +82,7 @@ Expr MakeConv1D(Expr data,
 }
 
 
-TVM_REGISTER_API("relay.op.nn._make.conv1d")
+TVM_REGISTER_GLOBAL("relay.op.nn._make.conv1d")
 .set_body_typed(MakeConv1D);
 
 

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -34,8 +34,6 @@
 namespace tvm {
 namespace relay {
 
-// relay.nn.conv2d
-TVM_REGISTER_NODE_TYPE(Conv2DAttrs);
 
 template<typename T>
 Array<Array<Layout> > ConvInferCorrectLayout(
@@ -51,6 +49,10 @@ Array<Array<Layout> > ConvInferCorrectLayout(
                                {params->out_layout == "" ?
                                    params->data_layout : params->out_layout}};
 }
+
+
+// relay.nn.conv1d
+TVM_REGISTER_NODE_TYPE(Conv1DAttrs);
 
 // Positional relay function to create conv1d operator
 // used by frontend FFI.
@@ -105,6 +107,9 @@ with the layer input to produce a tensor of outputs.
 .add_type_rel("Conv1D", Conv1DRel<Conv1DAttrs>)
 .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv1DAttrs>);
 
+
+// relay.nn.conv2d
+TVM_REGISTER_NODE_TYPE(Conv2DAttrs);
 
 // Positional relay function to create conv2d operator
 // used by frontend FFI.

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -104,7 +104,7 @@ bool Conv1DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   // dilation
   Array<IndexExpr> oshape({dshape_ncw[0], channels, 0});
 
-  if (!dshape_ncw[2].as<ir::Any>()) {
+  if (!dshape_ncw[2].as<ir::AnyNode>()) {
     oshape.Set(2, indexdiv(dshape_ncw[2] + param->padding[0] + param->padding[1] - dilated_ksize,
                            param->strides[0]) + 1);
   } else {

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -34,6 +34,94 @@ namespace tvm {
 namespace relay {
 
 template <typename AttrType>
+bool Conv1DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+               const TypeReporter& reporter) {
+  CHECK_EQ(types.size(), 3);
+  const auto* data = types[0].as<TensorTypeNode>();
+  const auto* weight = types[1].as<TensorTypeNode>();
+  if (data == nullptr) return false;
+  static const Layout kNCW("NCW");
+  static const Layout kOIW("OIW");
+
+  const AttrType* param = attrs.as<AttrType>();
+  CHECK(param != nullptr);
+  const Layout in_layout(param->data_layout);
+  const Layout kernel_layout(param->kernel_layout);
+
+  const auto trans_in_layout = BijectiveLayoutNode::make(in_layout, kNCW);
+  CHECK(trans_in_layout.defined())
+      << "Conv only support input layouts that are convertible from NCW."
+      << " But got " << in_layout;
+
+  const auto trans_kernel_layout = BijectiveLayoutNode::make(kernel_layout, kOIW);
+  CHECK(trans_kernel_layout.defined())
+      << "Conv only support kernel layouts that are convertible from OIW."
+      << " But got " << kernel_layout;
+
+  Layout out_layout(param->out_layout == "" ? param->data_layout : param->out_layout);
+  const auto trans_out_layout = BijectiveLayoutNode::make(out_layout, kNCW);
+  CHECK(trans_out_layout.defined())
+      << "Conv only support output layouts that are convertible from NCW."
+      << " But got " << out_layout;
+
+  Array<IndexExpr> dshape_ncw = trans_in_layout.ForwardShape(data->shape);
+
+  IndexExpr channels, dilated_ksize;
+  // infer weight if the kernel_size and channels are defined
+  if (param->kernel_size.defined() && param->channels.defined()) {
+    Array<IndexExpr> wshape;
+
+    wshape = {{param->channels, dshape_ncw[1], param->kernel_size}};
+
+    wshape = trans_kernel_layout.BackwardShape(wshape);
+    channels = param->channels;
+    dilated_ksize = 1 + (param->kernel_size - 1) * param->dilation;
+    DataType weight_dtype = data->dtype;
+    if (weight != nullptr) {
+      weight_dtype = weight->dtype;
+    }
+    // assign result to reporter
+    reporter->Assign(types[1], TensorTypeNode::make(wshape, weight_dtype));
+  } else {
+    // use weight to infer the conv shape.
+    if (weight == nullptr) return false;
+    auto wshape = trans_kernel_layout.ForwardShape(weight->shape);
+    if (param->kernel_size.defined()) {
+      // check the size
+      CHECK(reporter->AssertEQ(param->kernel_size, wshape[2]) )
+          << "Conv1D: shape of weight is inconsistent with kernel_size, "
+          << " kernel_size=" << param->kernel_size << " wshape=" << wshape;
+    }
+    if (param->channels.defined()) {
+      CHECK(reporter->AssertEQ(param->channels, wshape[0]))
+          << "Conv1D: shape of weight is inconsistent with channels, "
+          << " channels=" << param->channels << " wshape=" << wshape;
+    }
+    CHECK(reporter->AssertEQ(dshape_ncw[1], wshape[1]));
+    channels = wshape[0];
+    dilated_ksize = 1 + (wshape[2] - 1) * param->dilation;
+  }
+  // dilation
+  Array<IndexExpr> oshape({dshape_ncw[0], channels, 0});
+
+  if (!dshape_ncw[2].as<ir::Any>()) {
+    oshape.Set(2, indexdiv(dshape_ncw[2] + param->padding[0] + param->padding[1] - dilated_ksize,
+                           param->stride) + 1);
+  } else {
+    oshape.Set(2, dshape_ncw[2]);
+  }
+
+  DataType out_dtype = param->out_dtype;
+  if (out_dtype.bits() == 0) {
+    out_dtype = data->dtype;
+  }
+  oshape = trans_out_layout.BackwardShape(oshape);
+  // assign output type
+  reporter->Assign(types[2], TensorTypeNode::make(oshape, out_dtype));
+  return true;
+}
+
+template <typename AttrType>
 bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 3);

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1743,7 +1743,7 @@ def verify_conv(x_shape, w_shape, y_shape, padding, kernel_shape, strides, dilat
                                 dilations=dilations,
                                 # groups=1
                                 auto_pad=auto_pad)
-    else:                                
+    else:
         node = helper.make_node('Conv',
                                 inputs=['x', 'W'],
                                 outputs=['y'],
@@ -1758,8 +1758,7 @@ def verify_conv(x_shape, w_shape, y_shape, padding, kernel_shape, strides, dilat
                               'conv_test',
                               inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, list(x_shape)),
                                       helper.make_tensor_value_info("W", TensorProto.FLOAT, list(w_shape))],
-                              outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, list(y_shape))]
-                              )
+                              outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, list(y_shape))])
 
     model = helper.make_model(graph, producer_name='conv_test')
 
@@ -1774,94 +1773,34 @@ def verify_conv(x_shape, w_shape, y_shape, padding, kernel_shape, strides, dilat
 def test_conv():
     # Convolution with padding
     # Conv2D
-    verify_conv(x_shape=(1, 1, 5, 5),
-                w_shape=(1, 1, 3, 3),
-                y_shape=(1, 1, 5, 5),
-                padding=[1, 1, 1, 1],
-                kernel_shape=[3, 3],
-                strides=[1, 1],
-                dilations=[1, 1])
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 5, 5), [1, 1, 1, 1], [3, 3], [1, 1], [1, 1])
     # Conv1D
-    verify_conv(x_shape=(1, 1, 5),
-                w_shape=(1, 1, 3),
-                y_shape=(1, 1, 5),
-                padding=[1, 1],
-                kernel_shape=[3,],
-                strides=[1,],
-                dilations=[1,])
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 5), [1, 1], [3], [1], [1])
 
     # Convolution without padding
     # Conv2D
-    verify_conv(x_shape=(1, 1, 5, 5),
-                w_shape=(1, 1, 3, 3),
-                y_shape=(1, 1, 3, 3),
-                padding=[0, 0, 0, 0],
-                kernel_shape=[3, 3],
-                strides=[1, 1],
-                dilations=[1, 1])
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 3, 3), [0, 0, 0, 0], [3, 3], [1, 1], [1, 1])
     # Conv1D
-    verify_conv(x_shape=(1, 1, 5),
-                w_shape=(1, 1, 3),
-                y_shape=(1, 1, 3),
-                padding=[0, 0],
-                kernel_shape=[3,],
-                strides=[1,],
-                dilations=[1,])
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 3), [0, 0], [3], [1], [1])
 
     # Convolution with autopadding
-    verify_conv(x_shape=(1, 1, 5, 5),
-                w_shape=(1, 1, 3, 3),
-                y_shape=(1, 1, 5, 5),
-                kernel_shape=[3, 3],
-                strides=[1, 1],
-                dilations=[1, 1],
-                padding=None,
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 5, 5),
+                None, [3, 3], [1, 1], [1, 1],
                 auto_pad="SAME_UPPER")
     # Conv1D
-    verify_conv(x_shape=(1, 1, 5),
-                w_shape=(1, 1, 3),
-                y_shape=(1, 1, 5),
-                kernel_shape=[3,],
-                strides=[1,],
-                dilations=[1,],
-                padding=None,
-                auto_pad="SAME_UPPER")
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 5), None, [3], [1], [1], auto_pad="SAME_UPPER")
 
     # Convolution with non uniform stride
-    verify_conv(x_shape=(1, 1, 5, 5),
-                w_shape=(1, 1, 3, 3),
-                y_shape=(1, 1, 3, 3),
-                kernel_shape=[3, 3],
-                strides=[2, 2],
-                dilations=[1, 1],
-                padding=None,
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 3, 3),
+                None, [3, 3], [2, 2], [1, 1],
                 auto_pad="SAME_UPPER")
     # Conv1D
-    verify_conv(x_shape=(1, 1, 5),
-                w_shape=(1, 1, 3),
-                y_shape=(1, 1, 3),
-                kernel_shape=[3,],
-                strides=[2,],
-                dilations=[1,],
-                padding=None,
-                auto_pad="SAME_UPPER")
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 3), None, [3], [2], [1], auto_pad="SAME_UPPER")
 
     # Convolution with dilation
-    verify_conv(x_shape=(1, 1, 5, 5),
-                w_shape=(1, 1, 3, 3),
-                y_shape=(1, 1, 5, 5),
-                kernel_shape=[3, 3],
-                strides=[1, 1],
-                dilations=[2, 2],
-                padding=[2, 2, 2, 2])
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 5, 5), [2, 2, 2, 2], [3, 3], [1, 1], [2, 2])
     # Conv1D
-    verify_conv(x_shape=(1, 1, 5),
-                w_shape=(1, 1, 3),
-                y_shape=(1, 1, 5),
-                kernel_shape=[3,],
-                strides=[1,],
-                dilations=[2,],
-                padding=[2, 2])
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 5), [2, 2], [3], [1], [2])
 
 
 def verify_convtranspose(x_shape, w_shape, y_shape, p):
@@ -1927,15 +1866,15 @@ def verify_pooling(x_shape, kernel_shape, strides, pads, out_shape, mode, auto_p
         raise ValueError("Pool method {} is not supported.".format(mode))
 
     if pads is None:
-        pool_node = helper.make_node(node_type, 
-                                    inputs=["x"], 
+        pool_node = helper.make_node(node_type,
+                                    inputs=["x"],
                                     outputs=["y"],
                                     kernel_shape=kernel_shape,
                                     auto_pad=auto_pad,
                                     strides=strides)
     else:
-        pool_node = helper.make_node(node_type, 
-                                    inputs=["x"], 
+        pool_node = helper.make_node(node_type,
+                                    inputs=["x"],
                                     outputs=["y"],
                                     kernel_shape=kernel_shape,
                                     pads=pads,

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1732,11 +1732,11 @@ def test_or():
     verify_or(indata=[x, y], dtype=bool)
 
 
-def verify_conv(x_shape, w_shape, y_shape, p):
+def verify_conv(x_shape, w_shape, y_shape, p, kernel_shape):
     node = helper.make_node('Conv',
                             inputs=['x', 'W'],
                             outputs=['y'],
-                            kernel_shape=[3, 3],
+                            kernel_shape=kernel_shape,
                             # Default values for other attributes:
                             # strides=[1, 1],
                             # dilations=[1, 1],
@@ -1765,14 +1765,21 @@ def test_conv():
     # (1, 1, 3, 3) tensor for convolution weights
     # (1, 1, 5, 5) output tensor
     # [1, 1, 1, 1] list for pads
-    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 5, 5), [1, 1, 1, 1])
+    # [3, 3] kernel shape
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 5, 5), [1, 1, 1, 1], [3, 3])
+    # 1D version
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 5), [1, 1], [3])
 
     # Convolution without padding
     # (1, 1, 5, 5) input tensor
     # (1, 1, 3, 3) tensor for convolution weights
     # (1, 1, 3, 3) output tensor
     # [0, 0, 0, 0] list for pads
-    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 3, 3), [0, 0, 0, 0])
+    # [3, 3] kernel shape
+    verify_conv((1, 1, 5, 5), (1, 1, 3, 3), (1, 1, 3, 3), [0, 0, 0, 0], [3, 3])
+    # 1D version
+    verify_conv((1, 1, 5), (1, 1, 3), (1, 1, 3), [0, 0], [3])
+
 
 
 def verify_convtranspose(x_shape, w_shape, y_shape, p):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1956,6 +1956,7 @@ def verify_pooling(x_shape, kernel_shape, strides, pads, out_shape, mode, auto_p
             model, [x_np], target, ctx, out_shape)
         tvm.testing.assert_allclose(onnx_out, tvm_out, rtol=1e-5, atol=1e-5)
 
+
 def test_pooling():
     for mode in ['max', 'average']:
         # Pool1D

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -31,6 +31,101 @@ def run_infer_type(expr):
     entry = mod["main"]
     return entry if isinstance(expr, relay.Function) else entry.body
 
+
+def test_conv1d_infer_type():
+    # symbolic in batch dimension
+    n, c, w = tvm.var("n"), 10, 224
+    x = relay.var("x", relay.ty.TensorType((n, c, w), "float32"))
+    w = relay.var("w")
+    y = relay.nn.conv1d(x, w,
+                        kernel_size=3,
+                        padding=(1, 1),
+                        channels=2)
+    yy = run_infer_type(y)
+    assert yy.checked_type ==  relay.TensorType(
+        (n, 2, 224), "float32")
+    assert yy.args[1].checked_type == relay.TensorType(
+        (2, 10, 3), "float32")
+
+    # infer by shape of w, mixed precision
+    n, c, w = tvm.var("n"), 10, 224
+    x = relay.var("x", relay.TensorType((n, c, w), "int8"))
+    w = relay.var("w", relay.TensorType((2, 10, 3), "int8"))
+    y = relay.nn.conv1d(x, w, out_dtype="int32")
+    assert "out_dtype=\"int32\"" in y.astext()
+    yy = run_infer_type(y)
+    assert yy.checked_type ==  relay.TensorType(
+        (n, 2, 222), "int32")
+
+    # infer shape in case of different dtypes for input and weight.
+    n, c, w = tvm.var("n"), 10, 224
+    x = relay.var("x", relay.TensorType((n, c, w), "uint8"))
+    w = relay.var("w", relay.TensorType((2, 10, 3), "int8"))
+    y = relay.nn.conv1d(x, w, out_dtype="int32")
+    assert "out_dtype=\"int32\"" in y.astext()
+    yy = run_infer_type(y)
+    assert yy.checked_type ==  relay.TensorType(
+        (n, 2, 222), "int32")
+
+    # Infer with NWC
+    n, c, w = 4, 32, 224
+    x = relay.var("x", relay.TensorType((n, w, c), "int8"))
+    wt = relay.var("w")
+    y = relay.nn.conv1d(x, wt,
+                        kernel_size=3,
+                        padding=(1, 1),
+                        channels=16,
+                        data_layout="NWC",
+                        out_dtype="int32")
+    yy = run_infer_type(y)
+    assert yy.checked_type ==  relay.TensorType(
+        (n, w, 16), "int32")
+
+
+def test_conv1d_run():
+    def run_test_conv1d(dtype, out_dtype, scale, dshape, kshape,
+                        padding=(1, 1),
+                        fref=None,
+                        dilation=1,
+                        except_targets=None,
+                        **attrs):
+        if except_targets is None:
+            except_targets = []
+
+        x = relay.var("x", shape=dshape, dtype=dtype)
+        w = relay.var("w", dtype=dtype)
+        y = relay.nn.conv1d(x, w,
+                            padding=padding,
+                            dilation=dilation,
+                            **attrs)
+        func = relay.Function([x, w], y)
+        data = np.random.uniform(-scale, scale, size=dshape).astype(dtype)
+        kernel = np.random.uniform(-scale, scale, size=kshape).astype(dtype)
+        ref_res = topi.testing.conv1d_ncw_python(
+            data.astype(out_dtype), kernel.astype(out_dtype), 1, padding, dilation)
+
+        for target, ctx in ctx_list():
+            if target in except_targets:
+                continue
+            intrp1 = relay.create_executor("graph", ctx=ctx, target=target)
+            op_res1 = intrp1.evaluate(func)(data, kernel)
+            tvm.testing.assert_allclose(op_res1.asnumpy(), ref_res, rtol=1e-5, atol=1e-5)
+
+    # normal conv1d
+    dshape = (1, 3, 224)
+    kshape = (10, 3, 3)
+    run_test_conv1d("float32", "float32", 1, dshape, kshape,
+                    padding=(1, 1), channels=10, kernel_size=3)
+    # mixed precision
+    run_test_conv1d("int8", "int32", 1, dshape, kshape,
+                    padding=(1, 1), channels=10, kernel_size=3)
+    # dilated conv2d
+    dshape = (1, 3, 18)
+    kshape = (10, 3, 3)
+    run_test_conv1d("float32", "float32", 1, dshape, kshape,
+                    padding=(1, 1), channels=10, kernel_size=3, dilation=3)
+
+
 def test_conv2d_infer_type():
     # symbolic in batch dimension
     n, c, h, w = tvm.var("n"), 10, 224, 224
@@ -1115,6 +1210,7 @@ if __name__ == "__main__":
     test_avg_pool2d_no_count_pad()
     test_lrn()
     test_l2_normalize()
+    test_conv1d_infer_type()
     test_conv2d_infer_type()
     test_conv3d_infer_type()
     test_bitpack_infer_type()
@@ -1127,6 +1223,7 @@ if __name__ == "__main__":
     test_conv2d_transpose_nchw_run()
     test_conv2d_transpose_nhwc_run()
     test_conv1d_transpose_ncw_run()
+    test_conv1d_run()
     test_conv2d_run()
     test_conv2d_winograd()
     test_conv3d_run()

--- a/topi/python/topi/cuda/__init__.py
+++ b/topi/python/topi/cuda/__init__.py
@@ -19,8 +19,8 @@
 """CUDA specific declaration and schedules."""
 from __future__ import absolute_import as _abs
 
-from . import conv2d, depthwise_conv2d, conv2d_transpose_nchw, deformable_conv2d, \
-              group_conv2d_nchw, dense, conv1d_transpose_ncw
+from . import conv1d, conv2d, depthwise_conv2d, conv2d_transpose_nchw, \
+              deformable_conv2d, group_conv2d_nchw, dense, conv1d_transpose_ncw
 from . import conv3d
 from .conv2d_hwcn import schedule_conv2d_hwcn
 from .depthwise_conv2d import schedule_depthwise_conv2d_backward_input_nhwc

--- a/topi/python/topi/cuda/conv1d.py
+++ b/topi/python/topi/cuda/conv1d.py
@@ -32,7 +32,6 @@ def conv1d_cuda(cfg,
                 padding,
                 dilation,
                 layout='NCW',
-                pad_method='SYMMETRIC',
                 out_dtype='float32'):
     """ 1D convolution forward operator for cuda backend.
 
@@ -61,10 +60,6 @@ def conv1d_cuda(cfg,
     layout : str
         How input data is laid out, must be one of ['NCW', 'NWC']
 
-    pad_method : str
-        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
-        Useful when dealing with Tensorflow and Keras funkiness.
-    
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
@@ -79,10 +74,10 @@ def conv1d_cuda(cfg,
 
     if layout == 'NCW':
         return nn.conv1d_ncw(data, kernel, stride, padding, dilation,
-                             pad_method, out_dtype)
+                             out_dtype)
     elif layout == 'NWC':
         return nn.conv1d_nwc(data, kernel, stride, padding, dilation,
-                             pad_method, out_dtype)
+                             out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))
 
 

--- a/topi/python/topi/cuda/conv1d.py
+++ b/topi/python/topi/cuda/conv1d.py
@@ -14,14 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, unused-argument
 """Compute definition for conv1d with cuda backend"""
 import tvm
 from tvm import autotvm
-from tvm.contrib import cudnn
 
 from .. import nn, generic
-from ..util import get_const_tuple, traverse_inline
+from ..util import traverse_inline
 
 
 @autotvm.register_topi_compute(nn.conv1d, ['cuda', 'gpu'], ['direct'])
@@ -55,7 +54,7 @@ def conv1d_cuda(cfg,
         Padding size, or ['VALID', 'SAME']
 
     dilation : int
-        Dilation rate if convolution should be dilated. 
+        Dilation rate if convolution should be dilated.
 
     layout : str
         How input data is laid out, must be one of ['NCW', 'NWC']
@@ -63,9 +62,7 @@ def conv1d_cuda(cfg,
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
-    target = tvm.target.current_target()
-
-    if out_dtype == None:
+    if out_dtype is None:
         out_dtype = data.dtype
     if isinstance(stride, (tuple, list)):
         stride = stride[0]
@@ -75,7 +72,7 @@ def conv1d_cuda(cfg,
     if layout == 'NCW':
         return nn.conv1d_ncw(data, kernel, stride, padding, dilation,
                              out_dtype)
-    elif layout == 'NWC':
+    if layout == 'NWC':
         return nn.conv1d_nwc(data, kernel, stride, padding, dilation,
                              out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))

--- a/topi/python/topi/cuda/conv1d.py
+++ b/topi/python/topi/cuda/conv1d.py
@@ -1,0 +1,290 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Compute definition for conv1d with cuda backend"""
+import tvm
+from tvm import autotvm
+from tvm.contrib import cudnn
+
+from .. import nn, generic
+from ..util import get_const_tuple, traverse_inline
+
+
+@autotvm.register_topi_compute(nn.conv1d, ['cuda', 'gpu'], ['direct'])
+def conv1d_cuda(cfg, data, kernel, stride, padding, dilation, layout='NCW', pad_method='SYMMETRIC', out_dtype='float32'):
+    """ 1D convolution forward operator for cuda backend.
+
+    Parameters
+    ----------
+    cfg : ConfigEntity
+        The config for this template
+
+    data : tvm.Tensor
+        3-D input shape [batch, in_channel, in_width] for layout == 'NCW'
+        and [batch, in_width, in_channel] for layout == 'NWC'
+
+    kernel : tvm.Tensor
+        3-D kernel with shape [num_filter, in_channel, filter_size] for layout == 'NCW'
+        and [filter_size, in_channel, num_filter] for layout == 'NWC'
+
+    stride : int
+        The spatial stride along width
+
+    padding : int or str
+        Padding size, or ['VALID', 'SAME']
+
+    dilation : int
+        Dilation rate if convolution should be dilated. 
+
+    layout : str
+        How input data is laid out, must be one of ['NCW', 'NWC']
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
+        Useful when dealing with Tensorflow and Keras funkiness.
+    
+    out_dtype : str
+        The output data type. If None then output is same type as input.
+    """
+    target = tvm.target.current_target()
+
+    if out_dtype == None:
+        out_dtype = data.dtype
+    if isinstance(stride, (tuple, list)):
+        stride = stride[0]
+    if isinstance(dilation, (tuple, list)):
+        dilation = dilation[0]
+
+    if layout == 'NCW':
+        return nn.conv1d_ncw(data, kernel, stride, padding, dilation, pad_method, out_dtype)
+    elif layout == 'NWC':
+        return nn.conv1d_nwc(data, kernel, stride, padding, dilation, pad_method, out_dtype)
+    raise ValueError("This layout is not yet supported: {}".format(layout))
+
+
+@autotvm.register_topi_schedule(generic.schedule_conv1d_ncw, ["cuda", "gpu"], ["direct"])
+def schedule_conv1d_ncw(cfg, outs):
+    """TOPI schedule callback of conv1d ncw for cuda gpu
+
+    Parameters
+    ----------
+    cfg : ConfigEntity
+        the config for this template.
+
+    outs : Array of Tensor
+        The computation graph description of conv1d
+        in the format of an array of tensors.
+
+    Returns
+    -------
+    s : Schedule
+        The computation schedule for conv1d.
+    """
+    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
+    s = tvm.create_schedule([x.op for x in outs])
+
+    def _callback(op):
+        if op.tag == 'conv1d_ncw':
+            pad_data = op.input_tensors[0]
+            kernel = op.input_tensors[1]
+            conv = op.output(0)
+
+            ##### space definition begin #####
+            n, f, x = s[conv].op.axis
+            rc = s[conv].op.reduce_axis[0]
+            cfg.define_split("tile_n", cfg.axis(n), num_outputs=4)
+            cfg.define_split("tile_f", cfg.axis(f), num_outputs=4)
+            cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
+            cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
+            cfg.define_knob("auto_unroll_max_step", [64, 512, 1500])
+
+            target = tvm.target.current_target()
+            if target.target_name in ['nvptx', 'rocm']:
+                cfg.define_knob("unroll_explicit", [1])
+            else:
+                cfg.define_knob("unroll_explicit", [0, 1])
+
+            ##### space definition end #####
+
+            if isinstance(kernel.op, tvm.tensor.ComputeOp) and 'dilate' in kernel.op.tag:
+                s[kernel].compute_inline()
+
+            if conv.op in s.outputs:
+                output = conv
+                OL = s.cache_write(conv, 'local')
+            else:
+                output = s.outputs[0].output(0)
+                s[conv].set_scope('local')
+                OL = conv
+
+            # create cache stage
+            s[pad_data].set_scope('shared')
+            AA = pad_data
+            WW = s.cache_read(kernel, 'shared', [OL])
+
+            # tile and bind spatial axes
+            n, f, x = s[output].op.axis
+            kernel_scope, n = s[output].split(n, nparts=1)
+            bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
+            bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
+            bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
+
+            s[output].reorder(bn, bf, bx, vn, vf, vx, tn, tf, tx, ni, fi, xi)
+            s[output].bind(bn, tvm.thread_axis("blockIdx.z"))
+            s[output].bind(bf, tvm.thread_axis("blockIdx.y"))
+            s[output].bind(bx, tvm.thread_axis("blockIdx.x"))
+            s[output].bind(vn, tvm.thread_axis("vthread"))
+            s[output].bind(vf, tvm.thread_axis("vthread"))
+            s[output].bind(vx, tvm.thread_axis("vthread"))
+
+            s[output].bind(tx, tvm.thread_axis("threadIdx.x"))
+            s[OL].compute_at(s[output], tx)
+            # number of threads
+            n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
+            n_tx = cfg["tile_x"].size[2]
+
+            # tile reduction axes
+            n, f, x = s[OL].op.axis
+            rc, rx = s[OL].op.reduce_axis
+            rco, rcm, rci = cfg['tile_rc'].apply(s, OL, rc)
+            s[OL].reorder(rco, rcm, rx, rci, n, f, x)
+
+            s[AA].compute_at(s[OL], rx)
+            s[WW].compute_at(s[OL], rx)
+
+            # cooperative fetching
+            for load in [AA, WW]:
+                n, f, x = s[load].op.axis
+                fused = s[load].fuse(f, x)
+                tz, fused = s[load].split(fused, nparts=n_tz)
+                tx, fused = s[load].split(fused, nparts=n_tx)
+                s[load].bind(tz, tvm.thread_axis("threadIdx.y"))
+                s[load].bind(tx, tvm.thread_axis("threadIdx.x"))
+
+            s[output].pragma(kernel_scope, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)
+            s[output].pragma(kernel_scope, 'unroll_explicit', cfg['unroll_explicit'].val)
+
+    traverse_inline(s, outs[0].op, _callback)
+
+    return s
+
+
+@autotvm.register_topi_schedule(generic.schedule_conv1d_nwc, ["cuda", "gpu"], ["direct"])
+def schedule_conv1d_nwc(cfg, outs):
+    """TOPI schedule callback of conv1d nwc for cuda gpu
+
+    Parameters
+    ----------
+    cfg : ConfigEntity
+        the config for this template.
+
+    outs : Array of Tensor
+        The computation graph description of conv1d
+        in the format of an array of tensors.
+
+    Returns
+    -------
+    s : Schedule
+        The computation schedule for conv1d.
+    """
+    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
+    s = tvm.create_schedule([x.op for x in outs])
+
+    def _callback(op):
+        if op.tag == 'conv1d_nwc':
+            pad_data = op.input_tensors[0]
+            kernel = op.input_tensors[1]
+            conv = op.output(0)
+
+            ##### space definition begin #####
+            n, x, f = s[conv].op.axis
+            rc = s[conv].op.reduce_axis[0]
+            cfg.define_split("tile_n", cfg.axis(n), num_outputs=4)
+            cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
+            cfg.define_split("tile_f", cfg.axis(f), num_outputs=4)
+            cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
+            cfg.define_knob("auto_unroll_max_step", [64, 512, 1500])
+
+            target = tvm.target.current_target()
+            if target.target_name in ['nvptx', 'rocm']:
+                cfg.define_knob("unroll_explicit", [1])
+            else:
+                cfg.define_knob("unroll_explicit", [0, 1])
+
+            ##### space definition end #####
+
+            if isinstance(kernel.op, tvm.tensor.ComputeOp) and 'dilate' in kernel.op.tag:
+                s[kernel].compute_inline()
+
+            if conv.op in s.outputs:
+                output = conv
+                OL = s.cache_write(conv, 'local')
+            else:
+                output = s.outputs[0].output(0)
+                s[conv].set_scope('local')
+                OL = conv
+
+            # create cache stage
+            s[pad_data].set_scope('shared')
+            AA = pad_data
+            WW = s.cache_read(kernel, 'shared', [OL])
+
+            # tile and bind spatial axes
+            n, f, x = s[output].op.axis
+            kernel_scope, n = s[output].split(n, nparts=1)
+            bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
+            bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
+            bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
+
+            s[output].reorder(bn, bx, bf, vn, vx, vf, tn, tx, tf, ni, xi, fi)
+            s[output].bind(bn, tvm.thread_axis("blockIdx.z"))
+            s[output].bind(bx, tvm.thread_axis("blockIdx.y"))
+            s[output].bind(bf, tvm.thread_axis("blockIdx.x"))
+            s[output].bind(vn, tvm.thread_axis("vthread"))
+            s[output].bind(vx, tvm.thread_axis("vthread"))
+            s[output].bind(vf, tvm.thread_axis("vthread"))
+
+            s[output].bind(tf, tvm.thread_axis("threadIdx.x"))
+            s[OL].compute_at(s[output], tf)
+            # number of threads
+            n_tz = cfg["tile_n"].size[2] * cfg["tile_x"].size[2]
+            n_tx = cfg["tile_f"].size[2]
+
+            # tile reduction axes
+            n, x, f = s[OL].op.axis
+            rc, rx = s[OL].op.reduce_axis
+            rco, rcm, rci = cfg['tile_rc'].apply(s, OL, rc)
+            s[OL].reorder(rco, rcm, rx, rci, n, x, f)
+
+            s[AA].compute_at(s[OL], rx)
+            s[WW].compute_at(s[OL], rx)
+
+            # cooperative fetching
+            for load in [AA, WW]:
+                n, x, f = s[load].op.axis
+                fused = s[load].fuse(x, f)
+                tz, fused = s[load].split(fused, nparts=n_tz)
+                tx, fused = s[load].split(fused, nparts=n_tx)
+                s[load].bind(tz, tvm.thread_axis("threadIdx.y"))
+                s[load].bind(tx, tvm.thread_axis("threadIdx.x"))
+
+            s[output].pragma(kernel_scope, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)
+            s[output].pragma(kernel_scope, 'unroll_explicit', cfg['unroll_explicit'].val)
+
+    traverse_inline(s, outs[0].op, _callback)
+
+    return s

--- a/topi/python/topi/cuda/conv1d.py
+++ b/topi/python/topi/cuda/conv1d.py
@@ -186,7 +186,7 @@ def schedule_conv1d_ncw(cfg, outs):
 
             N, CO, OW = get_const_tuple(output.shape)
             _, CI, KW = get_const_tuple(kernel.shape)
-            cfg.add_flop(2 * N, * OW * CO * KW * CI)
+            cfg.add_flop(2 * N * OW * CO * KW * CI)
 
     traverse_inline(s, outs[0].op, _callback)
 
@@ -301,7 +301,7 @@ def schedule_conv1d_nwc(cfg, outs):
 
             N, OW, CO = get_const_tuple(output.shape)
             KW, CI, _ = get_const_tuple(kernel.shape)
-            cfg.add_flop(2 * N, * OW * CO * KW * CI)
+            cfg.add_flop(2 * N * OW * CO * KW * CI)
 
     traverse_inline(s, outs[0].op, _callback)
 

--- a/topi/python/topi/cuda/conv1d.py
+++ b/topi/python/topi/cuda/conv1d.py
@@ -27,7 +27,7 @@ from ..util import traverse_inline
 def conv1d_cuda(cfg,
                 data,
                 kernel,
-                stride,
+                strides,
                 padding,
                 dilation,
                 layout='NCW',
@@ -47,13 +47,13 @@ def conv1d_cuda(cfg,
         3-D kernel with shape [num_filter, in_channel, filter_size] for layout == 'NCW'
         and [filter_size, in_channel, num_filter] for layout == 'NWC'
 
-    stride : int
+    strides : int or tuple
         The spatial stride along width
 
     padding : int or str
         Padding size, or ['VALID', 'SAME']
 
-    dilation : int
+    dilation : int or tuple
         Dilation rate if convolution should be dilated.
 
     layout : str
@@ -64,16 +64,16 @@ def conv1d_cuda(cfg,
     """
     if out_dtype is None:
         out_dtype = data.dtype
-    if isinstance(stride, (tuple, list)):
-        stride = stride[0]
+    if isinstance(strides, (tuple, list)):
+        strides = strides[0]
     if isinstance(dilation, (tuple, list)):
         dilation = dilation[0]
 
     if layout == 'NCW':
-        return nn.conv1d_ncw(data, kernel, stride, padding, dilation,
+        return nn.conv1d_ncw(data, kernel, strides, padding, dilation,
                              out_dtype)
     if layout == 'NWC':
-        return nn.conv1d_nwc(data, kernel, stride, padding, dilation,
+        return nn.conv1d_nwc(data, kernel, strides, padding, dilation,
                              out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))
 

--- a/topi/python/topi/cuda/conv1d.py
+++ b/topi/python/topi/cuda/conv1d.py
@@ -25,7 +25,15 @@ from ..util import get_const_tuple, traverse_inline
 
 
 @autotvm.register_topi_compute(nn.conv1d, ['cuda', 'gpu'], ['direct'])
-def conv1d_cuda(cfg, data, kernel, stride, padding, dilation, layout='NCW', pad_method='SYMMETRIC', out_dtype='float32'):
+def conv1d_cuda(cfg,
+                data,
+                kernel,
+                stride,
+                padding,
+                dilation,
+                layout='NCW',
+                pad_method='SYMMETRIC',
+                out_dtype='float32'):
     """ 1D convolution forward operator for cuda backend.
 
     Parameters
@@ -70,13 +78,16 @@ def conv1d_cuda(cfg, data, kernel, stride, padding, dilation, layout='NCW', pad_
         dilation = dilation[0]
 
     if layout == 'NCW':
-        return nn.conv1d_ncw(data, kernel, stride, padding, dilation, pad_method, out_dtype)
+        return nn.conv1d_ncw(data, kernel, stride, padding, dilation,
+                             pad_method, out_dtype)
     elif layout == 'NWC':
-        return nn.conv1d_nwc(data, kernel, stride, padding, dilation, pad_method, out_dtype)
+        return nn.conv1d_nwc(data, kernel, stride, padding, dilation,
+                             pad_method, out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))
 
 
-@autotvm.register_topi_schedule(generic.schedule_conv1d_ncw, ["cuda", "gpu"], ["direct"])
+@autotvm.register_topi_schedule(generic.schedule_conv1d_ncw, ["cuda", "gpu"],
+                                ["direct"])
 def schedule_conv1d_ncw(cfg, outs):
     """TOPI schedule callback of conv1d ncw for cuda gpu
 
@@ -120,7 +131,8 @@ def schedule_conv1d_ncw(cfg, outs):
 
             ##### space definition end #####
 
-            if isinstance(kernel.op, tvm.tensor.ComputeOp) and 'dilate' in kernel.op.tag:
+            if isinstance(kernel.op,
+                          tvm.tensor.ComputeOp) and 'dilate' in kernel.op.tag:
                 s[kernel].compute_inline()
 
             if conv.op in s.outputs:
@@ -175,15 +187,18 @@ def schedule_conv1d_ncw(cfg, outs):
                 s[load].bind(tz, tvm.thread_axis("threadIdx.y"))
                 s[load].bind(tx, tvm.thread_axis("threadIdx.x"))
 
-            s[output].pragma(kernel_scope, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)
-            s[output].pragma(kernel_scope, 'unroll_explicit', cfg['unroll_explicit'].val)
+            s[output].pragma(kernel_scope, 'auto_unroll_max_step',
+                             cfg['auto_unroll_max_step'].val)
+            s[output].pragma(kernel_scope, 'unroll_explicit',
+                             cfg['unroll_explicit'].val)
 
     traverse_inline(s, outs[0].op, _callback)
 
     return s
 
 
-@autotvm.register_topi_schedule(generic.schedule_conv1d_nwc, ["cuda", "gpu"], ["direct"])
+@autotvm.register_topi_schedule(generic.schedule_conv1d_nwc, ["cuda", "gpu"],
+                                ["direct"])
 def schedule_conv1d_nwc(cfg, outs):
     """TOPI schedule callback of conv1d nwc for cuda gpu
 
@@ -227,7 +242,8 @@ def schedule_conv1d_nwc(cfg, outs):
 
             ##### space definition end #####
 
-            if isinstance(kernel.op, tvm.tensor.ComputeOp) and 'dilate' in kernel.op.tag:
+            if isinstance(kernel.op,
+                          tvm.tensor.ComputeOp) and 'dilate' in kernel.op.tag:
                 s[kernel].compute_inline()
 
             if conv.op in s.outputs:
@@ -282,8 +298,10 @@ def schedule_conv1d_nwc(cfg, outs):
                 s[load].bind(tz, tvm.thread_axis("threadIdx.y"))
                 s[load].bind(tx, tvm.thread_axis("threadIdx.x"))
 
-            s[output].pragma(kernel_scope, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)
-            s[output].pragma(kernel_scope, 'unroll_explicit', cfg['unroll_explicit'].val)
+            s[output].pragma(kernel_scope, 'auto_unroll_max_step',
+                             cfg['auto_unroll_max_step'].val)
+            s[output].pragma(kernel_scope, 'unroll_explicit',
+                             cfg['unroll_explicit'].val)
 
     traverse_inline(s, outs[0].op, _callback)
 

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -35,6 +35,42 @@ def _default_schedule(outs, auto_inline):
 
 
 @tvm.target.generic_func
+def schedule_conv1d_ncw(outs):
+    """Schedule for conv1d_ncw
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of conv2d_hwcn
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+@tvm.target.generic_func
+def schedule_conv1d_nwc(outs):
+    """Schedule for conv1d_nwc
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of conv2d_hwcn
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+@tvm.target.generic_func
 def schedule_conv2d_hwcn(outs):
     """Schedule for conv2d_hwcn
 

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -41,7 +41,7 @@ def schedule_conv1d_ncw(outs):
     Parameters
     ----------
     outs: Array of Tensor
-          The computation graph description of conv2d_hwcn
+          The computation graph description of conv1d_ncw
           in the format of an array of tensors.
 
     Returns
@@ -59,7 +59,7 @@ def schedule_conv1d_nwc(outs):
     Parameters
     ----------
     outs: Array of Tensor
-          The computation graph description of conv2d_hwcn
+          The computation graph description of conv1d_nwc
           in the format of an array of tensors.
 
     Returns

--- a/topi/python/topi/nn/__init__.py
+++ b/topi/python/topi/nn/__init__.py
@@ -19,6 +19,7 @@
 """Neural network operators"""
 from __future__ import absolute_import as _abs
 
+from .conv1d import *
 from .conv2d import *
 from .conv3d import *
 from .deformable_conv2d import *

--- a/topi/python/topi/nn/conv1d.py
+++ b/topi/python/topi/nn/conv1d.py
@@ -23,7 +23,8 @@ from ..util import simplify
 from .util import get_pad_tuple1d
 
 
-def conv1d(data, kernel, layout='NCW', stride=1, padding='VALID', pad_method='SYMMETRIC', dilation=1, out_dtype=None):
+@tvm.target.generic_func
+def conv1d(data, kernel, stride=1, padding='VALID', dilation=1, layout='NCW', pad_method='SYMMETRIC', out_dtype=None):
     """ 1D convolution forward operator.
 
     Parameters
@@ -36,22 +37,22 @@ def conv1d(data, kernel, layout='NCW', stride=1, padding='VALID', pad_method='SY
         3-D kernel with shape [num_filter, in_channel, filter_size] for layout == 'NCW'
         and [filter_size, in_channel, num_filter] for layout == 'NWC'
 
-    layout : str
-        How input data is laid out, must be one of ['NCW', 'NWC']
-
     stride : int
         The spatial stride along width
 
     padding : int or str
         Padding size, or ['VALID', 'SAME']
 
-    pad_method : str
-        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
-        Useful when dealing with Tensorflow and Keras funkiness.
-
     dilation : int
         Dilation rate if convolution should be dilated. 
 
+    layout : str
+        How input data is laid out, must be one of ['NCW', 'NWC']
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
+        Useful when dealing with Tensorflow and Keras funkiness.
+    
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
@@ -63,13 +64,13 @@ def conv1d(data, kernel, layout='NCW', stride=1, padding='VALID', pad_method='SY
         dilation = dilation[0]
 
     if layout == 'NCW':
-        return conv1d_ncw(data, kernel, stride, padding, pad_method, dilation, out_dtype)
+        return conv1d_ncw(data, kernel, stride, padding, dilation, pad_method, out_dtype)
     elif layout == 'NWC':
-        return conv1d_nwc(data, kernel, stride, padding, pad_method, dilation, out_dtype)
+        return conv1d_nwc(data, kernel, stride, padding, dilation, pad_method, out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))
 
 
-def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', dilation=1, out_dtype=None):
+def conv1d_ncw(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='SYMMETRIC', out_dtype=None):
     """ 1D convolution forward operator for NCW layout.
 
     Parameters
@@ -87,11 +88,11 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
         Padding size can be an integer for equal padding,
         a tuple of (left, right) or a string in ['VALID', 'SAME'].
 
-    pad_method : str
-        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
-
     dilation : int
         Dilation rate if convolution should be dilated. 
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
 
     out_dtype : str
         The output data type. If None then output is same type as input.
@@ -132,7 +133,7 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
             axis=[rc, rw]), tag="conv1d_ncw")
 
 
-def conv1d_nwc(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', dilation=1, out_dtype=None):
+def conv1d_nwc(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='SYMMETRIC', out_dtype=None):
     """ 1D convolution forward operator for NWC layout.
 
     Parameters
@@ -150,11 +151,11 @@ def conv1d_nwc(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
         Padding size can be an integer for equal padding,
         a tuple of (left, right) or a string in ['VALID', 'SAME'].
 
-    pad_method : str
-        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
-
     dilation : int
         Dilation rate if convolution should be dilated. 
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
 
     out_dtype : str
         The output data type. If None then output is same type as input.

--- a/topi/python/topi/nn/conv1d.py
+++ b/topi/python/topi/nn/conv1d.py
@@ -50,7 +50,7 @@ def conv1d(data,
         Padding size, or ['VALID', 'SAME']
 
     dilation : int
-        Dilation rate if convolution should be dilated. 
+        Dilation rate if convolution should be dilated.
 
     layout : str
         How input data is laid out, must be one of ['NCW', 'NWC']
@@ -58,7 +58,7 @@ def conv1d(data,
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
-    if out_dtype == None:
+    if out_dtype is None:
         out_dtype = data.dtype
     if isinstance(stride, (tuple, list)):
         stride = stride[0]
@@ -67,7 +67,7 @@ def conv1d(data,
 
     if layout == 'NCW':
         return conv1d_ncw(data, kernel, stride, padding, dilation, out_dtype)
-    elif layout == 'NWC':
+    if layout == 'NWC':
         return conv1d_nwc(data, kernel, stride, padding, dilation, out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))
 
@@ -96,7 +96,7 @@ def conv1d_ncw(data,
         a tuple of (left, right) or a string in ['VALID', 'SAME'].
 
     dilation : int
-        Dilation rate if convolution should be dilated. 
+        Dilation rate if convolution should be dilated.
 
     out_dtype : str
         The output data type. If None then output is same type as input.
@@ -122,8 +122,9 @@ def conv1d_ncw(data,
 
     return tvm.compute(
         (batch, out_channels, out_width),
-        lambda b, c, w: tvm.sum(temp[b, rc, w * stride + rw * dilation].astype(
-            out_dtype) * kernel[c, rc, rw].astype(out_dtype),
+        lambda b, c, w: tvm.sum(
+            temp[b, rc, w * stride + rw * dilation].astype(out_dtype)
+            * kernel[c, rc, rw].astype(out_dtype),
             axis=[rc, rw]),
         tag="conv1d_ncw")
 
@@ -152,7 +153,7 @@ def conv1d_nwc(data,
         a tuple of (left, right) or a string in ['VALID', 'SAME'].
 
     dilation : int
-        Dilation rate if convolution should be dilated. 
+        Dilation rate if convolution should be dilated.
 
     out_dtype : str
         The output data type. If None then output is same type as input.
@@ -178,7 +179,8 @@ def conv1d_nwc(data,
 
     return tvm.compute(
         (batch, out_width, out_channels),
-        lambda b, w, c: tvm.sum(temp[b, w * stride + rw * dilation, rc].astype(
-            out_dtype) * kernel[rw, rc, c].astype(out_dtype),
+        lambda b, w, c: tvm.sum(
+            temp[b, w * stride + rw * dilation, rc].astype(out_dtype)
+            * kernel[rw, rc, c].astype(out_dtype),
             axis=[rc, rw]),
         tag="conv1d_nwc")

--- a/topi/python/topi/nn/conv1d.py
+++ b/topi/python/topi/nn/conv1d.py
@@ -24,7 +24,14 @@ from .util import get_pad_tuple1d
 
 
 @tvm.target.generic_func
-def conv1d(data, kernel, stride=1, padding='VALID', dilation=1, layout='NCW', pad_method='SYMMETRIC', out_dtype=None):
+def conv1d(data,
+           kernel,
+           stride=1,
+           padding='VALID',
+           dilation=1,
+           layout='NCW',
+           pad_method='SYMMETRIC',
+           out_dtype=None):
     """ 1D convolution forward operator.
 
     Parameters
@@ -64,13 +71,21 @@ def conv1d(data, kernel, stride=1, padding='VALID', dilation=1, layout='NCW', pa
         dilation = dilation[0]
 
     if layout == 'NCW':
-        return conv1d_ncw(data, kernel, stride, padding, dilation, pad_method, out_dtype)
+        return conv1d_ncw(data, kernel, stride, padding, dilation, pad_method,
+                          out_dtype)
     elif layout == 'NWC':
-        return conv1d_nwc(data, kernel, stride, padding, dilation, pad_method, out_dtype)
+        return conv1d_nwc(data, kernel, stride, padding, dilation, pad_method,
+                          out_dtype)
     raise ValueError("This layout is not yet supported: {}".format(layout))
 
 
-def conv1d_ncw(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='SYMMETRIC', out_dtype=None):
+def conv1d_ncw(data,
+               kernel,
+               stride=1,
+               padding='VALID',
+               dilation=1,
+               pad_method='SYMMETRIC',
+               out_dtype=None):
     """ 1D convolution forward operator for NCW layout.
 
     Parameters
@@ -102,10 +117,11 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='
 
     # Compute the output shape
     dilated_kernel_size = (kernel_size - 1) * dilation + 1
-    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_kernel_size,))
+    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_kernel_size, ))
     out_channels = simplify(out_channels)
     out_width = simplify(
-        (data_width - dilated_kernel_size + pad_left + pad_right) // stride + 1)
+        (data_width - dilated_kernel_size + pad_left + pad_right) // stride +
+        1)
 
     # Apply selected padding
     if pad_method == 'SYMMETRIC':
@@ -127,13 +143,19 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='
 
     return tvm.compute(
         (batch, out_channels, out_width),
-        lambda b, c, w: tvm.sum(
-            temp[b, rc, w * stride + rw * dilation].astype(out_dtype) *
-            kernel[c, rc, rw].astype(out_dtype),
-            axis=[rc, rw]), tag="conv1d_ncw")
+        lambda b, c, w: tvm.sum(temp[b, rc, w * stride + rw * dilation].astype(
+            out_dtype) * kernel[c, rc, rw].astype(out_dtype),
+                                axis=[rc, rw]),
+        tag="conv1d_ncw")
 
 
-def conv1d_nwc(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='SYMMETRIC', out_dtype=None):
+def conv1d_nwc(data,
+               kernel,
+               stride=1,
+               padding='VALID',
+               dilation=1,
+               pad_method='SYMMETRIC',
+               out_dtype=None):
     """ 1D convolution forward operator for NWC layout.
 
     Parameters
@@ -165,10 +187,11 @@ def conv1d_nwc(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='
 
     # Compute the output shape
     dilated_kernel_size = (kernel_size - 1) * dilation + 1
-    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_kernel_size,))
+    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_kernel_size, ))
     out_channels = simplify(out_channels)
     out_width = simplify(
-        (data_width - dilated_kernel_size + pad_left + pad_right) // stride + 1)
+        (data_width - dilated_kernel_size + pad_left + pad_right) // stride +
+        1)
 
     # Apply selected padding
     if pad_method == 'SYMMETRIC':
@@ -190,7 +213,7 @@ def conv1d_nwc(data, kernel, stride=1, padding='VALID', dilation=1, pad_method='
 
     return tvm.compute(
         (batch, out_width, out_channels),
-        lambda b, w, c: tvm.sum(
-            temp[b, w * stride + rw * dilation, rc].astype(out_dtype) *
-            kernel[rw, rc, c].astype(out_dtype),
-            axis=[rc, rw]), tag="conv1d_nwc")
+        lambda b, w, c: tvm.sum(temp[b, w * stride + rw * dilation, rc].astype(
+            out_dtype) * kernel[rw, rc, c].astype(out_dtype),
+                                axis=[rc, rw]),
+        tag="conv1d_nwc")

--- a/topi/python/topi/nn/conv1d.py
+++ b/topi/python/topi/nn/conv1d.py
@@ -1,0 +1,196 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-variable, unused-argument
+"""1D convolution operators."""
+from __future__ import absolute_import as _abs
+import tvm
+from .pad import pad
+from ..util import simplify
+from .util import get_pad_tuple1d
+
+
+def conv1d(data, kernel, layout='NCW', stride=1, padding='VALID', pad_method='SYMMETRIC', dilation=1, out_dtype=None):
+    """ 1D convolution forward operator.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        3-D input shape [batch, in_channel, in_width] for layout == 'NCW'
+        and [batch, in_width, in_channel] for layout == 'NWC'
+
+    kernel : tvm.Tensor
+        3-D kernel with shape [num_filter, in_channel, filter_size] for layout == 'NCW'
+        and [filter_size, in_channel, num_filter] for layout == 'NWC'
+
+    layout : str
+        How input data is laid out, must be one of ['NCW', 'NWC']
+
+    stride : int
+        The spatial stride along width
+
+    padding : int or str
+        Padding size, or ['VALID', 'SAME']
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
+        Useful when dealing with Tensorflow and Keras funkiness.
+
+    dilation : int
+        Dilation rate if convolution should be dilated. 
+
+    out_dtype : str
+        The output data type. If None then output is same type as input.
+    """
+    if layout == 'NCW':
+        return conv1d_ncw(data, kernel, stride, padding, pad_method, dilation, out_dtype)
+    elif layout == 'NWC':
+        return conv1d_nwc(data, kernel, stride, padding, pad_method, dilation, out_dtype)
+    raise ValueError("This layout is not yet supported: {}".format(layout))
+
+
+def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', dilation=1, out_dtype=None):
+    """ 1D convolution forward operator for NCW layout.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        3-D with shape [batch, in_channel, in_width]
+
+    kernel : tvm.Tensor
+        3-D with shape [num_filter, in_channel, filter_size]
+
+    stride : int
+        The spatial stride along width
+
+    padding : int or str
+        Padding size, or ['VALID', 'SAME']
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
+
+    dilation : int
+        Dilation rate if convolution should be dilated. 
+
+    out_dtype : str
+        The output data type. If None then output is same type as input.
+    """
+    if out_dtype == None:
+        out_dtype = data.dtype
+    # Dilate and pad
+    if isinstance(stride, (tuple, list)):
+        stride = stride[0]
+    if isinstance(dilation, (tuple, list)):
+        dilation = dilation[0]
+    batch, in_channels, data_width = data.shape
+    out_channels, _, kernel_size = kernel.shape
+
+    # Compute the output shape
+    dilated_kernel_size = (kernel_size - 1) * dilation + 1
+    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_kernel_size,))
+    out_channels = simplify(out_channels)
+    out_width = simplify(
+        (data_width - dilated_kernel_size + pad_left + pad_right) // stride + 1)
+
+    # Apply selected padding
+    if pad_method == 'SYMMETRIC':
+        pad_before = [0, 0, pad_left]
+        pad_after = [0, 0, pad_right]
+    elif pad_method == 'BEFORE':
+        pad_before = [0, 0, pad_right + pad_left]
+        pad_after = [0, 0, 0]
+    else:
+        pad_before = [0, 0, 0]
+        pad_after = [0, 0, pad_right + pad_left]
+    temp = pad(data, pad_before, pad_after, name='pad_temp')
+
+    # Compute graph
+    rc = tvm.reduce_axis((0, in_channels), name='rc')
+    rw = tvm.reduce_axis((0, kernel_size), name='rw')
+
+    return tvm.compute(
+        (batch, out_channels, out_width),
+        lambda b, c, w: tvm.sum(
+            temp[b, rc, w * stride + rw * dilation].astype(out_dtype) *
+            kernel[c, rc, rw].astype(out_dtype),
+            axis=[rc, rw]), tag="conv1d_ncw")
+
+
+def conv1d_nwc(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', dilation=1, out_dtype=None):
+    """ 1D convolution forward operator for NWC layout.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        3-D with shape [batch, in_width, in_channel]
+
+    kernel : tvm.Tensor
+        3-D with shape [filter_size, in_channel, num_filter]
+
+    stride : int
+        The spatial stride along width
+
+    padding : int or str
+        Padding size, or ['VALID', 'SAME']
+
+    pad_method : str
+        How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
+
+    dilation : int
+        Dilation rate if convolution should be dilated. 
+
+    out_dtype : str
+        The output data type. If None then output is same type as input.
+    """
+    if out_dtype == None:
+        out_dtype = data.dtype
+    # Dilate and pad
+    if isinstance(stride, (tuple, list)):
+        stride = stride[0]
+    if isinstance(dilation, (tuple, list)):
+        dilation = dilation[0]
+    batch, data_width, in_channels = data.shape
+    kernel_size, _, out_channels = kernel.shape
+
+    # Compute the output shape
+    dilated_kernel_size = (kernel_size - 1) * dilation + 1
+    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_kernel_size,))
+    out_channels = simplify(out_channels)
+    out_width = simplify(
+        (data_width - dilated_kernel_size + pad_left + pad_right) // stride + 1)
+
+    # Apply selected padding
+    if pad_method == 'SYMMETRIC':
+        pad_before = [0, pad_left, 0]
+        pad_after = [0, pad_right, 0]
+    elif pad_method == 'BEFORE':
+        pad_before = [0, pad_right + pad_left, 0]
+        pad_after = [0, 0, 0]
+    else:
+        pad_before = [0, 0, 0]
+        pad_after = [0, pad_right + pad_left, 0]
+    temp = pad(data, pad_before, pad_after, name='pad_temp')
+
+    # Compute graph
+    rc = tvm.reduce_axis((0, in_channels), name='rc')
+    rw = tvm.reduce_axis((0, kernel_size), name='rw')
+
+    return tvm.compute(
+        (batch, out_width, out_channels),
+        lambda b, w, c: tvm.sum(
+            temp[b, w * stride + rw * dilation, rc].astype(out_dtype) *
+            kernel[rw, rc, c].astype(out_dtype),
+            axis=[rc, rw]), tag="conv1d_nwc")

--- a/topi/python/topi/nn/conv1d.py
+++ b/topi/python/topi/nn/conv1d.py
@@ -55,6 +55,13 @@ def conv1d(data, kernel, layout='NCW', stride=1, padding='VALID', pad_method='SY
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
+    if out_dtype == None:
+        out_dtype = data.dtype
+    if isinstance(stride, (tuple, list)):
+        stride = stride[0]
+    if isinstance(dilation, (tuple, list)):
+        dilation = dilation[0]
+
     if layout == 'NCW':
         return conv1d_ncw(data, kernel, stride, padding, pad_method, dilation, out_dtype)
     elif layout == 'NWC':
@@ -76,8 +83,9 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
     stride : int
         The spatial stride along width
 
-    padding : int or str
-        Padding size, or ['VALID', 'SAME']
+    padding : int, tuple, or str
+        Padding size can be an integer for equal padding,
+        a tuple of (left, right) or a string in ['VALID', 'SAME'].
 
     pad_method : str
         How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
@@ -88,13 +96,6 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
-    if out_dtype == None:
-        out_dtype = data.dtype
-    # Dilate and pad
-    if isinstance(stride, (tuple, list)):
-        stride = stride[0]
-    if isinstance(dilation, (tuple, list)):
-        dilation = dilation[0]
     batch, in_channels, data_width = data.shape
     out_channels, _, kernel_size = kernel.shape
 
@@ -112,9 +113,11 @@ def conv1d_ncw(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
     elif pad_method == 'BEFORE':
         pad_before = [0, 0, pad_right + pad_left]
         pad_after = [0, 0, 0]
-    else:
+    elif pad_method == 'AFTER':
         pad_before = [0, 0, 0]
         pad_after = [0, 0, pad_right + pad_left]
+    else:
+        raise ValueError("Pad method {} is not supported.".format(pad_method))
     temp = pad(data, pad_before, pad_after, name='pad_temp')
 
     # Compute graph
@@ -143,8 +146,9 @@ def conv1d_nwc(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
     stride : int
         The spatial stride along width
 
-    padding : int or str
-        Padding size, or ['VALID', 'SAME']
+    padding : int, tuple, or str
+        Padding size can be an integer for equal padding,
+        a tuple of (left, right) or a string in ['VALID', 'SAME'].
 
     pad_method : str
         How to add padding, must be one of ['SYMMETRIC', 'BEFORE', 'AFTER']
@@ -155,13 +159,6 @@ def conv1d_nwc(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
     out_dtype : str
         The output data type. If None then output is same type as input.
     """
-    if out_dtype == None:
-        out_dtype = data.dtype
-    # Dilate and pad
-    if isinstance(stride, (tuple, list)):
-        stride = stride[0]
-    if isinstance(dilation, (tuple, list)):
-        dilation = dilation[0]
     batch, data_width, in_channels = data.shape
     kernel_size, _, out_channels = kernel.shape
 
@@ -179,9 +176,11 @@ def conv1d_nwc(data, kernel, stride=1, padding='VALID', pad_method='SYMMETRIC', 
     elif pad_method == 'BEFORE':
         pad_before = [0, pad_right + pad_left, 0]
         pad_after = [0, 0, 0]
-    else:
+    elif pad_method == 'AFTER':
         pad_before = [0, 0, 0]
         pad_after = [0, pad_right + pad_left, 0]
+    else:
+        raise ValueError("Pad method {} is not supported.".format(pad_method))
     temp = pad(data, pad_before, pad_after, name='pad_temp')
 
     # Compute graph

--- a/topi/python/topi/testing/__init__.py
+++ b/topi/python/topi/testing/__init__.py
@@ -21,6 +21,7 @@ Used to verify the correctness of operators in TOPI .
 """
 from __future__ import absolute_import as _abs
 
+from .conv1d_ncw_python import conv1d_ncw_python
 from .conv2d_hwcn_python import conv2d_hwcn_python
 from .conv2d_nchw_python import conv2d_nchw_python
 from .conv2d_nhwc_python import conv2d_nhwc_python

--- a/topi/python/topi/testing/conv1d_ncw_python.py
+++ b/topi/python/topi/testing/conv1d_ncw_python.py
@@ -44,7 +44,7 @@ def dilate_np(x, dilation):
     return x
 
 
-def conv1d_ncw_python(a_np, w_np, stride, padding, dilation, pad_method):
+def conv1d_ncw_python(a_np, w_np, stride, padding, dilation):
     """1D convolution operator in NCW layout
 
     Parameters
@@ -65,9 +65,6 @@ def conv1d_ncw_python(a_np, w_np, stride, padding, dilation, pad_method):
     dilation : int
         Dilation rate of the kernel
 
-    pad_method : str
-        How to pad data, must be in ['SYMMETRIC', 'BEFORE', 'AFTER']
-
     Returns
     -------
     b_np : numpy.ndarray
@@ -85,15 +82,7 @@ def conv1d_ncw_python(a_np, w_np, stride, padding, dilation, pad_method):
     out_w = ((in_w - dilated_filter_w + pad_left + pad_right) // stride) + 1
 
     padded_a_np = np.zeros((batch, in_c, in_w + pad_left + pad_right))
-    if pad_method == 'SYMMETRIC':
-        padded_a_np[:, :, pad_left:(in_w + pad_left)] = a_np
-    elif pad_method == 'BEFORE':
-        padded_a_np[:, :, (pad_left + pad_right)
-                           :(in_w + pad_left + pad_right)] = a_np
-    elif pad_method == 'AFTER':
-        padded_a_np[:, :, :in_w] = a_np
-    else:
-        raise ValueError("Pad method {} is not supported.".format(pad_method))
+    padded_a_np[:, :, pad_left:(in_w + pad_left)] = a_np
 
     b_np = np.zeros((batch, out_c, out_w))
     for n in range(batch):

--- a/topi/python/topi/testing/conv1d_ncw_python.py
+++ b/topi/python/topi/testing/conv1d_ncw_python.py
@@ -44,7 +44,7 @@ def dilate_np(x, dilation):
     return x
 
 
-def conv1d_ncw_python(a_np, w_np, stride, padding, pad_method, dilation):
+def conv1d_ncw_python(a_np, w_np, stride, padding, dilation, pad_method):
     """1D convolution operator in NCW layout
 
     Parameters
@@ -62,11 +62,11 @@ def conv1d_ncw_python(a_np, w_np, stride, padding, pad_method, dilation):
         Single int for padding size or tuple of (left, right) padding
         or a string in ['VALID', 'SAME']
 
-    pad_method : str
-        How to pad data, must be in ['SYMMETRIC', 'BEFORE', 'AFTER']
-
     dilation : int
         Dilation rate of the kernel
+
+    pad_method : str
+        How to pad data, must be in ['SYMMETRIC', 'BEFORE', 'AFTER']
 
     Returns
     -------

--- a/topi/python/topi/testing/conv1d_ncw_python.py
+++ b/topi/python/topi/testing/conv1d_ncw_python.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-variable
+"""1D convolution in python"""
+import numpy as np
+import scipy
+import topi
+from topi.nn.util import get_pad_tuple1d
+
+def conv1d_ncw_python(a_np, w_np, stride, padding, pad_method, dilation):
+    """1D convolution operator in NCW layout
+
+    Parameters
+    ----------
+    a_np : numpy.ndarray
+        3-D with shape [batch, in_channel, in_width]
+    
+    w_np : numpy.ndarray
+        3-D with shape [num_filter, in_channel, filter_width]
+
+    stride : int
+        Stride size
+
+    padding : int, tuple, or str
+        Single int for padding size or tuple of (left, right) padding
+        or a string in ['VALID', 'SAME']
+
+    pad_method : str
+        How to pad data, must be in ['SYMMETRIC', 'BEFORE', 'AFTER']
+
+    dilation : int
+        Dilation rate of the kernel
+
+    Returns
+    -------
+    b_np : np.ndarray
+        3-D with shape [batch, out_channel, out_width]
+    """
+    batch, in_c, in_w = a_np.shape
+    out_c, _, filter_w = w_np.shape
+    if isinstance(stride, (tuple, list)):
+        stride = stride[0]
+    if isinstance(dilation, (tuple, list)):
+        dilation = dilation[0]
+
+    dilated_filter_w = (filter_w - 1) * dilation + 1
+    pad_left, pad_right = get_pad_tuple1d(padding, (dilated_filter_w,))
+    out_w = (in_w - dilated_filter_w + pad_left + pad_right) // (stride + 1)
+
+    padded_a_np = np.zeros((batch, in_c, in_w + pad_left + pad_right))
+    if pad_method == 'SYMMETRIC':
+        padded_a_np[:, :, pad_left:(in_w + pad_left)] = a_np
+    elif pad_method == 'BEFORE':
+        padded_a_np[:, :, (pad_left + pad_right):(in_w + pad_left + pad_right)] = a_np
+    elif pad_method == 'AFTER':
+        padded_a_np[:, :, :in_w] = a_np
+    else:
+        raise ValueError("Pad method {} is not supported.".format(pad_method))

--- a/topi/python/topi/testing/conv1d_ncw_python.py
+++ b/topi/python/topi/testing/conv1d_ncw_python.py
@@ -14,10 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=unused-variable
+# pylint: disable=unused-variable, invalid-name
 """1D convolution in python"""
 import numpy as np
-import topi
 from topi.nn.util import get_pad_tuple1d
 
 

--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -19,6 +19,7 @@
 """x86 specific declaration and schedules."""
 from __future__ import absolute_import as _abs
 
+from .conv1d import schedule_conv1d_nwc
 from .conv2d import schedule_conv2d, schedule_conv2d_nhwc
 from .binarize_pack import schedule_binarize_pack
 from .binary_dense import schedule_binary_dense

--- a/topi/python/topi/x86/conv1d.py
+++ b/topi/python/topi/x86/conv1d.py
@@ -112,7 +112,7 @@ def schedule_conv1d_nwc(outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
 
-            n_pad, c_pad, w_pad = data_pad.op.axis
+            n_pad, w_pad, c_pad = data_pad.op.axis
             pad_fused = s[data_pad].fuse(n_pad, w_pad)
             s[data_pad].parallel(pad_fused)
             C = conv

--- a/topi/python/topi/x86/conv1d.py
+++ b/topi/python/topi/x86/conv1d.py
@@ -18,7 +18,6 @@
 """Conv1D schedule on for Intel CPU"""
 from __future__ import absolute_import as _abs
 import tvm
-from tvm import autotvm
 from .. import generic, tag
 
 

--- a/topi/python/topi/x86/conv1d.py
+++ b/topi/python/topi/x86/conv1d.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,invalid-name
+"""Conv1D schedule on for Intel CPU"""
+from __future__ import absolute_import as _abs
+import tvm
+from tvm import autotvm
+from .. import generic, tag
+
+@generic.schedule_conv1d_ncw.register(["cpu"])
+def schedule_conv1d_nwc(outs):
+    """Create schedule for tensors"""
+    s = tvm.create_schedule([x.op for x in outs])
+    output_op = outs[0].op
+    scheduled_ops = []
+
+    def traverse(op):
+        """Traverse operators from computation graph"""
+        # inline all one-to-one-mapping operators except the last stage (output)
+        if tag.is_broadcast(op.tag):
+            if op not in s.outputs:
+                s[op].compute_inline()
+            else: # inject custom schedule
+                if len(op.axis) == 3: # schedule bias + bn + relu
+                    n, c, w = op.axis
+                    fused = s[op].fuse(n, c)
+                    s[op].parallel(fused)
+                    s[op].vectorize(w)
+            for tensor in op.input_tensors:
+                if isinstance(tensor.op, tvm.tensor.ComputeOp) and tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+
+        if 'conv1d_ncw' in op.tag:
+            conv = op.output(0)
+            kernel = op.input_tensors[1]
+            if isinstance(kernel.op, tvm.tensor.ComputeOp) and "dilate" in kernel.op.tag:
+                s[kernel].compute_inline()
+
+            data = op.input_tensors[0]
+            data_pad = None
+            if isinstance(data.op, tvm.tensor.ComputeOp) and "pad" in data.op.tag:
+                data_pad = data
+                data = data_pad.op.input_tensors[0]
+
+            n_pad, c_pad, w_pad = data_pad.op.axis
+            pad_fused = s[data_pad].fuse(n_pad, c_pad)
+            s[data_pad].parallel(pad_fused)
+            C = conv
+            n, c, w = C.op.axis
+            rc, rw = C.op.reduce_axis
+            n_out, c_out, w_out = output_op.axis
+            s[C].vectorize(w)
+            if op != output_op: # fuse bias + bn + relu into conv
+                s[C].compute_at(s[output_op], w_out)
+            else:
+                fused = s[C].fuse(n, c)
+                s[C].parallel(fused)
+
+        scheduled_ops.append(op)
+
+    traverse(output_op)
+    return s

--- a/topi/python/topi/x86/conv1d.py
+++ b/topi/python/topi/x86/conv1d.py
@@ -23,7 +23,7 @@ from .. import generic, tag
 
 
 @generic.schedule_conv1d_ncw.register(["cpu"])
-def schedule_conv1d_nwc(outs):
+def schedule_conv1d_ncw(outs):
     """Create schedule for tensors"""
     s = tvm.create_schedule([x.op for x in outs])
     output_op = outs[0].op
@@ -75,6 +75,7 @@ def schedule_conv1d_nwc(outs):
 
     traverse(output_op)
     return s
+
 
 @generic.schedule_conv1d_nwc.register(["cpu"])
 def schedule_conv1d_nwc(outs):

--- a/topi/python/topi/x86/conv1d.py
+++ b/topi/python/topi/x86/conv1d.py
@@ -21,6 +21,7 @@ import tvm
 from tvm import autotvm
 from .. import generic, tag
 
+
 @generic.schedule_conv1d_ncw.register(["cpu"])
 def schedule_conv1d_nwc(outs):
     """Create schedule for tensors"""
@@ -68,6 +69,60 @@ def schedule_conv1d_nwc(outs):
                 s[C].compute_at(s[output_op], w_out)
             else:
                 fused = s[C].fuse(n, c)
+                s[C].parallel(fused)
+
+        scheduled_ops.append(op)
+
+    traverse(output_op)
+    return s
+
+@generic.schedule_conv1d_nwc.register(["cpu"])
+def schedule_conv1d_nwc(outs):
+    """Create schedule for tensors"""
+    s = tvm.create_schedule([x.op for x in outs])
+    output_op = outs[0].op
+    scheduled_ops = []
+
+    def traverse(op):
+        """Traverse operators from computation graph"""
+        # inline all one-to-one-mapping operators except the last stage (output)
+        if tag.is_broadcast(op.tag):
+            if op not in s.outputs:
+                s[op].compute_inline()
+            else: # inject custom schedule
+                if len(op.axis) == 3: # schedule bias + bn + relu
+                    n, w, c = op.axis
+                    fused = s[op].fuse(n, w)
+                    s[op].parallel(fused)
+                    s[op].vectorize(c)
+            for tensor in op.input_tensors:
+                if isinstance(tensor.op, tvm.tensor.ComputeOp) and tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+
+        if 'conv1d_nwc' in op.tag:
+            conv = op.output(0)
+            kernel = op.input_tensors[1]
+            if isinstance(kernel.op, tvm.tensor.ComputeOp) and "dilate" in kernel.op.tag:
+                s[kernel].compute_inline()
+
+            data = op.input_tensors[0]
+            data_pad = None
+            if isinstance(data.op, tvm.tensor.ComputeOp) and "pad" in data.op.tag:
+                data_pad = data
+                data = data_pad.op.input_tensors[0]
+
+            n_pad, c_pad, w_pad = data_pad.op.axis
+            pad_fused = s[data_pad].fuse(n_pad, w_pad)
+            s[data_pad].parallel(pad_fused)
+            C = conv
+            n, w, c = C.op.axis
+            rc, rw = C.op.reduce_axis
+            n_out, w_out, c_out = output_op.axis
+            s[C].vectorize(c)
+            if op != output_op: # fuse bias + bn + relu into conv
+                s[C].compute_at(s[output_op], c_out)
+            else:
+                fused = s[C].fuse(n, w)
                 s[C].parallel(fused)
 
         scheduled_ops.append(op)

--- a/topi/tests/python/test_topi_conv1d.py
+++ b/topi/tests/python/test_topi_conv1d.py
@@ -103,6 +103,9 @@ def test_conv1d():
         verify_conv1d(1, 16, 32, 16, 3, 1, 1, 'SAME', layout)
         verify_conv1d(1, 16, 32, 16, 2, 1, 1, 'SAME', layout)
         verify_conv1d(1, 16, 32, 16, 1, 1, 1, 'SAME', layout)
+        # Non-power-of-two shape
+        verify_conv1d(1, 17, 12, 21, 3, 1, 1, 'SAME', layout)
+        verify_conv1d(1, 5, 27, 18, 3, 1, 1, 'VALID', layout)
 
 
 

--- a/topi/tests/python/test_topi_conv1d.py
+++ b/topi/tests/python/test_topi_conv1d.py
@@ -97,6 +97,13 @@ def test_conv1d():
         verify_conv1d(1, 16, 32, 16, 3, 2, 1, 'SAME', layout)
         # With dilation
         verify_conv1d(1, 16, 32, 16, 3, 1, 2, 'SAME', layout)
+        # Large batch size
+        verify_conv1d(8, 16, 32, 16, 3, 1, 1, 'SAME', layout)
+        # Other kernel sizes
+        verify_conv1d(1, 16, 32, 16, 3, 1, 1, 'SAME', layout)
+        verify_conv1d(1, 16, 32, 16, 2, 1, 1, 'SAME', layout)
+        verify_conv1d(1, 16, 32, 16, 1, 1, 1, 'SAME', layout)
+
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv1d.py
+++ b/topi/tests/python/test_topi_conv1d.py
@@ -33,7 +33,6 @@ def verify_conv1d(batch,
                   stride=1,
                   dilation=1,
                   padding='VALID',
-                  pad_method='SYMMETRIC',
                   layout='NCW'):
     if layout == 'NCW':
         in_shape = [batch, in_channels, in_width]
@@ -55,8 +54,7 @@ def verify_conv1d(batch,
         else:
             np_in = a_np
             np_w = w_np
-        b_np = topi.testing.conv1d_ncw_python(np_in, np_w, stride, padding,
-                                              dilation, pad_method)
+        b_np = topi.testing.conv1d_ncw_python(np_in, np_w, stride, padding, dilation)
         if layout == 'NWC':
             b_np = np.transpose(b_np, [0, 2, 1])
         return a_np, w_np, b_np
@@ -69,8 +67,7 @@ def verify_conv1d(batch,
             print("Skip because %s is not enabled" % device)
             return
         with tvm.target.create(device):
-            B = topi.nn.conv1d(A, W, stride, padding, dilation, layout,
-                               pad_method, 'float32')
+            B = topi.nn.conv1d(A, W, stride, padding, dilation, layout, 'float32')
             if layout == 'NCW':
                 s = topi.generic.schedule_conv1d_ncw([B])
             else:
@@ -88,19 +85,19 @@ def verify_conv1d(batch,
         check_device(device)
 
 
-def test_conv1d_transpose():
+def test_conv1d():
     for layout in ["NCW", "NWC"]:
         # Most basic test case
-        verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'VALID', 'SYMMETRIC', layout)
+        verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'VALID', layout)
         # With padding
-        verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'SAME', 'SYMMETRIC', layout)
+        verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'SAME', layout)
         # Realistic dimensions
-        verify_conv1d(1, 16, 32, 16, 3, 1, 1, 'SAME', 'SYMMETRIC', layout)
+        verify_conv1d(1, 16, 32, 16, 3, 1, 1, 'SAME', layout)
         # With stride
-        verify_conv1d(1, 16, 32, 16, 3, 2, 1, 'SAME', 'SYMMETRIC', layout)
+        verify_conv1d(1, 16, 32, 16, 3, 2, 1, 'SAME', layout)
         # With dilation
-        verify_conv1d(1, 16, 32, 16, 3, 1, 2, 'SAME', 'SYMMETRIC', layout)
+        verify_conv1d(1, 16, 32, 16, 3, 1, 2, 'SAME', layout)
 
 
 if __name__ == "__main__":
-    test_conv1d_transpose()
+    test_conv1d()

--- a/topi/tests/python/test_topi_conv1d.py
+++ b/topi/tests/python/test_topi_conv1d.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test code for transposed convolution."""
+import numpy as np
+import itertools
+import tvm
+import topi
+import topi.testing
+from tvm.contrib.pickle_memoize import memoize
+from topi.util import get_const_tuple
+from common import get_all_backend
+
+
+def verify_conv1d(batch, in_channels, in_width, filters,
+                  kernel_size=3, stride=1, dilation=1,
+                  padding='VALID', pad_method='SYMMETRIC', layout='NCW'):
+    if layout == 'NCW':
+        in_shape = [batch, in_channels, in_width]
+        kernel_shape = [filters, in_channels, kernel_size]
+    else:
+        in_shape = [batch, in_width, in_channels]
+        kernel_shape = [kernel_size, in_channels, filters]
+
+    dtype = 'float32'
+    A = tvm.placeholder(in_shape, name='A', dtype=dtype)
+    W = tvm.placeholder(kernel_shape, name='W', dtype=dtype)
+
+    def get_ref_data(layout):
+        a_np = np.random.uniform(size=in_shape).astype(dtype)
+        w_np = np.random.uniform(size=kernel_shape).astype(dtype)
+        if layout == 'NWC':
+            np_in = np.transpose(a_np, [0, 2, 1])
+            np_w = np.transpose(w_np, [2, 1, 0])
+        else:
+            np_in = a_np
+            np_w = w_np
+        b_np = topi.testing.conv1d_ncw_python(
+            np_in, np_w, stride, padding, pad_method, dilation)
+        if layout == 'NWC':
+            b_np = np.transpose(b_np, [0, 2, 1])
+        return a_np, w_np, b_np
+
+    a_np, w_np, b_np = get_ref_data(layout)
+
+    def check_device(device):
+        ctx = tvm.context(device, 0)
+        if not ctx.exist:
+            print("Skip because %s is not enabled" % device)
+            return
+        with tvm.target.create(device):
+            B = topi.nn.conv1d(A, W, layout, stride,
+                               padding, pad_method, dilation)
+            if layout == 'NCW':
+                s = topi.generic.schedule_conv1d_ncw([B])
+            else:
+                s = topi.generic.schedule_conv1d_nwc([B])
+
+        a = tvm.nd.array(a_np, ctx)
+        w = tvm.nd.array(w_np, ctx)
+        b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=dtype), ctx)
+
+        func = tvm.build(s, [A, W, B], device)
+        func(a, w, b)
+        tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
+
+    for device in get_all_backend():
+        check_device(device)
+
+
+def test_conv1d_transpose():
+    verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'VALID', 'SYMMETRIC', "NCW")
+
+
+if __name__ == "__main__":
+    test_conv1d_transpose()

--- a/topi/tests/python/test_topi_conv1d.py
+++ b/topi/tests/python/test_topi_conv1d.py
@@ -84,13 +84,22 @@ def verify_conv1d(batch,
         func(a, w, b)
         tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
 
-    for device in ['llvm', 'cuda']:#get_all_backend():
+    for device in get_all_backend():
         check_device(device)
 
 
 def test_conv1d_transpose():
-    verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'VALID', 'SYMMETRIC', "NCW")
-    verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'VALID', 'SYMMETRIC', "NWC")
+    for layout in ["NCW", "NWC"]:
+        # Most basic test case
+        verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'VALID', 'SYMMETRIC', layout)
+        # With padding
+        verify_conv1d(1, 1, 8, 1, 3, 1, 1, 'SAME', 'SYMMETRIC', layout)
+        # Realistic dimensions
+        verify_conv1d(1, 16, 32, 16, 3, 1, 1, 'SAME', 'SYMMETRIC', layout)
+        # With stride
+        verify_conv1d(1, 16, 32, 16, 3, 2, 1, 'SAME', 'SYMMETRIC', layout)
+        # With dilation
+        verify_conv1d(1, 16, 32, 16, 3, 1, 2, 'SAME', 'SYMMETRIC', layout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As NLP models become increasingly important in industry it's important we have first class support for Conv1D with dilation. This PR adds the Conv1D operation to Topi and Relay for both CPU and GPU. It supports both NCW and NWC layouts natively.

Conv1D is implemented in the ONNX frontend our current convolution testing for ONNX is expanded.
