### PR TITLE
Fix Base64OutStream portability issue

### DIFF
--- a/src/common/base64.h
+++ b/src/common/base64.h
@@ -258,7 +258,7 @@ class Base64OutStream: public dmlc::Stream {
    * \brief finish writing of all current base64 stream, do some post processing
    * \param endch character to put to end of stream, if it is EOF, then nothing will be appended.
    */
-  void Finish(char endch = EOF) {
+  void Finish(int endch = EOF) {
     using base64::EncodeTable;
     if (buf__top_ == 1) {
       PutChar(EncodeTable[buf_[1] >> 2]);


### PR DESCRIPTION
Fixes #4660 
On ARM, char is unsigned by default while on x86 it is signed by default. On ARM, this causes the logic in `Base64OutStream::Finish` to incorrectly add a char with value of 255 to the end of every b64 string. Fix is to use int for the endchar. Alternatively we could explicitly use `signed char`.
https://www.linuxtopia.org/online_books/an_introduction_to_gcc/gccintro_71.html