### PR TITLE
[CI] Bump to use the new cpu image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,12 +41,12 @@
 
 // Hashtag in the source to build current CI docker builds
 //
-// - ci-cpu:v0.54: e7c88a99f830de30814df14eaa980547ecbd61c1
+// - ci-cpu:v0.55: 07b45d958d4af91ec1bab66f6cf391d1ce12ddaf
 //
 
 ci_lint = "tvmai/ci-lint:v0.51"
 ci_gpu = "tvmai/ci-gpu:v0.56"
-ci_cpu = "tvmai/ci-cpu:v0.54"
+ci_cpu = "tvmai/ci-cpu:v0.55"
 ci_i386 = "tvmai/ci-i386:v0.52"
 
 // tvm libraries

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -16,7 +16,7 @@
 # under the License.
 
 # CI docker CPU env
-# tag: v0.54
+# tag: v0.55
 FROM ubuntu:16.04
 
 RUN apt-get update --fix-missing


### PR DESCRIPTION
Related docker update

https://github.com/apache/incubator-tvm/pull/4675
https://github.com/apache/incubator-tvm/pull/4674
cc @tmoreau89 @liangfu 