### PR TITLE
[Runtime] EdgeTPU runtime for Coral Boards

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -154,6 +154,11 @@ set(USE_TFLITE OFF)
 # /path/to/tensorflow: tensorflow root path when use tflite library
 set(USE_TENSORFLOW_PATH none)
 
+# Possible values:
+# - OFF: disable tflite support for edgetpu
+# - /path/to/edgetpu: use specific path to edgetpu library
+set(USE_EDGETPU OFF)
+
 # Whether use CuDNN
 set(USE_CUDNN OFF)
 

--- a/cmake/modules/contrib/TFLite.cmake
+++ b/cmake/modules/contrib/TFLite.cmake
@@ -25,6 +25,15 @@ if(NOT USE_TFLITE STREQUAL "OFF")
   list(APPEND RUNTIME_SRCS ${TFLITE_CONTRIB_SRC})
   include_directories(${USE_TENSORFLOW_PATH})
 
+  # Additional EdgeTPU libs
+  # Need to specify path to repo e.g. set(USE_EDGETPU /home/mendel/edgetpu)
+  if (NOT USE_EDGETPU STREQUAL "ON")
+    file(GLOB EDGETPU_CONTRIB_SRC src/runtime/contrib/edgetpu/*.cc)
+    list(APPEND RUNTIME_SRCS ${EDGETPU_CONTRIB_SRC})
+    include_directories(${USE_EDGETPU}/libedgetpu)
+    list(APPEND TVM_RUNTIME_LINKER_LIBS ${USE_EDGETPU}/libedgetpu/direct/aarch64/libedgetpu.so.1)
+  endif()
+
   if (USE_TFLITE STREQUAL "ON")
     set(USE_TFLITE ${USE_TENSORFLOW_PATH}/tensorflow/lite/tools/make/gen/*/lib)
   endif()

--- a/cmake/modules/contrib/TFLite.cmake
+++ b/cmake/modules/contrib/TFLite.cmake
@@ -26,8 +26,8 @@ if(NOT USE_TFLITE STREQUAL "OFF")
   include_directories(${USE_TENSORFLOW_PATH})
 
   # Additional EdgeTPU libs
