### PR TITLE
[Relay][Frontend][TF] Fix handling of 0D scalar Constant

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -2400,9 +2400,7 @@ class GraphProto(object):
 
             array_ndim = len(np_array.shape)
             if array_ndim == 0:
-                new_array = np.empty([1], dtype=np_array.dtype)
-                new_array[0] = np_array
-                self._nodes[name] = [tvm.relay.const(new_array)]
+                self._nodes[name] = [tvm.relay.const(np_array)]
             else:
                 self._params[name] = tvm.nd.array(np_array)
                 self._nodes[name] = [_expr.var(name,


### PR DESCRIPTION
Consider the following snippet of a TensorFlow model:
```
node {
  name: "flatten_1/stack/0"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_INT32
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_INT32
        tensor_shape {
        }
        int_val: -1
      }
    }
  }
}
node {
  name: "flatten_1/stack"
  op: "Pack"
  input: "flatten_1/stack/0"
  input: "flatten_1/Prod"
  attr {
    key: "N"
    value {
      i: 2
    }
  }
  attr {
    key: "T"
    value {
      type: DT_INT32
    }
  }
  attr {
    key: "axis"
    value {
      i: 0
    }
  }
}
```

The Pack operator accepts two inputs: the 0D constant `flatten_1/stack/0` and a 0D tensor  `flatten_1/Prod`. Currently, the TF frontend cannot handle this model because it turns the 0D constant `flatten_1/stack/0` into a 1D constant of dimension `(1,)`:
https://github.com/apache/incubator-tvm/blob/f4c4fde4a07d2346c159f1d5c6ccd00fb8fb7c7d/python/tvm/relay/frontend/tensorflow.py#L2402-L2405

This PR modifies the frontend to handle 0D constants properly.

cc @yongwww