### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -155,7 +155,7 @@ def test_bias_add():
     for dtype in ['float16', 'float32']:
         xshape=(10, 2, 3, 4)
         bshape=(2,)
-        rtol = 1e-2 if dtype is 'float16' else 1e-5
+        rtol = 1e-2 if dtype == 'float16' else 1e-5
         x = relay.var("x", shape=xshape, dtype=dtype)
         bias = relay.var("bias", dtype=dtype)
         z = relay.nn.bias_add(x, bias)


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise __SyntaxWarnings__ so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% __python__
```
>>> dtype = "float"
>>> dtype += "16"
>>> dtype == "float16"
True
>>> dtype is "float16"
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
