### PR TITLE
WIP: Flake8: Add undefined names test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: |
         pip install flake8
-        flake8 . --count --select=E9,F63,F7 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Initialize submodules
       run: git submodule update --recursive --init
 


### PR DESCRIPTION
Work in Progress: Do not merge.  

F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user. 

This test on this repo raises a lot of false reports because it gets really confused by the [HYBRID_GLOBALS](https://github.com/apache/incubator-tvm/blob/master/python/tvm/hybrid/runtime.py#L113) approach of adding globals without declaring them as globals in the local scope.  (This could be overcome by adding them as `--builtins=` in the flake8 command.)

However, there are other undefined names that are not in HYBRID_GLOBALS that should be addressed such as the missing import of tensorflow.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
