### PR TITLE
Fix Python syntax error in start_rpc_server_to_tracker.py

### DIFF
--- a/apps/vta_rpc/start_rpc_server_to_tracker.py
+++ b/apps/vta_rpc/start_rpc_server_to_tracker.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-PROJROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
+PROJROOT="$( cd '$( dirname "${BASH_SOURCE[0]}" )/../../' && pwd )"
 
 # Derive target specified by vta_config.json
 VTA_CONFIG=${PROJROOT}/vta/config/vta_config.py


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/apache/incubator-tvm on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./apps/vta_rpc/start_rpc_server_to_tracker.py:18:18: E999 SyntaxError: invalid syntax
PROJROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
                 ^
```

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