-  # Need to specify path to repo e.g. set(USE_EDGETPU /home/mendel/edgetpu)
-  if (NOT USE_EDGETPU STREQUAL "ON")
+  if (NOT USE_EDGETPU STREQUAL "OFF")
+    message(STATUS "Build with contrib.edgetpu")
     file(GLOB EDGETPU_CONTRIB_SRC src/runtime/contrib/edgetpu/*.cc)
     list(APPEND RUNTIME_SRCS ${EDGETPU_CONTRIB_SRC})
     include_directories(${USE_EDGETPU}/libedgetpu)

--- a/python/tvm/contrib/tflite_runtime.py
+++ b/python/tvm/contrib/tflite_runtime.py
@@ -18,7 +18,7 @@
 from .._ffi.function import get_global_func
 from ..rpc import base as rpc_base
 
-def create(tflite_model_bytes, ctx):
+def create(tflite_model_bytes, ctx, target_edgetpu=False):
     """Create a runtime executor module given a tflite model and context.
     Parameters
     ----------
@@ -27,6 +27,9 @@ def create(tflite_model_bytes, ctx):
     ctx : TVMContext
         The context to deploy the module. It can be local or remote when there
         is only one TVMContext.
+    target_edgetpu: bool
+        Targets execution on the edge TPU via tflite when running on the Coral board.
+        Set to False by default.
     Returns
     -------
     tflite_runtime : TFLiteModule
@@ -34,9 +37,15 @@ def create(tflite_model_bytes, ctx):
     """
     device_type = ctx.device_type
     if device_type >= rpc_base.RPC_SESS_MASK:
-        fcreate = ctx._rpc_sess.get_function("tvm.tflite_runtime.create")
+        if target_edgetpu:
+            fcreate = ctx._rpc_sess.get_function("tvm.edgetpu_runtime.create")
+        else:
+            fcreate = ctx._rpc_sess.get_function("tvm.tflite_runtime.create")
         return TFLiteModule(fcreate(bytearray(tflite_model_bytes), ctx))
-    fcreate = get_global_func("tvm.tflite_runtime.create")
+    if target_edgetpu:
+        fcreate = get_global_func("tvm.edgetpu_runtime.create")
+    else:
+        fcreate = get_global_func("tvm.tflite_runtime.create")
     return TFLiteModule(fcreate(bytearray(tflite_model_bytes), ctx))
 
 
@@ -50,12 +59,12 @@ class TFLiteModule(object):
     Parameters
     ----------
     module : Module
-        The interal tvm module that holds the actual tflite functions.
+        The internal tvm module that holds the actual tflite functions.
 
     Attributes
     ----------
     module : Module
-        The interal tvm module that holds the actual tflite functions.
+        The internal tvm module that holds the actual tflite functions.
     """
 
     def __init__(self, module):
@@ -63,7 +72,6 @@ class TFLiteModule(object):
         self._set_input = module["set_input"]
         self._invoke = module["invoke"]
         self._get_output = module["get_output"]
-        self._allocate_tensors = module["allocate_tensors"]
 
     def set_input(self, index, value):
         """Set inputs to the module via kwargs
@@ -90,12 +98,6 @@ class TFLiteModule(object):
             List of input values to be feed to
         """
         self._invoke()
-
-    def allocate_tensors(self):
-        """Allocate space for all tensors.
-        """
-        self._allocate_tensors()
-
 
     def get_output(self, index):
         """Get index-th output to out

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.cc
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.cc
@@ -45,17 +45,15 @@ void EdgeTPURuntime::Init(const std::string& tflite_model_bytes,
   edgetpu_context_ = edgetpu::EdgeTpuManager::GetSingleton()->OpenDevice();
   // Add custom edgetpu ops to resolver
   resolver.AddCustom(edgetpu::kCustomOp, edgetpu::RegisterCustomOp());
-  // Ensure that the build went successfully
-  if (tflite::InterpreterBuilder(*model, resolver)(&interpreter_) != kTfLiteOk) {
-    std::cerr << "Failed to build interpreter." << std::endl;
-  }
+  // Build interpreter
+  TfLiteStatus status = tflite::InterpreterBuilder(*model, resolver)(&interpreter_);
+  CHECK_TFLITE_STATUS(status) << "Failed to build interpreter.";
   // Bind EdgeTPU context with interpreter.
   interpreter_->SetExternalContext(kTfLiteEdgeTpuContext, edgetpu_context_.get());
   interpreter_->SetNumThreads(1);
   // Allocate tensors
-  if (interpreter_->AllocateTensors() != kTfLiteOk) {
-    std::cerr << "Failed to allocate tensors." << std::endl;
-  }
+  status = interpreter_->AllocateTensors();
+  CHECK_TFLITE_STATUS(status) << "Failed to allocate tensors.";
 
   ctx_ = ctx;
 }

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.cc
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.cc
@@ -21,7 +21,6 @@
  * \file edgetpu_runtime.cc
  */
 #include <tvm/runtime/registry.h>
-#include <tvm/dtype.h>
 #include <tensorflow/lite/interpreter.h>
 #include <tensorflow/lite/kernels/register.h>
 #include <tensorflow/lite/model.h>
@@ -34,37 +33,37 @@ namespace tvm {
 namespace runtime {
 
 #define TVM_DTYPE_DISPATCH(type, DType, ...)            \
-  if (type == Float(64)) {                              \
+  if (type == DataType::Float(64)) {                    \
     typedef double DType;                               \
     {__VA_ARGS__}                                       \
-  } else if (type == Float(32)) {                       \
+  } else if (type == DataType::Float(32)) {             \
     typedef float DType;                                \
     {__VA_ARGS__}                                       \
-  } else if (type == Float(16)) {                       \
+  } else if (type == DataType::Float(16)) {             \
     typedef uint16_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == Int(64)) {                         \
+  } else if (type == DataType::Int(64)) {               \
     typedef int64_t DType;                              \
     {__VA_ARGS__}                                       \
-  } else if (type == Int(32)) {                         \
+  } else if (type == DataType::Int(32)) {               \
     typedef int32_t DType;                              \
     {__VA_ARGS__}                                       \
-  } else if (type == Int(16)) {                         \
+  } else if (type == DataType::Int(16)) {               \
     typedef int16_t DType;                              \
     {__VA_ARGS__}                                       \
-  } else if (type == Int(8)) {                          \
+  } else if (type == DataType::Int(8)) {                \
     typedef int8_t DType;                               \
     {__VA_ARGS__}                                       \
-  } else if (type == UInt(64)) {                        \
+  } else if (type == DataType::UInt(64)) {              \
     typedef uint64_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == UInt(32)) {                        \
+  } else if (type == DataType::UInt(32)) {              \
     typedef uint32_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == UInt(16)) {                        \
+  } else if (type == DataType::UInt(16)) {              \
     typedef uint16_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == UInt(8)) {                         \
+  } else if (type == DataType::UInt(8)) {               \
     typedef uint8_t DType;                              \
     {__VA_ARGS__}                                       \
   } else {                                              \
@@ -74,22 +73,22 @@ namespace runtime {
 DataType TfLiteDType2TVMDType_(TfLiteType dtype) {
   switch (dtype) {
     case kTfLiteFloat32:
-      return Float(32);
+      return DataType::Float(32);
     case kTfLiteInt32:
-      return Int(32);
+      return DataType::Int(32);
     case kTfLiteInt64:
-      return Int(64);
+      return DataType::Int(64);
     case kTfLiteInt16:
-      return Int(16);
+      return DataType::Int(16);
     case kTfLiteInt8:
-      return Int(8);
+      return DataType::Int(8);
     case kTfLiteUInt8:
-      return UInt(8);
+      return DataType::UInt(8);
     case kTfLiteFloat16:
-      return Float(16);
+      return DataType::Float(16);
     default:
       LOG(FATAL) << "tflite data type not support yet: " << dtype;
-      return Float(32);
+      return DataType::Float(32);
   }
 }
 

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.h
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.h
@@ -25,11 +25,13 @@
 #ifndef TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_
 #define TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_
 
+#include <string>
+#include <memory>
+
 #include "../tflite/tflite_runtime.h"
 
 namespace tvm {
 namespace runtime {
-
 
 /*!
  * \brief EdgeTPU runtime.

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.h
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.h
@@ -25,13 +25,7 @@
 #ifndef TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_
 #define TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_
 
-#include <dlpack/dlpack.h>
-#include <tvm/runtime/ndarray.h>
-#include <tvm/runtime/packed_func.h>
-
-#include <vector>
-#include <string>
-#include <memory>
+#include "../tflite/tflite_runtime.h"
 
 namespace tvm {
 namespace runtime {
@@ -43,17 +37,8 @@ namespace runtime {
  *  This runtime can be accessed in various languages via
  *  the TVM runtime PackedFunc API.
  */
-class EdgeTPURuntime : public ModuleNode {
+class EdgeTPURuntime : public TFLiteRuntime {
  public:
-  /*!
-   * \brief Get member function to front-end.
-   * \param name The name of the function.
-   * \param sptr_to_self The pointer to the module node.
-   * \return The corresponding member function.
-   */
-  virtual PackedFunc GetFunction(const std::string& name,
-                                 const ObjectPtr<Object>& sptr_to_self);
-
   /*!
    * \return The type key of the executor.
    */
@@ -62,44 +47,15 @@ class EdgeTPURuntime : public ModuleNode {
   }
 
   /*!
-   * \brief Invoke the internal tflite interpreter and run the whole model in 
-   * dependency order.
-   */
-  void Invoke();
-
-  /*!
-   * \brief Initialize the tflite runtime with tflite model and context.
+   * \brief Initialize the edge TPU tflite runtime with tflite model and context.
    * \param tflite_model_bytes The tflite model.
    * \param ctx The context where the tflite model will be executed on.
    */
   void Init(const std::string& tflite_model_bytes,
             TVMContext ctx);
 
-  /*!
-   * \brief set index-th input to the model.
-   * \param index The input index.
-   * \param data_in The input data.
-   */
-  void SetInput(int index, DLTensor* data_in);
-  /*!
-   * \brief Return NDArray for given input index.
-   * \param index The input index.
-   *
-   * \return NDArray corresponding to given input node index.
-   */
-  NDArray GetInput(int index) const;
-  /*!
-   * \brief Return NDArray for given output index.
-   * \param index The output index.
-   *
-   * \return NDArray corresponding to given output node index.
-   */
-  NDArray GetOutput(int index) const;
-
  private:
-  std::unique_ptr<tflite::Interpreter> interpreter_;
   std::shared_ptr<edgetpu::EdgeTpuContext> edgetpu_context_;
-  TVMContext ctx_;
 };
 
 }  // namespace runtime

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.h
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.h
@@ -18,12 +18,12 @@
  */
 
 /*!
- * \brief Tflite runtime that can run tflite model
- *        containing only tvm PackedFunc.
- * \file tflite_runtime.h
+ * \brief EdgeTPU runtime that can run tflite model compiled
+ *        for EdgeTPU containing only tvm PackedFunc.
+ * \file edgetpu_runtime.h
  */
-#ifndef TVM_RUNTIME_CONTRIB_TFLITE_TFLITE_RUNTIME_H_
-#define TVM_RUNTIME_CONTRIB_TFLITE_TFLITE_RUNTIME_H_
+#ifndef TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_
+#define TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_
 
 #include <dlpack/dlpack.h>
 #include <tvm/runtime/ndarray.h>
@@ -38,12 +38,12 @@ namespace runtime {
 
 
 /*!
- * \brief Tflite runtime.
+ * \brief EdgeTPU runtime.
  *
- *  This runtime can be accessed in various language via
- *  TVM runtime PackedFunc API.
+ *  This runtime can be accessed in various languages via
+ *  the TVM runtime PackedFunc API.
  */
-class TFLiteRuntime : public ModuleNode {
+class EdgeTPURuntime : public ModuleNode {
  public:
   /*!
    * \brief Get member function to front-end.
@@ -58,7 +58,7 @@ class TFLiteRuntime : public ModuleNode {
    * \return The type key of the executor.
    */
   const char* type_key() const final {
-    return "TFLiteRuntime";
+    return "EdgeTPURuntime";
   }
 
   /*!
@@ -98,10 +98,11 @@ class TFLiteRuntime : public ModuleNode {
 
  private:
   std::unique_ptr<tflite::Interpreter> interpreter_;
+  std::shared_ptr<edgetpu::EdgeTpuContext> edgetpu_context_;
   TVMContext ctx_;
 };
 
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RUNTIME_CONTRIB_TFLITE_TFLITE_RUNTIME_H_
+#endif  // TVM_RUNTIME_CONTRIB_EDGETPU_EDGETPU_RUNTIME_H_

--- a/src/runtime/contrib/tflite/tflite_runtime.cc
+++ b/src/runtime/contrib/tflite/tflite_runtime.cc
@@ -99,13 +99,11 @@ void TFLiteRuntime::Init(const std::string& tflite_model_bytes,
     tflite::FlatBufferModel::BuildFromBuffer(buffer, buffer_size);
   tflite::ops::builtin::BuiltinOpResolver resolver;
   // Build interpreter
-  if (tflite::InterpreterBuilder(*model, resolver)(&interpreter_) != kTfLiteOk) {
-    std::cerr << "Failed to build interpreter." << std::endl;
-  }
+  TfLiteStatus status = tflite::InterpreterBuilder(*model, resolver)(&interpreter_);
+  CHECK_TFLITE_STATUS(status) << "Failed to build interpreter.";
   // Allocate tensors
-  if (interpreter_->AllocateTensors() != kTfLiteOk) {
-    std::cerr << "Failed to allocate tensors." << std::endl;
-  }
+  status = interpreter_->AllocateTensors();
+  CHECK_TFLITE_STATUS(status) << "Failed to allocate tensors.";
 
   ctx_ = ctx;
 }

--- a/src/runtime/contrib/tflite/tflite_runtime.cc
+++ b/src/runtime/contrib/tflite/tflite_runtime.cc
@@ -91,7 +91,6 @@ DataType TfLiteDType2TVMDType(TfLiteType dtype) {
   }
 }
 
-
 void TFLiteRuntime::Init(const std::string& tflite_model_bytes,
                          TVMContext ctx) {
   const char* buffer = tflite_model_bytes.c_str();

--- a/src/runtime/contrib/tflite/tflite_runtime.cc
+++ b/src/runtime/contrib/tflite/tflite_runtime.cc
@@ -79,9 +79,9 @@ DataType TfLiteDType2TVMDType(TfLiteType dtype) {
     case kTfLiteInt64:
       return DataType::Int(64);
     case kTfLiteInt16:
-      returnDataType::Int(16);
+      return DataType::Int(16);
     case kTfLiteInt8:
-      returnDataType::Int(8);
+      return DataType::Int(8);
     case kTfLiteUInt8:
       return DataType::UInt(8);
     case kTfLiteFloat16:

--- a/src/runtime/contrib/tflite/tflite_runtime.cc
+++ b/src/runtime/contrib/tflite/tflite_runtime.cc
@@ -21,7 +21,6 @@
  * \file tflite_runtime.cc
  */
 #include <tvm/runtime/registry.h>
-#include <tvm/dtype.h>
 #include <tensorflow/lite/interpreter.h>
 #include <tensorflow/lite/kernels/register.h>
 #include <tensorflow/lite/model.h>
@@ -33,37 +32,37 @@ namespace tvm {
 namespace runtime {
 
 #define TVM_DTYPE_DISPATCH(type, DType, ...)            \
-  if (type == DataType::Float(64)) {                              \
+  if (type == DataType::Float(64)) {                    \
     typedef double DType;                               \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::Float(32)) {                       \
+  } else if (type == DataType::Float(32)) {             \
     typedef float DType;                                \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::Float(16)) {                       \
+  } else if (type == DataType::Float(16)) {             \
     typedef uint16_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::Int(64)) {                         \
+  } else if (type == DataType::Int(64)) {               \
     typedef int64_t DType;                              \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::Int(32)) {                         \
+  } else if (type == DataType::Int(32)) {               \
     typedef int32_t DType;                              \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::Int(16)) {                         \
+  } else if (type == DataType::Int(16)) {               \
     typedef int16_t DType;                              \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::Int(8)) {                          \
+  } else if (type == DataType::Int(8)) {                \
     typedef int8_t DType;                               \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::UInt(64)) {                        \
+  } else if (type == DataType::UInt(64)) {              \
     typedef uint64_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::UInt(32)) {                        \
+  } else if (type == DataType::UInt(32)) {              \
     typedef uint32_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::UInt(16)) {                        \
+  } else if (type == DataType::UInt(16)) {              \
     typedef uint16_t DType;                             \
     {__VA_ARGS__}                                       \
-  } else if (type == DataType::UInt(8)) {                         \
+  } else if (type == DataType::UInt(8)) {               \
     typedef uint8_t DType;                              \
     {__VA_ARGS__}                                       \
   } else {                                              \

--- a/src/runtime/contrib/tflite/tflite_runtime.h
+++ b/src/runtime/contrib/tflite/tflite_runtime.h
@@ -36,6 +36,7 @@
 namespace tvm {
 namespace runtime {
 
+#define CHECK_TFLITE_STATUS(ret) CHECK_EQ(ret, kTfLiteOk)
 
 /*!
  * \brief Tflite runtime.

--- a/src/runtime/contrib/tflite/tflite_runtime.h
+++ b/src/runtime/contrib/tflite/tflite_runtime.h
@@ -57,7 +57,7 @@ class TFLiteRuntime : public ModuleNode {
   /*!
    * \return The type key of the executor.
    */
-  const char* type_key() const final {
+  const char* type_key() const {
     return "TFLiteRuntime";
   }
 
@@ -96,8 +96,9 @@ class TFLiteRuntime : public ModuleNode {
    */
   NDArray GetOutput(int index) const;
 
- private:
+  // TFLite interpreter
   std::unique_ptr<tflite::Interpreter> interpreter_;
+  // TVM context
   TVMContext ctx_;
 };
 

--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -19,7 +19,7 @@ import tvm
 import numpy as np
 from tvm import rpc
 from tvm.contrib import util, tflite_runtime
-import tflite_runtime.interpreter as tflite
+# import tflite_runtime.interpreter as tflite
 
 
 def skipped_test_tflite_runtime():
@@ -99,10 +99,8 @@ def skipped_test_tflite_runtime():
             np.testing.assert_equal(out.asnumpy(), tflite_output)
 
     # Target CPU on coral board
-    check_local()
     check_remote()
     # Target EdgeTPU on coral board
-    check_local(targetedgetpu=True)
     check_remote(targetedgetpu=True)
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import tvm
+import numpy as np
+from tvm import rpc
+from tvm.contrib import util, tflite_runtime
+import tflite_runtime.interpreter as tflite
+
+
+def skipped_test_tflite_runtime():
+
+    def get_tflite_model_path(target_edgetpu):
+        # Return a path to the model
+        edgetpu_path = os.getenv('EDGETPU_PATH', "/home/mendel/edgetpu")
+        # Obtain mobilenet model from the edgetpu repo path
+        if target_edgetpu:
+            model_path = os.path.join(edgetpu_path, "test_data/mobilenet_v1_1.0_224_quant_edgetpu.tflite")
+        else:
+            model_path = os.path.join(edgetpu_path, "test_data/mobilenet_v1_1.0_224_quant.tflite")
+        return model_path
+    
+
+    def init_interpreter(model_path, target_edgetpu):
+        # Initialize interpreter
+        if target_edgetpu:
+            edgetpu_path = os.getenv('EDGETPU_PATH', "/home/mendel/edgetpu")
+            libedgetpu = os.path.join(edgetpu_path, "libedgetpu/direct/aarch64/libedgetpu.so.1")
+            interpreter = tflite.Interpreter(
+                    model_path=model_path,
+                    experimental_delegates=[tflite.load_delegate(libedgetpu)])
+        else:
+            interpreter = tflite.Interpreter(model_path=model_path)
+        return interpreter
+
+    def check_local(target_edgetpu=False):
+        tflite_model_path = get_tflite_model_path(target_edgetpu)
+
+        # inference via tflite interpreter python apis
+        interpreter = init_interpreter(tflite_model_path, target_edgetpu)
+        interpreter.allocate_tensors()
+        input_details = interpreter.get_input_details()
+        output_details = interpreter.get_output_details()
+        
+        input_shape = input_details[0]['shape']
+        tflite_input = np.array(np.random.random_sample(input_shape), dtype=np.uint8)
+        interpreter.set_tensor(input_details[0]['index'], tflite_input)
+        interpreter.invoke()
+        tflite_output = interpreter.get_tensor(output_details[0]['index'])
+        
+        # inference via tvm tflite runtime
+        with open(tflite_model_path, 'rb') as model_fin:
+            runtime = tflite_runtime.create(model_fin.read(), tvm.cpu(0), target_edgetpu)
+            runtime.set_input(0, tvm.nd.array(tflite_input))
+            runtime.invoke()
+            out = runtime.get_output(0)
+            np.testing.assert_equal(out.asnumpy(), tflite_output)
+
+    def check_remote(target_edgetpu=False):
+        tflite_model_path = get_tflite_model_path(target_edgetpu)
+
+        # inference via tflite interpreter python apis
+        interpreter = init_interpreter(tflite_model_path, target_edgetpu)
+        interpreter.allocate_tensors()
+        input_details = interpreter.get_input_details()
+        output_details = interpreter.get_output_details()
+        
+        input_shape = input_details[0]['shape']
+        tflite_input = np.array(np.random.random_sample(input_shape), dtype=np.uint8)
+        interpreter.set_tensor(input_details[0]['index'], tflite_input)
+        interpreter.invoke()
+        tflite_output = interpreter.get_tensor(output_details[0]['index'])
+
+        # inference via remote tvm tflite runtime
+        server = rpc.Server("localhost")
+        remote = rpc.connect(server.host, server.port)
+        ctx = remote.cpu(0)
+        a = remote.upload(tflite_model_path)
+
+        with open(tflite_model_path, 'rb') as model_fin:
+            runtime = tflite_runtime.create(model_fin.read(), remote.cpu(0))
+            runtime.set_input(0, tvm.nd.array(tflite_input, remote.cpu(0)))
+            runtime.invoke()
+            out = runtime.get_output(0)
+            np.testing.assert_equal(out.asnumpy(), tflite_output)
+
+    # Target CPU on coral board
+    check_local()
+    check_remote()
+    # Target EdgeTPU on coral board
+    check_local(targetedgetpu=True)
+    check_remote(targetedgetpu=True)
+
+if __name__ == "__main__":
+    # skipped_test_tflite_runtime()
+    pass

--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -102,8 +102,8 @@ def skipped_test_tflite_runtime():
     # check_local()
     check_remote()
     # Target EdgeTPU on coral board
-    # check_local(targetedgetpu=True)
-    check_remote(targetedgetpu=True)
+    # check_local(target_edgetpu=True)
+    check_remote(target_edgetpu=True)
 
 if __name__ == "__main__":
     # skipped_test_tflite_runtime()

--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -99,8 +99,10 @@ def skipped_test_tflite_runtime():
             np.testing.assert_equal(out.asnumpy(), tflite_output)
 
     # Target CPU on coral board
+    # check_local()
     check_remote()
     # Target EdgeTPU on coral board
+    # check_local(targetedgetpu=True)
     check_remote(targetedgetpu=True)
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_tflite_runtime.py
+++ b/tests/python/contrib/test_tflite_runtime.py
@@ -96,8 +96,7 @@ def skipped_test_tflite_runtime():
             out = runtime.get_output(0)
             np.testing.assert_equal(out.asnumpy(), tflite_output)
 
-    # TODO(ZihengJiang): Test below needs to be re-enabled upon fix
-    # check_local()
+    check_local()
     check_remote()
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_tflite_runtime.py
+++ b/tests/python/contrib/test_tflite_runtime.py
@@ -36,16 +36,14 @@ def skipped_test_tflite_runtime():
         return tflite_model
 
 
-    def check_verify():
+    def check_local():
         tflite_fname = "model.tflite"
         tflite_model = create_tflite_model()
         temp = util.tempdir()
         tflite_model_path = temp.relpath(tflite_fname)
-        print(tflite_model_path)
         open(tflite_model_path, 'wb').write(tflite_model)
 
         # inference via tflite interpreter python apis
-        print('interpreter')
         interpreter = tflite.Interpreter(model_path=tflite_model_path)
         interpreter.allocate_tensors()
         input_details = interpreter.get_input_details()
@@ -57,11 +55,9 @@ def skipped_test_tflite_runtime():
         interpreter.invoke()
         tflite_output = interpreter.get_tensor(output_details[0]['index'])
         
-        print('tvm tflite runtime')
         # inference via tvm tflite runtime
         with open(tflite_model_path, 'rb') as model_fin:
             runtime = tflite_runtime.create(model_fin.read(), tvm.cpu(0))
-            runtime.allocate_tensors()
             runtime.set_input(0, tvm.nd.array(tflite_input))
             runtime.invoke()
             out = runtime.get_output(0)
@@ -95,14 +91,13 @@ def skipped_test_tflite_runtime():
 
         with open(tflite_model_path, 'rb') as model_fin:
             runtime = tflite_runtime.create(model_fin.read(), remote.cpu(0))
-            runtime.allocate_tensors()
             runtime.set_input(0, tvm.nd.array(tflite_input, remote.cpu(0)))
             runtime.invoke()
             out = runtime.get_output(0)
             np.testing.assert_equal(out.asnumpy(), tflite_output)
 
 
-    check_verify()
+    check_local()
     check_remote()
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_tflite_runtime.py
+++ b/tests/python/contrib/test_tflite_runtime.py
@@ -96,7 +96,7 @@ def skipped_test_tflite_runtime():
             out = runtime.get_output(0)
             np.testing.assert_equal(out.asnumpy(), tflite_output)
 
-
+    # TODO(ZihengJiang): Test below needs to be re-enabled upon fix
     # check_local()
     check_remote()
 

--- a/tests/python/contrib/test_tflite_runtime.py
+++ b/tests/python/contrib/test_tflite_runtime.py
@@ -97,7 +97,7 @@ def skipped_test_tflite_runtime():
             np.testing.assert_equal(out.asnumpy(), tflite_output)
 
 
-    check_local()
+    # check_local()
     check_remote()
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR extends the TFLite runtime to support edgeTPU-equipped Coral boards in order to measure inference time of models on edgeTPU with TVM RPC.

## Instructions to run the EdgeTPU runtime experiments

### Coral Board setup
You'll need to follow these instructions: https://coral.ai/docs/dev-board/get-started/
```
# Clone TensorFlow, and prepare the library dir
# Note the older version of TF that we'll need to use
git clone https://github.com/tensorflow/tensorflow --recursive --branch=1.8.0
cd tensorflow
mkdir tensorflow/lite/tools/make/gen
mkdir tensorflow/lite/tools/make/gen/generic-aarch64_armv8-a
mkdir tensorflow/lite/tools/make/gen/generic-aarch64_armv8-a/lib

# TF dependence
cd ~ && git clone https://github.com/google/flatbuffers.git
cd flatbuffers && cmake -G "Unix Makefiles" && make && sudo make install

# EdgeTPU lib
cd ~ && git clone https://github.com/google-coral/edgetpu.git
```

### Cross compile tflite static library on x86 machine
```
# Prerequisites 
sudo apt-get update
sudo apt-get install crossbuild-essential-arm64

# cross-compile tflite library (note you need to use older version)
git clone https://github.com/tensorflow/tensorflow.git --recursive --branch=1.8.0
cd tensorflow
./tensorflow/lite/tools/make/download_dependencies.sh
./tensorflow/lite/tools/make/build_aarch64_lib.sh
# Copy the tensorflow lib over to your coral board
scp tensorflow/lite/tools/make/gen/generic-aarch64_armv8-a/lib/libtensorflow-lite.a  mendel@coral:/home/mendel/tensorflow/tensorflow/lite/tools/make/gen/generic-aarch64_armv8-a/lib/
```

### Build TVM runtime on Coral Board
```
cd ~ && git clone --recursive --branch=master https://github.com/apache/incubator-tvm.git tvm
cd tvm && mkdir build && cp cmake/config.cmake build
echo 'set(USE_GRAPH_RUNTIME_DEBUG ON)' >> build/config.cmake
echo 'set(USE_TFLITE ON)' >> build/config.cmake
echo 'set(USE_TENSORFLOW_PATH /home/mendel/tensorflow)' >> build/config.cmake
echo 'set(USE_EDGETPU /home/mendel/edgetpu)' >> build/config.cmake
cd build && cmake ..
make runtime -j4
```

### Execute the RPC server on Coral
First, follow this guide to set up a tracker for your remote devices: https://docs.tvm.ai/tutorials/autotvm/tune_relay_arm.html#start-rpc-tracker.
On the coral, once TVM runtime has been built, execute:
```
PYTHONPATH=/home/mendel/tvm/python:$PYTHONPATH python3 -m tvm.exec.rpc_server --tracker $TVM_TRACKER_HOST:$TVM_TRACKER_NODE --key coral
```

### Evaluate MobileNet on Coral board

Execute the following python script:
```python
import numpy as np

import tvm
from tvm import autotvm, relay
from tvm.contrib import tflite_runtime

target = "cpu"

# Note: replace "tracker" and 9191 with your tracker host and port name
remote = autotvm.measure.request_remote("coral", "tracker", 9191, timeout=60)
ctx = remote.cpu(0)

if target == "edge_tpu":
    tflite_fp = "mobilenet_v2_1.0_224_quant_edgetpu.tflite"
else:
    tflite_fp = "mobilenet_v2_1.0_224_quant.tflite"
input_data = np.random.rand(1,224,224,3).astype("uint8")
with open(tflite_fp, 'rb') as f:
    runtime = tflite_runtime.create(f.read(), ctx, runtime_target=target)
    runtime.set_input(0, tvm.nd.array(input_data, ctx))
    ftimer = runtime.module.time_evaluator("invoke", ctx,
            number=10,
            repeat=3)
    times = np.array(ftimer().results) * 1000
    print("It took {0:.2f}ms to run mobilenet".format(np.mean(times)))
```

Upon running it, you'll get:
`It took 143.74ms to run mobilenet`

Now, set `target = "edge_tpu"` and you'll get:
`It took 3.22ms to run mobilenet`

## Notable interface changes

* The TFLite runtime API does not expose the `allocate()` method anymore, and tensor allocation is done as part of the initialization process.