### PR TITLE
[VTA] Update docker for TSIM based simulation

### DIFF
--- a/docker/install/ubuntu_install_chisel.sh
+++ b/docker/install/ubuntu_install_chisel.sh
@@ -28,4 +28,15 @@ apt-get install apt-transport-https
 echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 apt-get update
-apt-get install -y verilator sbt
+
+# Note: The settings in vta/hardware/chisel/project/build.properties
+# file determines required sbt version.
+apt-get install -y sbt=1.1.1
+
+# Install the Verilator with major version 4.0
+wget https://www.veripool.org/ftp/verilator-4.010.tgz
+tar xf verilator-4.010.tgz
+cd verilator-4.010/
+./configure
+make -j4
+make install


### PR DESCRIPTION
This PR tries to update the docker for TSIM based simulation in CI. Following packages would be installed:

* sbt=1.1.1
* verilator=4.10.0