### PR TITLE
[AutoTVM] Download fallback schedule file if it does not exist

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -214,7 +214,11 @@ def load_reference_log(backend, model, workload_name, template_key):
 
     if key not in REFERENCE_LOG_CACHE:
         tmp = []
-        if os.path.isfile(os.path.join(AUTOTVM_TOPHUB_ROOT_PATH, package_name)):
+        # Download the config file from tophub if not exists.
+        if not os.path.exists(filename):
+            tophub_location = _get_tophub_location()
+            download_package(tophub_location, package_name)
+        if os.path.isfile(filename): # in case download failed
             find = False
             inp = None
             counts = {}


### PR DESCRIPTION
Autotvm will download the default schedule file from tophub if user does not specify a schedule file. Howver, if user specifies a shedule file but a certain workload is not found in the file. It will fallback to default config, which will search the default schedule file for a closest config. However, in this case, as no schedule is downloaded from tophub, it fails to find a closest config and the performance is really bad. 

An example of performance before and after is shown below:
The model is mxnet resnet50_v1 and device is NVIDIA K80 GPU

Before:
Total_time                                                                -                                                                        550853.527(us)

After:
Total_time                                                                -                                                                        28898.537(us)



Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
