### PR TITLE
[REFACTOR][IR] Allow Module to store BaseFunc

### DIFF
--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -62,7 +62,7 @@ struct Module;
 class ModuleNode : public RelayNode {
  public:
   /*! \brief A map from ids to all global functions. */
-  tvm::Map<GlobalVar, Function> functions;
+  tvm::Map<GlobalVar, BaseFunc> functions;
   /*! \brief A map from global type vars to ADT type data. */
   tvm::Map<GlobalTypeVar, TypeData> type_definitions;
 
@@ -75,7 +75,7 @@ class ModuleNode : public RelayNode {
     v->Visit("global_type_var_map_", &global_type_var_map_);
   }
 
-  TVM_DLL static Module make(tvm::Map<GlobalVar, Function> global_funcs,
+  TVM_DLL static Module make(tvm::Map<GlobalVar, BaseFunc> global_funcs,
                              tvm::Map<GlobalTypeVar, TypeData> global_type_defs,
                              std::unordered_set<std::string> imports = {});
 
@@ -86,7 +86,7 @@ class ModuleNode : public RelayNode {
    * \param update Controls whether you can replace a definition in the
    * environment.
    */
-  TVM_DLL void Add(const GlobalVar& var, const Function& func, bool update = false);
+  TVM_DLL void Add(const GlobalVar& var, const BaseFunc& func, bool update = false);
 
   /*!
    * \brief Add a function to the global environment.
@@ -95,7 +95,7 @@ class ModuleNode : public RelayNode {
    *
    * It does not do type inference as Add does.
    */
-  TVM_DLL void AddUnchecked(const GlobalVar& var, const Function& func);
+  TVM_DLL void AddUnchecked(const GlobalVar& var, const BaseFunc& func);
 
   /*!
    * \brief Add a type-level definition to the global environment.
@@ -124,7 +124,7 @@ class ModuleNode : public RelayNode {
    * \param var The name of the global function to update.
    * \param func The new function.
    */
-  TVM_DLL void Update(const GlobalVar& var, const Function& func);
+  TVM_DLL void Update(const GlobalVar& var, const BaseFunc& func);
 
   /*!
    * \brief Update a type definition in the global environment.
@@ -184,14 +184,14 @@ class ModuleNode : public RelayNode {
    * \param var The global var to lookup.
    * \returns The function named by the variable argument.
    */
-  TVM_DLL Function Lookup(const GlobalVar& var) const;
+  TVM_DLL BaseFunc Lookup(const GlobalVar& var) const;
 
   /*!
    * \brief Look up a global function by its string name
    * \param name The name of the function.
    * \returns The function named by the argument.
    */
-  TVM_DLL Function Lookup(const std::string& name) const;
+  TVM_DLL BaseFunc Lookup(const std::string& name) const;
 
   /*!
    * \brief Look up a global type definition by its variable.
@@ -256,7 +256,7 @@ class ModuleNode : public RelayNode {
    */
   TVM_DLL static Module FromExpr(
     const Expr& expr,
-    const tvm::Map<GlobalVar, Function>& global_funcs = {},
+    const tvm::Map<GlobalVar, BaseFunc>& global_funcs = {},
     const tvm::Map<GlobalTypeVar, TypeData>& type_definitions = {});
 
   static constexpr const char* _type_key = "relay.Module";

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -463,7 +463,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     // Optimize input Relay Function and returns Relay Module
     relay::Module relay_module = Optimize(func, targets_, params);
     // Get the updated function.
-    func = relay_module->Lookup("main");
+    func = Downcast<Function>(relay_module->Lookup("main"));
 
     // Generate code for the updated function.
     graph_codegen_ = std::unique_ptr<GraphCodegen>(new GraphCodegen());

--- a/src/relay/backend/vm/inline_primitives.cc
+++ b/src/relay/backend/vm/inline_primitives.cc
@@ -110,19 +110,23 @@ struct PrimitiveInliner : ExprMutator {
     auto gvar_funcs = module_->functions;
     for (auto pair : gvar_funcs) {
       auto global = pair.first;
-      auto func = pair.second;
-      DLOG(INFO) << "Before inlining primitives: " << global
-                 << std::endl << AsText(func, false);
+      auto base_func = pair.second;
+      if (auto* n = base_func.as<FunctionNode>()) {
+        auto func = GetRef<Function>(n);
 
-      func = FunctionNode::make(func->params,
-                                VisitExpr(func->body),
-                                func->ret_type,
-                                func->type_params,
-                                func->attrs);
-      module_->Add(global, func, true);
+        DLOG(INFO) << "Before inlining primitives: " << global
+                   << std::endl << AsText(func, false);
 
-      DLOG(INFO) << "After inlining primitives: " << global
-                 << std::endl << AsText(func, false);
+        func = FunctionNode::make(func->params,
+                                  VisitExpr(func->body),
+                                  func->ret_type,
+                                  func->type_params,
+                                  func->attrs);
+        module_->Add(global, func, true);
+
+        DLOG(INFO) << "After inlining primitives: " << global
+                   << std::endl << AsText(func, false);
+      }
     }
     return module_;
   }

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -188,13 +188,15 @@ class LambdaLifter : public ExprMutator {
     // There is an ordering bug here.
     auto glob_funcs = module_->functions;
     for (auto pair : glob_funcs) {
-      auto func = pair.second;
-      func = FunctionNode::make(func->params,
-                                VisitExpr(func->body),
-                                func->ret_type,
-                                func->type_params,
-                                func->attrs);
-      module_->Add(pair.first, func, true);
+      if (auto* n = pair.second.as<FunctionNode>()) {
+        auto func = GetRef<Function>(n);
+        func = FunctionNode::make(func->params,
+                                  VisitExpr(func->body),
+                                  func->ret_type,
+                                  func->type_params,
+                                  func->attrs);
+        module_->Add(pair.first, func, true);
+      }
     }
     return module_;
   }

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -486,7 +486,7 @@ class PrettyPrinter :
     return doc;
   }
 
-  Doc PrintFunc(const Doc& prefix, const Function& fn) {
+  Doc PrintFunc(const Doc& prefix, const relay::Function& fn) {
     Doc doc;
     doc << prefix;
     if (fn->type_params.size() > 0) {
@@ -512,6 +512,17 @@ class PrettyPrinter :
     }
     doc << PrintBody(fn->body);
     return doc;
+  }
+
+  Doc PrintFunc(const Doc& prefix, const BaseFunc& base_func) {
+    if (auto* n = base_func.as<relay::FunctionNode>()) {
+      return PrintFunc(prefix, GetRef<relay::Function>(n));
+    } else {
+      // def @xyz = meta['ExternalFunc'][id]
+      Doc doc;
+      doc << prefix << " = " <<  meta_.GetMetaNode(base_func);
+      return doc;
+    }
   }
 
   Doc PrintMod(const Module& mod) {

--- a/src/relay/pass/fold_constant.cc
+++ b/src/relay/pass/fold_constant.cc
@@ -217,7 +217,7 @@ class ConstantFolder : public ExprMutator {
     mod->Add(global, func);
     auto seq = transform::Sequential(passes);
     mod = seq(mod);
-    auto entry_func = mod->Lookup("main");
+    auto entry_func = Downcast<Function>(mod->Lookup("main"));
     expr = expr.as<FunctionNode>() == nullptr ? entry_func->body : entry_func;
     return ObjectToExpr(executor_(expr));
   }

--- a/src/relay/pass/gradient.cc
+++ b/src/relay/pass/gradient.cc
@@ -82,7 +82,12 @@ Type WithGradientType(const Type& t) {
 //! \brief if the expression is a GlobalVar, transform to it's expression.
 Expr DeGlobal(const Module& mod, const Expr& e) {
   if (const auto* x = e.as<GlobalVarNode>()) {
-    return mod->Lookup(GetRef<GlobalVar>(x))->body;
+    BaseFunc base_func = mod->Lookup(GetRef<GlobalVar>(x));
+    if (auto* n = base_func.as<FunctionNode>()) {
+      return n->body;
+    } else {
+      return e;
+    }
   } else {
     return e;
   }

--- a/src/relay/pass/pass_manager.cc
+++ b/src/relay/pass/pass_manager.cc
@@ -323,10 +323,14 @@ Module FunctionPassNode::operator()(const Module& mod,
   Module updated_mod = ModuleNode::make(mod->functions, mod->type_definitions, mod->Imports());
   std::vector<std::pair<GlobalVar, Function> > updates;
   for (const auto& it : updated_mod->functions) {
-    auto updated_func = SkipFunction(it.second)
-                            ? it.second
-                            : pass_func(it.second, updated_mod, pass_ctx);
-    updates.push_back({it.first, updated_func});
+    // only picks up relay::Function
+    if (auto* n = it.second.as<FunctionNode>()) {
+      Function func = GetRef<Function>(n);
+      auto updated_func = SkipFunction(func)
+                          ? func
+                          : pass_func(func, updated_mod, pass_ctx);
+      updates.push_back({it.first, updated_func});
+    }
   }
 
   for (const auto& pair : updates) {

--- a/src/relay/pass/quantize/realize.cc
+++ b/src/relay/pass/quantize/realize.cc
@@ -192,7 +192,7 @@ Expr QuantizeRealize(const Call& ref_call,
 Expr FoldConstantOpt(const Expr& expr) {
   auto mod = ModuleNode::FromExpr(expr);
   mod = transform::FoldConstant()(mod);
-  auto entry_func = mod->Lookup("main");
+  auto entry_func = Downcast<Function>(mod->Lookup("main"));
   return expr.as<FunctionNode>() == nullptr ? entry_func->body : entry_func;
 }
 

--- a/tests/cpp/relay_transform_sequential.cc
+++ b/tests/cpp/relay_transform_sequential.cc
@@ -86,7 +86,7 @@ TEST(Relay, Sequential) {
   CHECK(mod.defined());
   auto entry_func = mod->GetGlobalVar("main");
   CHECK(entry_func.defined());
-  relay::Function f = mod->Lookup("main");
+  relay::Function f = Downcast<relay::Function>(mod->Lookup("main"));
   CHECK(f.defined());
 
   // Expected function


### PR DESCRIPTION
Under the unified IR. We will allow a single IRModule
to store different function variants, such as relay::Function,
ExternFunc, and low-level function.

This PR changes relay::Function -> BaseFunc in the module file
to support multiple function variants.

This PR depends on #4673 