### PR TITLE
[VTA] Fix an issue in updating uop_idx in the TensorGemm module

### DIFF
--- a/vta/hardware/chisel/src/main/scala/core/TensorGemm.scala
+++ b/vta/hardware/chisel/src/main/scala/core/TensorGemm.scala
@@ -280,7 +280,7 @@ class TensorGemm(debug: Boolean = false)(implicit p: Parameters)
       (state === sExe &&
         uop_idx === uop_end - 1.U)) {
     uop_idx := dec.uop_begin
-  }.elsewhen(state === sExe) {
+  }.elsewhen(state === sExe && dec.uop_begin =/= uop_end) {
     uop_idx := uop_idx + 1.U
   }
 


### PR DESCRIPTION
This PR fixed an issue in updating `uop_idx` counter in the `TensorGemm` module.

### Problem
When evaluating `deploy_vision_on_vta.py` with TSIM backend, it is required to run the module with
```python
m.run()
```
However, it throws an instance of `dmlc::Error`, saying
```
virtual_memory.cc:48: Check failed: phy_addr != 0 (0 vs. 0) : trying to get address that is nullptr
```
The root cause is that `uop_idx` increases unexpectedly.

This PR fixes the above issue and enables successful evaluation of `deploy_vision_on_vta.py` with TSIM backend.