### PR TITLE
[VTA] Support network which have no unique operator as start/stop name for graph pack.

### DIFF
--- a/vta/python/vta/top/graphpack.py
+++ b/vta/python/vta/top/graphpack.py
@@ -343,7 +343,10 @@ def graph_pack(expr,
         and node index equals stop_name_idx.
 
     count_meta:boolean, optional
-        start_name_idx and stop_name_idx count meta or not.
+        When count_meta is False, the operator increase logic would not count the meta that have
+        the type 'relay.expr.Constant', start_name_idx and stop_name_idx follow the index from
+        'expr.astext(show_meta_data=False)'. When count_meta is True, the operator increase
+        logic would count the meta.
 
     Returns
     -------

--- a/vta/python/vta/top/graphpack.py
+++ b/vta/python/vta/top/graphpack.py
@@ -277,11 +277,11 @@ def get_subgraph(expr, start_name, stop_name, start_name_idx, stop_name_idx, cou
             if isinstance(value, relay.expr.Call):
                 if isinstance(value.op, relay.op.Op):
                     if value.op.name == start_name and not start_found:
-                        if operator_current_idx == start_name_idx or start_name_idx == -1:
+                        if operator_current_idx == start_name_idx or start_name_idx is None:
                             value = relay.expr.Call(bitpack_start, [value])
                             start_found = True
                     elif value.op.name == stop_name:
-                        if operator_current_idx == stop_name_idx or stop_name_idx == -1:
+                        if operator_current_idx == stop_name_idx or stop_name_idx is None:
                             raise BT()
 
             operator_current_idx = _operator_idx_inc(value, count_meta, operator_current_idx)
@@ -309,8 +309,8 @@ def graph_pack(expr,
                weight_bits,
                start_name="nn.max_pool2d",
                stop_name="nn.global_avg_pool2d",
-               start_name_idx=-1,
-               stop_name_idx=-1,
+               start_name_idx=None,
+               stop_name_idx=None,
                count_meta=False):
     """Pack the graph into batch&channel packed format.
 
@@ -329,17 +329,17 @@ def graph_pack(expr,
         The bit-width of the weights.
 
     start_name: str, optional
-       Start packing from certain known node when start_name_idx is -1.
+       Start packing from certain known node when start_name_idx is None.
 
     stop_name: str, optional
-       Stop packing from certain known node when stop_name_idx is -1.
+       Stop packing from certain known node when stop_name_idx is None.
 
     start_name_idx: str, optional
-        When start_name_idx not equal -1, start packing only when node name equal start_name
+        When start_name_idx not None, start packing only when node name equal start_name
         and node idx equal start_name_idx.
 
     stop_name_idx: str, optional
-        When stop_name_idx not equal -1, stop packing only when node name equal stop_name
+        When stop_name_idx not None, stop packing only when node name equal stop_name
         and node index equal stop_name_idx.
 
     count_meta:boolean, optional

--- a/vta/python/vta/top/graphpack.py
+++ b/vta/python/vta/top/graphpack.py
@@ -334,13 +334,13 @@ def graph_pack(expr,
     stop_name: str, optional
        Stop packing from certain known node when stop_name_idx is None.
 
-    start_name_idx: str, optional
+    start_name_idx: int, optional
         When start_name_idx not None, start packing only when node name equal start_name
-        and node idx equal start_name_idx.
+        and node idx equals start_name_idx.
 
-    stop_name_idx: str, optional
+    stop_name_idx: int, optional
         When stop_name_idx not None, stop packing only when node name equal stop_name
-        and node index equal stop_name_idx.
+        and node index equals stop_name_idx.
 
     count_meta:boolean, optional
         start_name_idx and stop_name_idx count meta or not.


### PR DESCRIPTION
[Issue]
  Current vta use 'start' and 'stop' name to define the pack start point
  and end point, but this method not work for these network which have
  no 2 unique operator as  start point and stop point.

[Solution]
  In this solution we give 2 addtional parameters start_name_indx and
  stop_name_indx to make vta pack logic work with the said network,
  for exampl for following networks which have no unique operator,

  %0 = nn.add
  %1 = nn.conv2d
  %2 = nn.batch_norm
  %3 = nn.leaky_relu
  %4 = nn.add
  %5 = nn.conv2d
  %6 = nn.batch_norm
  %7 = nn.leaky_relu
  %8 = nn.add

  with this solution we can use following parameter format to make
  vta work on it.

  relay_prog = graph_pack(
                //....
                start_name="nn.add",
                stop_name="nn.add",
                start_name_idx=0,
                stop_name_idx=4)
