### PR TITLE
Fix Python syntax error AGAIN in start_rpc_server_to_tracker.py

### DIFF
--- a/apps/vta_rpc/start_rpc_server_to_tracker.py
+++ b/apps/vta_rpc/start_rpc_server_to_tracker.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-PROJROOT="$( cd '$( dirname "${BASH_SOURCE[0]}" )/../../' && pwd )"
+PROJROOT="""$( cd "$( dirname '${BASH_SOURCE[0]}' )/../../" && pwd )"""
 
 # Derive target specified by vta_config.json
 VTA_CONFIG=${PROJROOT}/vta/config/vta_config.py


### PR DESCRIPTION
#4682 Tried to fix a Python syntax error but did not go far enough because there are _three sets_ of embedded quotes.

This PR solves the syntax error by using Python's triple quoted strings on the outside and then double quotes in the middle and then single quotes on the inside.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
