### PR TITLE
[REFACTOR][FFI] Make more clear naming for C API Type codes.

### DIFF
--- a/apps/extension/src/tvm_ext.cc
+++ b/apps/extension/src/tvm_ext.cc
@@ -156,7 +156,7 @@ TVM_REGISTER_GLOBAL("tvm_ext.nd_create")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
   int additional_info = args[0];
   *rv = NDSubClass(additional_info);
-  CHECK_EQ(rv->type_code(), kNDArrayContainer);
+  CHECK_EQ(rv->type_code(), kTVMNDArrayHandle);
 
 });
 

--- a/golang/src/ndarray.go
+++ b/golang/src/ndarray.go
@@ -47,7 +47,7 @@ func (parray Array) nativeCPtr() (retVal uintptr) {
 }
 
 func (parray Array) nativeCopyFrom(data unsafe.Pointer, datalen int) (err error) {
-    ret := C.TVMArrayCopyFromBytes((*C.TVMArray)(unsafe.Pointer(parray.nativeCPtr())),
+    ret := C.TVMArrayCopyFromBytes((*C.DLTensor)(unsafe.Pointer(parray.nativeCPtr())),
                                    data,
                                    C.ulong(datalen))
     if ret != 0 {
@@ -65,7 +65,7 @@ func (parray Array) nativeCopyFrom(data unsafe.Pointer, datalen int) (err error)
 func (parray Array) CopyFrom(val interface{}) (err error) {
     var data unsafe.Pointer
     var datalen int
-    dtype := ((*C.TVMArray)(unsafe.Pointer(parray))).dtype
+    dtype := ((*C.DLTensor)(unsafe.Pointer(parray))).dtype
 
     switch val.(type) {
         case []int8:
@@ -126,7 +126,7 @@ func (parray Array) CopyFrom(val interface{}) (err error) {
 }
 
 func (parray Array) nativeCopyTo (data unsafe.Pointer, datalen int) (err error){
-    ret := C.TVMArrayCopyToBytes((*C.TVMArray)(unsafe.Pointer(parray.nativeCPtr())),
+    ret := C.TVMArrayCopyToBytes((*C.DLTensor)(unsafe.Pointer(parray.nativeCPtr())),
                                   unsafe.Pointer(data),
                                   C.ulong(datalen))
 
@@ -149,7 +149,7 @@ func (parray Array) AsSlice() (retVal interface{}, err error) {
     for ii := range shape {
         size *= shape[ii]
     }
-    dtype := ((*C.TVMArray)(unsafe.Pointer(parray))).dtype
+    dtype := ((*C.DLTensor)(unsafe.Pointer(parray))).dtype
 
     switch parray.GetDType() {
         case "int8":
@@ -221,13 +221,13 @@ func (parray Array) AsSlice() (retVal interface{}, err error) {
 
 // GetNdim returns the number of dimentions in Array
 func (parray Array) GetNdim() (retVal int32) {
-    retVal = int32(((*C.TVMArray)(unsafe.Pointer(parray))).ndim)
+    retVal = int32(((*C.DLTensor)(unsafe.Pointer(parray))).ndim)
     return
 }
 
 // GetShape returns the number of dimentions in Array
 func (parray Array) GetShape() (retVal []int64) {
-    shapePtr := (*C.int64_t)(((*C.TVMArray)(unsafe.Pointer(parray))).shape)
+    shapePtr := (*C.int64_t)(((*C.DLTensor)(unsafe.Pointer(parray))).shape)
     ndim := parray.GetNdim()
 
     shapeSlice := (*[1<<31] int64)(unsafe.Pointer(shapePtr))[:ndim:ndim]
@@ -238,14 +238,14 @@ func (parray Array) GetShape() (retVal []int64) {
 
 // GetDType returns the number of dimentions in Array
 func (parray Array) GetDType() (retVal string) {
-    ret := ((*C.TVMArray)(unsafe.Pointer(parray))).dtype
+    ret := ((*C.DLTensor)(unsafe.Pointer(parray))).dtype
     retVal, _ = dtypeFromTVMType(*(*pTVMType)(unsafe.Pointer(&ret)))
     return
 }
 
 // GetCtx returns the number of dimentions in Array
 func (parray Array) GetCtx() (retVal Context) {
-    ret := ((*C.TVMArray)(unsafe.Pointer(parray))).ctx
+    ret := ((*C.DLTensor)(unsafe.Pointer(parray))).ctx
     retVal = *(*Context)(unsafe.Pointer(&ret))
     return
 }
@@ -342,6 +342,6 @@ func Empty(shape []int64, args ...interface{}) (parray *Array, err error) {
 //
 // `ret` indicates the status of this api execution.
 func nativeTVMArrayFree(parray Array) (retVal int32) {
-    retVal = (int32)(C.TVMArrayFree((*C.TVMArray)(unsafe.Pointer(parray.nativeCPtr()))))
+    retVal = (int32)(C.TVMArrayFree((*C.DLTensor)(unsafe.Pointer(parray.nativeCPtr()))))
     return
 }

--- a/golang/src/value.go
+++ b/golang/src/value.go
@@ -33,38 +33,38 @@ import (
     "unsafe"
 )
 
-// KHandle is golang type code for TVM enum kHandle.
-var KHandle                 = int32(C.kHandle)
-// KNull is golang type code for TVM kNull.
-var KNull                   = int32(C.kNull)
-// KTVMType is golang type code for TVM kTVMType.
-var KTVMType                = int32(C.kTVMType)
+// KHandle is golang type code for TVM enum kTVMOpaqueHandle.
+var KHandle                 = int32(C.kTVMOpaqueHandle)
+// KNull is golang type code for TVM kTVMNullptr.
+var KNull                   = int32(C.kTVMNullptr)
+// KTVMType is golang type code for TVM kTVMDataType.
+var KTVMType                = int32(C.kTVMDataType)
 // KTVMContext is golang type code for TVM kTVMContext.
 var KTVMContext             = int32(C.kTVMContext)
-// KArrayHandle is golang type code for TVM kArrayHandle.
-var KArrayHandle            = int32(C.kArrayHandle)
-// KObjectHandle is golang type code for TVM kObjectHandle.
-var KObjectHandle             = int32(C.kObjectHandle)
-// KModuleHandle is gonag type code for TVM kModuleHandle.
-var KModuleHandle           = int32(C.kModuleHandle)
-// KFuncHandle is gonalg type code for TVM kFuncHandle.
-var KFuncHandle             = int32(C.kFuncHandle)
-// KStr is golang type code for TVM kStr.
-var KStr                    = int32(C.kStr)
-// KBytes is golang type code for TVM kBytes.
-var KBytes                  = int32(C.kBytes)
-// KNDArrayContainer is golang typecode for kNDArrayContainer.
-var KNDArrayContainer       = int32(C.kNDArrayContainer)
-// KExtBegin is golang enum corresponding to TVM kExtBegin.
-var KExtBegin               = int32(C.kExtBegin)
+// KArrayHandle is golang type code for TVM kTVMDLTensorHandle.
+var KArrayHandle            = int32(C.kTVMDLTensorHandle)
+// KObjectHandle is golang type code for TVM kTVMObjectHandle.
+var KObjectHandle             = int32(C.kTVMObjectHandle)
+// KModuleHandle is gonag type code for TVM kTVMModuleHandle.
+var KModuleHandle           = int32(C.kTVMModuleHandle)
+// KFuncHandle is gonalg type code for TVM kTVMPackedFuncHandle.
+var KFuncHandle             = int32(C.kTVMPackedFuncHandle)
+// KStr is golang type code for TVM kTVMStr.
+var KStr                    = int32(C.kTVMStr)
+// KBytes is golang type code for TVM kTVMBytes.
+var KBytes                  = int32(C.kTVMBytes)
+// KNDArrayContainer is golang typecode for kTVMNDArrayHandle.
+var KNDArrayContainer       = int32(C.kTVMNDArrayHandle)
+// KExtBegin is golang enum corresponding to TVM kTVMExtBegin.
+var KExtBegin               = int32(C.kTVMExtBegin)
 // KNNVMFirst is golang enum corresponding to TVM kNNVMFirst.
-var KNNVMFirst              = int32(C.kNNVMFirst)
+var KNNVMFirst              = int32(C.kTVMNNVMFirst)
 // KNNVMLast is golang enum corresponding to TVM kNNVMLast.
-var KNNVMLast               = int32(C.kNNVMLast)
+var KNNVMLast               = int32(C.kTVMNNVMLast)
 // KExtReserveEnd is golang enum corresponding to TVM kExtReserveEnd.
-var KExtReserveEnd          = int32(C.kExtReserveEnd)
+var KExtReserveEnd          = int32(C.kTVMExtReserveEnd)
 // KExtEnd is golang enum corresponding to TVM kExtEnd.
-var KExtEnd                 = int32(C.kExtEnd)
+var KExtEnd                 = int32(C.kTVMExtEnd)
 // KDLInt is golang type code for TVM kDLInt.
 var KDLInt                  = int32(C.kDLInt)
 // KDLUInt is golang type code for TVM kDLUInt.

--- a/include/tvm/expr_operator.h
+++ b/include/tvm/expr_operator.h
@@ -682,7 +682,7 @@ inline PrimExpr MakeConstScalar(DataType t, ValueType value) {
   // datatypes lowering pass, we will lower the value to its true representation in the format
   // specified by the datatype.
   // TODO(gus) when do we need to start worrying about doubles not being precise enough?
-  if (static_cast<uint8_t>(t.code()) >= static_cast<uint8_t>(kCustomBegin)) {
+  if (static_cast<uint8_t>(t.code()) >= static_cast<uint8_t>(kTVMCustomBegin)) {
     return FloatImm(t, static_cast<double>(value));
   }
   LOG(FATAL) << "cannot make const for type " << t;

--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -88,7 +88,7 @@ inline TObjectRef NullValue() {
 
 template<>
 inline DataType NullValue<DataType>() {
-  return DataType(kHandle, 0, 0);
+  return DataType(DataType::kHandle, 0, 0);
 }
 
 /*! \brief Error thrown during attribute checking. */
@@ -492,7 +492,7 @@ inline void SetIntValue(T* ptr, const TVMArgValue& val) {
 
 template<>
 inline void SetValue<std::string>(std::string* ptr, const TVMArgValue& val) {
-  if (val.type_code() == kStr) {
+  if (val.type_code() == kTVMStr) {
     *ptr = val.operator std::string();
   } else {
     LOG(FATAL) << "Expect str";
@@ -762,7 +762,7 @@ class AttrsNode : public BaseAttrsNode {
       // linear search.
       auto ffind = [&args](const char* key, runtime::TVMArgValue* val) {
         for (int i = 0; i < args.size(); i += 2) {
-          CHECK_EQ(args.type_codes[i], kStr);
+          CHECK_EQ(args.type_codes[i], kTVMStr);
           if (!std::strcmp(key, args.values[i].v_str)) {
             *val = args[i + 1];
             return true;
@@ -777,7 +777,7 @@ class AttrsNode : public BaseAttrsNode {
       // construct a map then do lookup.
       std::unordered_map<std::string, runtime::TVMArgValue> kwargs;
       for (int i = 0; i < args.size(); i += 2) {
-        CHECK_EQ(args.type_codes[i], kStr);
+        CHECK_EQ(args.type_codes[i], kTVMStr);
         kwargs[args[i].operator std::string()] = args[i + 1];
       }
       auto ffind = [&kwargs](const char *key, runtime::TVMArgValue* val) {

--- a/include/tvm/packed_func_ext.h
+++ b/include/tvm/packed_func_ext.h
@@ -100,7 +100,7 @@ struct ObjectTypeChecker<Map<K, V> > {
 
 // extensions for tvm arg value
 inline TVMPODValue_::operator tvm::PrimExpr() const {
-  if (type_code_ == kNull) return PrimExpr();
+  if (type_code_ == kTVMNullptr) return PrimExpr();
   if (type_code_ == kDLInt) {
     CHECK_LE(value_.v_int64, std::numeric_limits<int>::max());
     CHECK_GE(value_.v_int64, std::numeric_limits<int>::min());
@@ -110,7 +110,7 @@ inline TVMPODValue_::operator tvm::PrimExpr() const {
     return PrimExpr(static_cast<float>(value_.v_float64));
   }
 
-  TVM_CHECK_TYPE_CODE(type_code_, kObjectHandle);
+  TVM_CHECK_TYPE_CODE(type_code_, kTVMObjectHandle);
   Object* ptr = static_cast<Object*>(value_.v_handle);
 
   if (ptr->IsInstance<IterVarNode>()) {
@@ -126,13 +126,13 @@ inline TVMPODValue_::operator tvm::PrimExpr() const {
 }
 
 inline TVMPODValue_::operator tvm::Integer() const {
-  if (type_code_ == kNull) return Integer();
+  if (type_code_ == kTVMNullptr) return Integer();
   if (type_code_ == kDLInt) {
     CHECK_LE(value_.v_int64, std::numeric_limits<int>::max());
     CHECK_GE(value_.v_int64, std::numeric_limits<int>::min());
     return Integer(static_cast<int>(value_.v_int64));
   }
-  TVM_CHECK_TYPE_CODE(type_code_, kObjectHandle);
+  TVM_CHECK_TYPE_CODE(type_code_, kTVMObjectHandle);
   Object* ptr = static_cast<Object*>(value_.v_handle);
   CHECK(ObjectTypeChecker<Integer>::Check(ptr))
       << "Expect type " << ObjectTypeChecker<PrimExpr>::TypeName()

--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -86,62 +86,44 @@ typedef enum {
 } TVMDeviceExtType;
 
 /*!
- * \brief The type code in TVMType
- * \note TVMType is used in two places.
+ * \brief The type code in used in the TVM FFI.
  */
 typedef enum {
   // The type code of other types are compatible with DLPack.
   // The next few fields are extension types
   // that is used by TVM API calls.
-  kHandle = 3U,
-  kNull = 4U,
-  kTVMType = 5U,
+  kTVMOpaqueHandle = 3U,
+  kTVMNullptr = 4U,
+  kTVMDataType = 5U,
   kTVMContext = 6U,
-  kArrayHandle = 7U,
-  kObjectHandle = 8U,
-  kModuleHandle = 9U,
-  kFuncHandle = 10U,
-  kStr = 11U,
-  kBytes = 12U,
-  kNDArrayContainer = 13U,
+  kTVMDLTensorHandle = 7U,
+  kTVMObjectHandle = 8U,
+  kTVMModuleHandle = 9U,
+  kTVMPackedFuncHandle = 10U,
+  kTVMStr = 11U,
+  kTVMBytes = 12U,
+  kTVMNDArrayHandle = 13U,
   // Extension codes for other frameworks to integrate TVM PackedFunc.
   // To make sure each framework's id do not conflict, use first and
   // last sections to mark ranges.
   // Open an issue at the repo if you need a section of code.
-  kExtBegin = 15U,
-  kNNVMFirst = 16U,
-  kNNVMLast = 20U,
+  kTVMExtBegin = 15U,
+  kTVMNNVMFirst = 16U,
+  kTVMNNVMLast = 20U,
   // The following section of code is used for non-reserved types.
-  kExtReserveEnd = 64U,
-  kExtEnd = 128U,
+  kTVMExtReserveEnd = 64U,
+  kTVMExtEnd = 128U,
   // The rest of the space is used for custom, user-supplied datatypes
-  kCustomBegin = 129U,
+  kTVMCustomBegin = 129U,
 } TVMTypeCode;
-
-/*!
- * \brief The data type used in TVM Runtime.
- *
- *  Examples
- *   - float: type_code = 2, bits = 32, lanes=1
- *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes=4
- *   - int8: type_code = 0, bits = 8, lanes=1
- *
- * \note Arguments TVM API function always takes bits=64 and lanes=1
- */
-typedef DLDataType TVMType;
 
 /*!
  * \brief The Device information, abstract away common device types.
  */
 typedef DLContext TVMContext;
 
-/*!
- * \brief The tensor array structure to TVM API.
- */
-typedef DLTensor TVMArray;
-
 /*! \brief the array handle */
-typedef TVMArray* TVMArrayHandle;
+typedef DLTensor* TVMArrayHandle;
 
 /*!
  * \brief Union type of values
@@ -152,13 +134,13 @@ typedef union {
   double v_float64;
   void* v_handle;
   const char* v_str;
-  TVMType v_type;
+  DLDataType v_type;
   TVMContext v_ctx;
 } TVMValue;
 
 /*!
  * \brief Byte array type used to pass in byte array
- *  When kBytes is used as data type.
+ *  When kTVMBytes is used as data type.
  */
 typedef struct {
   const char* data;

--- a/include/tvm/runtime/data_type.h
+++ b/include/tvm/runtime/data_type.h
@@ -44,7 +44,7 @@ class DataType {
     kInt = kDLInt,
     kUInt = kDLUInt,
     kFloat = kDLFloat,
-    kHandle = TVMTypeCode::kHandle,
+    kHandle = TVMTypeCode::kTVMOpaqueHandle,
   };
   /*! \brief default constructor */
   DataType() {}

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -88,7 +88,7 @@ class TVM_DLL DeviceAPI {
   virtual void* AllocDataSpace(TVMContext ctx,
                                size_t nbytes,
                                size_t alignment,
-                               TVMType type_hint) = 0;
+                               DLDataType type_hint) = 0;
   /*!
    * \brief Free a data space on device.
    * \param ctx The device context to perform operation.
@@ -115,7 +115,7 @@ class TVM_DLL DeviceAPI {
                               size_t num_bytes,
                               TVMContext ctx_from,
                               TVMContext ctx_to,
-                              TVMType type_hint,
+                              DLDataType type_hint,
                               TVMStreamHandle stream) = 0;
     /*!
    * \brief Create a new stream of execution.
@@ -177,7 +177,7 @@ class TVM_DLL DeviceAPI {
    */
   virtual void* AllocWorkspace(TVMContext ctx,
                                        size_t nbytes,
-                                       TVMType type_hint = {});
+                                       DLDataType type_hint = {});
   /*!
    * \brief Free temporal workspace in backend execution.
    *

--- a/include/tvm/runtime/util.h
+++ b/include/tvm/runtime/util.h
@@ -36,7 +36,7 @@ namespace runtime {
  * \param bits The number of bits to be matched.
  * \param lanes The number of lanes in the type.
  */
-inline bool TypeMatch(TVMType t, int code, int bits, int lanes = 1) {
+inline bool TypeMatch(DLDataType t, int code, int bits, int lanes = 1) {
   return t.code == code && t.bits == bits && t.lanes == lanes;
 }
 /*!
@@ -44,7 +44,7 @@ inline bool TypeMatch(TVMType t, int code, int bits, int lanes = 1) {
  * \param lhs The left operand.
  * \param rhs The right operand.
  */
-inline bool TypeEqual(TVMType lhs, TVMType rhs) {
+inline bool TypeEqual(DLDataType lhs, DLDataType rhs) {
   return lhs.code == rhs.code && lhs.bits == rhs.bits && lhs.lanes == rhs.lanes;
 }
 }  // namespace runtime

--- a/jvm/native/src/main/native/jni_helper_func.h
+++ b/jvm/native/src/main/native/jni_helper_func.h
@@ -167,8 +167,8 @@ jobject newObject(JNIEnv *env, const char *clsname) {
   return object;
 }
 
-void fromJavaDType(JNIEnv *env, jobject jdtype, TVMType *dtype) {
-  jclass tvmTypeClass = env->FindClass("org/apache/tvm/TVMType");
+void fromJavaDType(JNIEnv *env, jobject jdtype, DLDataType *dtype) {
+  jclass tvmTypeClass = env->FindClass("org/apache/tvm/DLDataType");
   dtype->code = (uint8_t)(env->GetIntField(jdtype, env->GetFieldID(tvmTypeClass, "typeCode", "I")));
   dtype->bits = (uint8_t)(env->GetIntField(jdtype, env->GetFieldID(tvmTypeClass, "bits", "I")));
   dtype->lanes = (uint16_t)(env->GetIntField(jdtype, env->GetFieldID(tvmTypeClass, "lanes", "I")));
@@ -191,21 +191,21 @@ jobject tvmRetValueToJava(JNIEnv *env, TVMValue value, int tcode) {
       return newTVMValueLong(env, static_cast<jlong>(value.v_int64));
     case kDLFloat:
       return newTVMValueDouble(env, static_cast<jdouble>(value.v_float64));
-    case kHandle:
+    case kTVMOpaqueHandle:
       return newTVMValueHandle(env, reinterpret_cast<jlong>(value.v_handle));
-    case kModuleHandle:
+    case kTVMModuleHandle:
       return newModule(env, reinterpret_cast<jlong>(value.v_handle));
-    case kFuncHandle:
+    case kTVMPackedFuncHandle:
       return newFunction(env, reinterpret_cast<jlong>(value.v_handle));
-    case kArrayHandle:
+    case kTVMDLTensorHandle:
       return newNDArray(env, reinterpret_cast<jlong>(value.v_handle), true);
-    case kNDArrayContainer:
+    case kTVMNDArrayHandle:
       return newNDArray(env, reinterpret_cast<jlong>(value.v_handle), false);
-    case kStr:
+    case kTVMStr:
       return newTVMValueString(env, value.v_str);
-    case kBytes:
+    case kTVMBytes:
       return newTVMValueBytes(env, reinterpret_cast<TVMByteArray *>(value.v_handle));
-    case kNull:
+    case kTVMNullptr:
       return newObject(env, "org/apache/tvm/TVMValueNull");
     default:
       LOG(FATAL) << "Do NOT know how to handle return type code " << tcode;

--- a/jvm/native/src/main/native/org_apache_tvm_native_c_api.cc
+++ b/jvm/native/src/main/native/org_apache_tvm_native_c_api.cc
@@ -98,7 +98,7 @@ JNIEXPORT void JNICALL Java_org_apache_tvm_LibInfo_tvmFuncPushArgString(
   value.v_str = env->GetStringUTFChars(garg, 0);
   TVMFuncArgsThreadLocalEntry *e = TVMFuncArgsThreadLocalStore::Get();
   e->tvmFuncArgValues.push_back(value);
-  e->tvmFuncArgTypes.push_back(kStr);
+  e->tvmFuncArgTypes.push_back(kTVMStr);
   // release string args later
   e->tvmFuncArgPushedStrs.push_back(std::make_pair(garg, value.v_str));
 }
@@ -126,7 +126,7 @@ JNIEXPORT void JNICALL Java_org_apache_tvm_LibInfo_tvmFuncPushArgBytes(
 
   TVMFuncArgsThreadLocalEntry *e = TVMFuncArgsThreadLocalStore::Get();
   e->tvmFuncArgValues.push_back(value);
-  e->tvmFuncArgTypes.push_back(kBytes);
+  e->tvmFuncArgTypes.push_back(kTVMBytes);
 
   e->tvmFuncArgPushedBytes.push_back(std::make_pair(garg, byteArray));
   // release (garg, data), byteArray later
@@ -242,7 +242,9 @@ extern "C" int funcInvokeCallback(TVMValue *args,
   for (int i = 0; i < numArgs; ++i) {
     TVMValue arg = args[i];
     int tcode = typeCodes[i];
-    if (tcode == kObjectHandle || tcode == kFuncHandle || tcode == kModuleHandle) {
+    if (tcode == kTVMObjectHandle ||
+        tcode == kTVMPackedFuncHandle ||
+        tcode == kTVMModuleHandle) {
       TVMCbArgToReturn(&arg, tcode);
     }
     jobject jarg = tvmRetValueToJava(env, arg, tcode);
@@ -393,7 +395,7 @@ JNIEXPORT jint JNICALL Java_org_apache_tvm_LibInfo_tvmArrayAlloc(
 
 JNIEXPORT jint JNICALL Java_org_apache_tvm_LibInfo_tvmArrayGetShape(
   JNIEnv *env, jobject obj, jlong jhandle, jobject jshape) {
-  TVMArray *array = reinterpret_cast<TVMArray *>(jhandle);
+  DLTensor *array = reinterpret_cast<DLTensor *>(jhandle);
   int64_t *shape = array->shape;
   int ndim = array->ndim;
 
@@ -424,7 +426,7 @@ JNIEXPORT jint JNICALL Java_org_apache_tvm_LibInfo_tvmArrayCopyFromJArray(
   JNIEnv *env, jobject obj, jbyteArray jarr, jlong jfrom, jlong jto) {
   jbyte *data = env->GetByteArrayElements(jarr, NULL);
 
-  TVMArray *from = reinterpret_cast<TVMArray *>(jfrom);
+  DLTensor *from = reinterpret_cast<DLTensor *>(jfrom);
   from->data = static_cast<void *>(data);
 
   int ret = TVMArrayCopyFromTo(static_cast<TVMArrayHandle>(from),
@@ -438,7 +440,7 @@ JNIEXPORT jint JNICALL Java_org_apache_tvm_LibInfo_tvmArrayCopyFromJArray(
 
 JNIEXPORT jint JNICALL Java_org_apache_tvm_LibInfo_tvmArrayCopyToJArray(
   JNIEnv *env, jobject obj, jlong jfrom, jbyteArray jarr) {
-  TVMArray *from = reinterpret_cast<TVMArray *>(jfrom);
+  DLTensor *from = reinterpret_cast<DLTensor *>(jfrom);
   int size = static_cast<int>(env->GetArrayLength(jarr));
   jbyte *pdata = env->GetByteArrayElements(jarr, NULL);
   int ret = 0;

--- a/python/tvm/_ffi/_ctypes/function.py
+++ b/python/tvm/_ffi/_ctypes/function.py
@@ -115,8 +115,8 @@ def _make_tvm_args(args, temp_args):
             type_codes[i] = TypeCode.NULL
         elif isinstance(arg, NDArrayBase):
             values[i].v_handle = ctypes.cast(arg.handle, ctypes.c_void_p)
-            type_codes[i] = (TypeCode.NDARRAY_CONTAINER
-                             if not arg.is_view else TypeCode.ARRAY_HANDLE)
+            type_codes[i] = (TypeCode.NDARRAY_HANDLE
+                             if not arg.is_view else TypeCode.DLTENSOR_HANDLE)
         elif isinstance(arg, _nd._TVM_COMPATS):
             values[i].v_handle = ctypes.c_void_p(arg._tvm_handle)
             type_codes[i] = arg.__class__._tvm_tcode
@@ -154,14 +154,14 @@ def _make_tvm_args(args, temp_args):
             type_codes[i] = TypeCode.MODULE_HANDLE
         elif isinstance(arg, FunctionBase):
             values[i].v_handle = arg.handle
-            type_codes[i] = TypeCode.FUNC_HANDLE
+            type_codes[i] = TypeCode.PACKED_FUNC_HANDLE
         elif isinstance(arg, ctypes.c_void_p):
             values[i].v_handle = arg
             type_codes[i] = TypeCode.HANDLE
         elif callable(arg):
             arg = convert_to_tvm_func(arg)
             values[i].v_handle = arg.handle
-            type_codes[i] = TypeCode.FUNC_HANDLE
+            type_codes[i] = TypeCode.PACKED_FUNC_HANDLE
             temp_args.append(arg)
         else:
             raise TypeError("Don't know how to handle type %s" % type(arg))
@@ -244,15 +244,15 @@ def _handle_return_func(x):
 
 # setup return handle for function type
 _object.__init_by_constructor__ = __init_handle_by_constructor__
-RETURN_SWITCH[TypeCode.FUNC_HANDLE] = _handle_return_func
+RETURN_SWITCH[TypeCode.PACKED_FUNC_HANDLE] = _handle_return_func
 RETURN_SWITCH[TypeCode.MODULE_HANDLE] = _return_module
-RETURN_SWITCH[TypeCode.NDARRAY_CONTAINER] = lambda x: _make_array(x.v_handle, False, True)
-C_TO_PY_ARG_SWITCH[TypeCode.FUNC_HANDLE] = _wrap_arg_func(
-    _handle_return_func, TypeCode.FUNC_HANDLE)
+RETURN_SWITCH[TypeCode.NDARRAY_HANDLE] = lambda x: _make_array(x.v_handle, False, True)
+C_TO_PY_ARG_SWITCH[TypeCode.PACKED_FUNC_HANDLE] = _wrap_arg_func(
+    _handle_return_func, TypeCode.PACKED_FUNC_HANDLE)
 C_TO_PY_ARG_SWITCH[TypeCode.MODULE_HANDLE] = _wrap_arg_func(
     _return_module, TypeCode.MODULE_HANDLE)
-C_TO_PY_ARG_SWITCH[TypeCode.ARRAY_HANDLE] = lambda x: _make_array(x.v_handle, True, False)
-C_TO_PY_ARG_SWITCH[TypeCode.NDARRAY_CONTAINER] = lambda x: _make_array(x.v_handle, False, True)
+C_TO_PY_ARG_SWITCH[TypeCode.DLTENSOR_HANDLE] = lambda x: _make_array(x.v_handle, True, False)
+C_TO_PY_ARG_SWITCH[TypeCode.NDARRAY_HANDLE] = lambda x: _make_array(x.v_handle, False, True)
 
 _CLASS_MODULE = None
 _CLASS_FUNCTION = None

--- a/python/tvm/_ffi/_cython/base.pxi
+++ b/python/tvm/_ffi/_cython/base.pxi
@@ -26,18 +26,18 @@ cdef enum TVMTypeCode:
     kInt = 0
     kUInt = 1
     kFloat = 2
-    kHandle = 3
-    kNull = 4
-    kTVMType = 5
+    kTVMOpaqueHandle = 3
+    kTVMNullptr = 4
+    kTVMDataType = 5
     kTVMContext = 6
-    kArrayHandle = 7
-    kObjectHandle = 8
-    kModuleHandle = 9
-    kFuncHandle = 10
-    kStr = 11
-    kBytes = 12
-    kNDArrayContainer = 13
-    kExtBegin = 15
+    kTVMDLTensorHandle = 7
+    kTVMObjectHandle = 8
+    kTVMModuleHandle = 9
+    kTVMPackedFuncHandle = 10
+    kTVMStr = 11
+    kTVMBytes = 12
+    kTVMNDArrayHandle = 13
+    kTVMExtBegin = 15
 
 cdef extern from "tvm/runtime/c_runtime_api.h":
     ctypedef struct DLDataType:

--- a/python/tvm/_ffi/_cython/object.pxi
+++ b/python/tvm/_ffi/_cython/object.pxi
@@ -97,5 +97,5 @@ cdef class ObjectBase:
         cdef void* chandle
         ConstructorCall(
             (<FunctionBase>fconstructor).chandle,
-            kObjectHandle, args, &chandle)
+            kTVMObjectHandle, args, &chandle)
         self.chandle = chandle

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -35,13 +35,13 @@ class TypeCode(object):
     NULL = 4
     TVM_TYPE = 5
     TVM_CONTEXT = 6
-    ARRAY_HANDLE = 7
+    DLTENSOR_HANDLE = 7
     OBJECT_HANDLE = 8
     MODULE_HANDLE = 9
-    FUNC_HANDLE = 10
+    PACKED_FUNC_HANDLE = 10
     STR = 11
     BYTES = 12
-    NDARRAY_CONTAINER = 13
+    NDARRAY_HANDLE = 13
     EXT_BEGIN = 15
 
 

--- a/rust/runtime/src/graph.rs
+++ b/rust/runtime/src/graph.rs
@@ -352,7 +352,7 @@ impl<'m, 't> GraphExecutor<'m, 't> {
     }
 }
 
-// Converts a string to TVM DLDataTypeCode. @see `String2TVMType` in packed_func.h
+// Converts a string to TVM DLDataTypeCode. @see `String2DLDataType` in packed_func.h
 named!(
   tvm_str_to_type<CompleteStr, DataType>,
   do_parse!(

--- a/src/api/api_base.cc
+++ b/src/api/api_base.cc
@@ -32,7 +32,7 @@
 namespace tvm {
 TVM_REGISTER_GLOBAL("_format_str")
 .set_body([](TVMArgs args,  TVMRetValue *ret) {
-    CHECK(args[0].type_code() == kObjectHandle);
+    CHECK(args[0].type_code() == kTVMObjectHandle);
     std::ostringstream os;
     os << args[0].operator ObjectRef();
     *ret = os.str();
@@ -40,7 +40,7 @@ TVM_REGISTER_GLOBAL("_format_str")
 
 TVM_REGISTER_GLOBAL("_raw_ptr")
 .set_body([](TVMArgs args,  TVMRetValue *ret) {
-    CHECK(args[0].type_code() == kObjectHandle);
+    CHECK(args[0].type_code() == kTVMObjectHandle);
     *ret = reinterpret_cast<int64_t>(args[0].value().v_handle);
   });
 

--- a/src/api/api_lang.cc
+++ b/src/api/api_lang.cc
@@ -64,7 +64,7 @@ TVM_REGISTER_GLOBAL("_Array")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
     std::vector<ObjectRef> data;
     for (int i = 0; i < args.size(); ++i) {
-      if (args[i].type_code() != kNull) {
+      if (args[i].type_code() != kTVMNullptr) {
         data.push_back(args[i].operator ObjectRef());
       } else {
         data.push_back(ObjectRef(nullptr));
@@ -78,7 +78,7 @@ TVM_REGISTER_GLOBAL("_Array")
 TVM_REGISTER_GLOBAL("_ArrayGetItem")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
     int64_t i = args[1];
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
     Object* ptr = static_cast<Object*>(args[0].value().v_handle);
     CHECK(ptr->IsInstance<ArrayNode>());
     auto* n = static_cast<const ArrayNode*>(ptr);
@@ -89,7 +89,7 @@ TVM_REGISTER_GLOBAL("_ArrayGetItem")
 
 TVM_REGISTER_GLOBAL("_ArraySize")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
     Object* ptr = static_cast<Object*>(args[0].value().v_handle);
     CHECK(ptr->IsInstance<ArrayNode>());
     *ret = static_cast<int64_t>(
@@ -99,11 +99,11 @@ TVM_REGISTER_GLOBAL("_ArraySize")
 TVM_REGISTER_GLOBAL("_Map")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
     CHECK_EQ(args.size() % 2, 0);
-    if (args.size() != 0 && args[0].type_code() == kStr) {
+    if (args.size() != 0 && args[0].type_code() == kTVMStr) {
       // StrMap
       StrMapNode::ContainerType data;
       for (int i = 0; i < args.num_args; i += 2) {
-        CHECK(args[i].type_code() == kStr)
+        CHECK(args[i].type_code() == kTVMStr)
             << "key of str map need to be str";
         CHECK(args[i + 1].IsObjectRef<ObjectRef>())
             << "value of the map to be NodeRef";
@@ -132,7 +132,7 @@ TVM_REGISTER_GLOBAL("_Map")
 
 TVM_REGISTER_GLOBAL("_MapSize")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
     Object* ptr = static_cast<Object*>(args[0].value().v_handle);
     if (ptr->IsInstance<MapNode>()) {
       auto* n = static_cast<const MapNode*>(ptr);
@@ -146,11 +146,11 @@ TVM_REGISTER_GLOBAL("_MapSize")
 
 TVM_REGISTER_GLOBAL("_MapGetItem")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
     Object* ptr = static_cast<Object*>(args[0].value().v_handle);
 
     if (ptr->IsInstance<MapNode>()) {
-      CHECK(args[1].type_code() == kObjectHandle);
+      CHECK(args[1].type_code() == kTVMObjectHandle);
       auto* n = static_cast<const MapNode*>(ptr);
       auto it = n->data.find(args[1].operator ObjectRef());
       CHECK(it != n->data.end())
@@ -168,12 +168,12 @@ TVM_REGISTER_GLOBAL("_MapGetItem")
 
 TVM_REGISTER_GLOBAL("_MapCount")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
     Object* ptr = static_cast<Object*>(args[0].value().v_handle);
 
     if (ptr->IsInstance<MapNode>()) {
       auto* n = static_cast<const MapNode*>(ptr);
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
       *ret = static_cast<int64_t>(
           n->data.count(args[1].operator ObjectRef()));
     } else {
@@ -186,7 +186,7 @@ TVM_REGISTER_GLOBAL("_MapCount")
 
 TVM_REGISTER_GLOBAL("_MapItems")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
-    CHECK_EQ(args[0].type_code(), kObjectHandle);
+    CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
     Object* ptr = static_cast<Object*>(args[0].value().v_handle);
 
     if (ptr->IsInstance<MapNode>()) {

--- a/src/codegen/codegen_c.cc
+++ b/src/codegen/codegen_c.cc
@@ -216,7 +216,7 @@ std::string CodeGenC::GetStructRef(
     DataType t, const PrimExpr& buffer, const PrimExpr& index, int kind) {
   if (kind < intrinsic::kArrKindBound_) {
     std::ostringstream os;
-    os << "(((TVMArray*)";
+    os << "(((DLTensor*)";
     this->PrintExpr(buffer, os);
     os << ")";
     if (kind == intrinsic::kArrAddr) {

--- a/src/codegen/codegen_c_host.cc
+++ b/src/codegen/codegen_c_host.cc
@@ -200,7 +200,7 @@ void CodeGenCHost::VisitExpr_(const CallNode *op, std::ostream& os) { // NOLINT(
     const std::string& type = op->args[0].as<StringImmNode>()->value;
     const IntImmNode* num = op->args[1].as<IntImmNode>();
     CHECK(num != nullptr);
-    static_assert(alignof(TVMValue) % alignof(TVMArray) == 0, "invariant");
+    static_assert(alignof(TVMValue) % alignof(DLTensor) == 0, "invariant");
     size_t unit = sizeof(TVMValue);
     size_t size = 0;
     if (type == "shape") {
@@ -210,7 +210,7 @@ void CodeGenCHost::VisitExpr_(const CallNode *op, std::ostream& os) { // NOLINT(
     } else if (type == "arg_tcode") {
       size = (num->value * sizeof(int) + unit - 1) / unit;
     } else if (type == "array") {
-      size = (num->value * sizeof(TVMArray) + unit - 1) / unit;
+      size = (num->value * sizeof(DLTensor) + unit - 1) / unit;
     } else {
       LOG(FATAL) << "Unknown stack alloca type " << type;
     }

--- a/src/codegen/datatype/registry.cc
+++ b/src/codegen/datatype/registry.cc
@@ -25,19 +25,23 @@
 namespace tvm {
 namespace datatype {
 
-TVM_REGISTER_GLOBAL("_datatype_register").set_body([](TVMArgs args, TVMRetValue* ret) {
+TVM_REGISTER_GLOBAL("_datatype_register")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
   datatype::Registry::Global()->Register(args[0], static_cast<uint8_t>(args[1].operator int()));
 });
 
-TVM_REGISTER_GLOBAL("_datatype_get_type_code").set_body([](TVMArgs args, TVMRetValue* ret) {
+TVM_REGISTER_GLOBAL("_datatype_get_type_code")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
   *ret = datatype::Registry::Global()->GetTypeCode(args[0]);
 });
 
-TVM_REGISTER_GLOBAL("_datatype_get_type_name").set_body([](TVMArgs args, TVMRetValue* ret) {
+TVM_REGISTER_GLOBAL("_datatype_get_type_name")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
   *ret = Registry::Global()->GetTypeName(args[0].operator int());
 });
 
-TVM_REGISTER_GLOBAL("_datatype_get_type_registered").set_body([](TVMArgs args, TVMRetValue* ret) {
+TVM_REGISTER_GLOBAL("_datatype_get_type_registered")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
   *ret = Registry::Global()->GetTypeRegistered(args[0].operator int());
 });
 
@@ -47,7 +51,8 @@ Registry* Registry::Global() {
 }
 
 void Registry::Register(const std::string& type_name, uint8_t type_code) {
-  CHECK(type_code >= kCustomBegin) << "Please choose a type code >= kCustomBegin for custom types";
+  CHECK(type_code >= kTVMCustomBegin)
+      << "Please choose a type code >= kTVMCustomBegin for custom types";
   code_to_name_[type_code] = type_name;
   name_to_code_[type_name] = type_code;
 }

--- a/src/codegen/datatype/registry.h
+++ b/src/codegen/datatype/registry.h
@@ -60,7 +60,7 @@ class Registry {
    * same code. Generally, this should be straightforward, as the user will be manually registering
    * all of their custom types.
    * \param type_name The name of the type, e.g. "bfloat"
-   * \param type_code The type code, which should be greater than TVMTypeCode::kExtEnd
+   * \param type_code The type code, which should be greater than TVMTypeCode::kTVMExtEnd
    */
   void Register(const std::string& type_name, uint8_t type_code);
 

--- a/src/codegen/llvm/codegen_cpu.cc
+++ b/src/codegen/llvm/codegen_cpu.cc
@@ -731,7 +731,7 @@ llvm::Value *CodeGenCPU::CreateCallTracePacked(const CallNode *op) {
   llvm::Value *ret_tcode_value = builder_->CreateAlignedLoad(ret_tcode, 8);
   // Check the ret_type_code and create cmp instruction.
   llvm::Value *cmp = builder_->CreateICmpNE(
-      ret_tcode_value, llvm::ConstantInt::get(t_int_, kNull));
+      ret_tcode_value, llvm::ConstantInt::get(t_int_, kTVMNullptr));
   builder_->CreateCondBr(cmp, update_block, continue_block);
   builder_->SetInsertPoint(update_block);
   builder_->CreateBr(continue_block);

--- a/src/codegen/stackvm/codegen_stackvm.cc
+++ b/src/codegen/stackvm/codegen_stackvm.cc
@@ -199,7 +199,7 @@ void CodeGenStackVM::VisitExpr_(const CallNode* op) {
     const std::string& type = op->args[0].as<StringImmNode>()->value;
     const IntImmNode* num = op->args[1].as<IntImmNode>();
     CHECK(num != nullptr);
-    static_assert(alignof(TVMValue) % alignof(TVMArray) == 0, "invariant");
+    static_assert(alignof(TVMValue) % alignof(DLTensor) == 0, "invariant");
     // static_assert(alignof(TVMValue) % alignof(tvm_index_t) == 0, "invariant");
     size_t unit = sizeof(TVMValue);
     size_t size = 0;
@@ -210,7 +210,7 @@ void CodeGenStackVM::VisitExpr_(const CallNode* op) {
     } else if (type == "arg_tcode") {
       size = (num->value * sizeof(int) + unit - 1) / unit;
     } else if (type == "array") {
-      size = (num->value * sizeof(TVMArray) + unit - 1) / unit;
+      size = (num->value * sizeof(DLTensor) + unit - 1) / unit;
     } else {
       LOG(FATAL) << "Unknown stack alloca type " << type;
     }

--- a/src/ir/attrs.cc
+++ b/src/ir/attrs.cc
@@ -43,7 +43,7 @@ void DictAttrsNode::InitByPackedArgs(
     runtime::TVMArgValue val = args[i + 1];
     if (val.IsObjectRef<ObjectRef>()) {
       dict.Set(key, val.operator ObjectRef());
-    } else if (val.type_code() == kStr) {
+    } else if (val.type_code() == kTVMStr) {
       dict.Set(key, PrimExpr(val.operator std::string()));
     } else {
       dict.Set(key, val.operator PrimExpr());

--- a/src/ir/op.cc
+++ b/src/ir/op.cc
@@ -129,10 +129,10 @@ void OpRegistry::UpdateAttr(const std::string& key,
   CHECK(p.second != plevel)
       << "Attribute " << key << " of operator " << this->name
       << " is already registered with same plevel=" << plevel;
-  CHECK(value.type_code() != kNull)
+  CHECK(value.type_code() != kTVMNullptr)
       << "Registered packed_func is Null for " << key
       << " of operator " << this->name;
-  if (p.second < plevel && value.type_code() != kNull) {
+  if (p.second < plevel && value.type_code() != kTVMNullptr) {
     op_map->data_[index] = std::make_pair(value, plevel);
   }
 }
@@ -195,7 +195,7 @@ TVM_REGISTER_GLOBAL("relay.op._Register")
       LOG(FATAL) << "attrs type key no longer supported";
     } else {
       // normal attr table override.
-      if (args[2].type_code() == kFuncHandle) {
+      if (args[2].type_code() == kTVMPackedFuncHandle) {
         // do an eager copy of the PackedFunc
         PackedFunc f = args[2];
         // If we get a function from frontend, avoid deleting it.

--- a/src/node/reflection.cc
+++ b/src/node/reflection.cc
@@ -97,7 +97,7 @@ runtime::TVMRetValue ReflectionVTable::GetAttr(
     success = true;
   } else if (!self->IsInstance<DictAttrsNode>()) {
     VisitAttrs(self, &getter);
-    success = getter.found_ref_object || ret.type_code() != kNull;
+    success = getter.found_ref_object || ret.type_code() != kTVMNullptr;
   } else {
     // specially handle dict attr
     DictAttrsNode* dnode = static_cast<DictAttrsNode*>(self);
@@ -258,13 +258,13 @@ void InitNodeByPackedArgs(Object* n, const TVMArgs& args) {
 
 // Expose to FFI APIs.
 void NodeGetAttr(TVMArgs args, TVMRetValue* ret) {
-  CHECK_EQ(args[0].type_code(), kObjectHandle);
+  CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
   Object* self = static_cast<Object*>(args[0].value().v_handle);
   *ret = ReflectionVTable::Global()->GetAttr(self, args[1]);
 }
 
 void NodeListAttrNames(TVMArgs args, TVMRetValue* ret) {
-  CHECK_EQ(args[0].type_code(), kObjectHandle);
+  CHECK_EQ(args[0].type_code(), kTVMObjectHandle);
   Object* self = static_cast<Object*>(args[0].value().v_handle);
 
   auto names = std::make_shared<std::vector<std::string> >(

--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -39,11 +39,11 @@
 namespace tvm {
 
 inline std::string Type2String(const DataType& t) {
-  return runtime::TVMType2String(t);
+  return runtime::DLDataType2String(t);
 }
 
 inline DataType String2Type(std::string s) {
-  return DataType(runtime::String2TVMType(s));
+  return DataType(runtime::String2DLDataType(s));
 }
 
 // indexer to index all the nodes

--- a/src/pass/lower_tvm_builtin.cc
+++ b/src/pass/lower_tvm_builtin.cc
@@ -260,9 +260,9 @@ class BuiltinLower : public StmtExprMutator {
           intrinsic::kTVMValueContent, arg));
       int arg_tcode = api_type.code();
       if (api_type.is_handle() && arg.as<StringImmNode>()) {
-        arg_tcode = kStr;
+        arg_tcode = kTVMStr;
       }
-      if (IsArrayHandle(arg)) arg_tcode = kArrayHandle;
+      if (IsArrayHandle(arg)) arg_tcode = kTVMDLTensorHandle;
       prep_seq_.emplace_back(
           StoreNode::make(stack_tcode_,
                       ConstInt32(arg_tcode),

--- a/src/pass/make_api.cc
+++ b/src/pass/make_api.cc
@@ -124,10 +124,10 @@ LoweredFunc MakeAPI(Stmt body,
         std::ostringstream msg;
         msg << name << ": Expect arg[" << i << "] to be pointer";
         seq_check.emplace_back(
-            AssertStmtNode::make(tcode == kHandle ||
-                             tcode == kNDArrayContainer ||
-                             tcode == kArrayHandle ||
-                             tcode == kNull, msg.str(), nop));
+            AssertStmtNode::make(tcode == kTVMOpaqueHandle ||
+                             tcode == kTVMNDArrayHandle ||
+                             tcode == kTVMDLTensorHandle ||
+                             tcode == kTVMNullptr, msg.str(), nop));
       } else if (t.is_int() || t.is_uint()) {
         std::ostringstream msg;
         msg << name << ": Expect arg[" << i << "] to be int";

--- a/src/relay/ir/doc.cc
+++ b/src/relay/ir/doc.cc
@@ -108,7 +108,7 @@ Doc PrintBool(bool value) {
 }
 
 Doc PrintDType(DataType dtype) {
-  return Doc(runtime::TVMType2String(dtype));
+  return Doc(runtime::DLDataType2String(dtype));
 }
 
 Doc PrintString(const std::string& value) {

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -932,7 +932,7 @@ class PrettyPrinter::AttrPrinter : public AttrVisitor {
     LOG(FATAL) << "do not allow void as argument";
   }
   void Visit(const char* key, DataType* value) final {
-    PrintKV(key, PrintString(runtime::TVMType2String(*value)));
+    PrintKV(key, PrintString(runtime::DLDataType2String(*value)));
   }
   void Visit(const char* key, runtime::NDArray* value) final {
     LOG(FATAL) << "do not allow NDarray as argument";

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1182,7 +1182,7 @@ double ToScalar(const runtime::NDArray& array) {
       return reinterpret_cast<double*>(array->data)[0];
     }
   }
-  LOG(FATAL) << "Unknown data type: " << tvm::runtime::TVMType2String(array->dtype);
+  LOG(FATAL) << "Unknown data type: " << tvm::runtime::DLDataType2String(array->dtype);
   // make compiler happy
   return -std::numeric_limits<double>::infinity();
 }

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -151,7 +151,7 @@ DeviceAPI* DeviceAPI::Get(TVMContext ctx, bool allow_missing) {
 
 void* DeviceAPI::AllocWorkspace(TVMContext ctx,
                                 size_t size,
-                                TVMType type_hint) {
+                                DLDataType type_hint) {
   return AllocDataSpace(ctx, size, kTempAllocaAlignment, type_hint);
 }
 
@@ -431,7 +431,7 @@ void* TVMBackendAllocWorkspace(int device_type,
   ctx.device_type = static_cast<DLDeviceType>(device_type);
   ctx.device_id = device_id;
 
-  TVMType type_hint;
+  DLDataType type_hint;
   type_hint.code = static_cast<decltype(type_hint.code)>(dtype_code_hint);
   type_hint.bits = static_cast<decltype(type_hint.bits)>(dtype_bits_hint);
   type_hint.lanes = 1;
@@ -479,22 +479,22 @@ int TVMFuncCall(TVMFunctionHandle func,
   (*static_cast<const PackedFunc*>(func)).CallPacked(
       TVMArgs(args, arg_type_codes, num_args), &rv);
   // handle return string.
-  if (rv.type_code() == kStr ||
-      rv.type_code() == kTVMType ||
-      rv.type_code() == kBytes) {
+  if (rv.type_code() == kTVMStr ||
+      rv.type_code() == kTVMDataType ||
+      rv.type_code() == kTVMBytes) {
     TVMRuntimeEntry* e = TVMAPIRuntimeStore::Get();
-    if (rv.type_code() != kTVMType) {
+    if (rv.type_code() != kTVMDataType) {
       e->ret_str = *rv.ptr<std::string>();
     } else {
       e->ret_str = rv.operator std::string();
     }
-    if (rv.type_code() == kBytes) {
+    if (rv.type_code() == kTVMBytes) {
       e->ret_bytes.data = e->ret_str.c_str();
       e->ret_bytes.size = e->ret_str.length();
-      *ret_type_code = kBytes;
+      *ret_type_code = kTVMBytes;
       ret_val->v_handle = &(e->ret_bytes);
     } else {
-      *ret_type_code = kStr;
+      *ret_type_code = kTVMStr;
       ret_val->v_str = e->ret_str.c_str();
     }
   } else {

--- a/src/runtime/contrib/cudnn/conv_forward.cc
+++ b/src/runtime/contrib/cudnn/conv_forward.cc
@@ -52,7 +52,7 @@ void ConvolutionForward(
   // Set Ctx
   entry_ptr->conv_entry.ctx = x->ctx;
   // Set Data Type
-  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2TVMType(conv_dtype));
+  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2DLDataType(conv_dtype));
   cudnnDataType_t data_type = CuDNNDataType::DLTypeToCuDNNType(x->dtype);
   // Dims includes N and C
   int full_dims = dims + 2;
@@ -194,8 +194,8 @@ void OutputShape(
   CuDNNThreadEntry* entry_ptr = CuDNNThreadEntry::ThreadLocal();
 
   // Set Data Type
-  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2TVMType(conv_dtype));
-  cudnnDataType_t data_type = CuDNNDataType::DLTypeToCuDNNType(String2TVMType(data_dtype));
+  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2DLDataType(conv_dtype));
+  cudnnDataType_t data_type = CuDNNDataType::DLTypeToCuDNNType(String2DLDataType(data_dtype));
   // Set Format
   entry_ptr->conv_entry.tensor_format = static_cast<cudnnTensorFormat_t>(format);
   // Dims includes N and C
@@ -276,8 +276,8 @@ void FindAlgo(
   CuDNNThreadEntry* entry_ptr = CuDNNThreadEntry::ThreadLocal();
 
   // Set Data Type
-  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2TVMType(conv_dtype));
-  cudnnDataType_t data_type = CuDNNDataType::DLTypeToCuDNNType(String2TVMType(data_dtype));
+  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2DLDataType(conv_dtype));
+  cudnnDataType_t data_type = CuDNNDataType::DLTypeToCuDNNType(String2DLDataType(data_dtype));
   // Set Format
   entry_ptr->conv_entry.tensor_format = static_cast<cudnnTensorFormat_t>(format);
   // Dims includes N and C

--- a/src/runtime/contrib/example_ext_runtime/example_ext_runtime.cc
+++ b/src/runtime/contrib/example_ext_runtime/example_ext_runtime.cc
@@ -142,10 +142,11 @@ class ExampleJsonModule : public ModuleNode {
       this->curr_subgraph_ = name;
       return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
         for (auto i = 0; i < args.size(); ++i) {
-          CHECK(args[i].type_code() == kNDArrayContainer || args[i].type_code() == kArrayHandle)
+          CHECK(args[i].type_code() == kTVMNDArrayHandle ||
+                args[i].type_code() == kTVMDLTensorHandle)
               << "Expect NDArray or DLTensor as inputs"
               << "\n";
-          if (args[i].type_code() == kArrayHandle) {
+          if (args[i].type_code() == kTVMDLTensorHandle) {
             DLTensor* arg = args[i];
             this->data_entry_[i].CopyFrom(arg);
           } else {
@@ -158,7 +159,7 @@ class ExampleJsonModule : public ModuleNode {
         }
         CHECK_GT(graph_.count(this->curr_subgraph_), 0U);
         auto out_idx = graph_[this->curr_subgraph_].back().output;
-        if (args[args.size() - 1].type_code() == kArrayHandle) {
+        if (args[args.size() - 1].type_code() == kTVMDLTensorHandle) {
           DLTensor* arg = args[args.size() - 1];
           this->data_entry_[out_idx].CopyTo(arg);
         } else {
@@ -341,4 +342,3 @@ TVM_REGISTER_GLOBAL("module.loadbinary_examplejson")
 
 }  // namespace runtime
 }  // namespace tvm
-

--- a/src/runtime/contrib/nnpack/convolution.cc
+++ b/src/runtime/contrib/nnpack/convolution.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -40,7 +40,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.nnpack.convolution_inference")
       DLTensor *input = args[0];
       DLTensor *kernel = args[1];
       DLTensor *bias = nullptr;
-      if (args[2].type_code() == kArrayHandle) {
+      if (args[2].type_code() == kTVMDLTensorHandle) {
         bias = args[2];
       }
       DLTensor *output = args[3];
@@ -103,7 +103,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.nnpack.convolution_inference")
       const size_t workspace_elements = (workspace_size + sizeof(float) - 1) / sizeof(float);
 
       TVMContext ctx = input->ctx;
-      TVMType type_hint = input->dtype;
+      DLDataType type_hint = input->dtype;
 
       DeviceAPI* cpu_api = DeviceAPI::Get(ctx);
       void* workspace_buffer =
@@ -140,7 +140,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.nnpack.convolution_inference_without_weight_tra
       DLTensor *input = args[0];
       DLTensor *transformed_kernel = args[1];
       DLTensor *bias = nullptr;
-      if (args[2].type_code() == kArrayHandle) {
+      if (args[2].type_code() == kTVMDLTensorHandle) {
         bias = args[2];
       }
       DLTensor *output = args[3];
@@ -199,7 +199,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.nnpack.convolution_inference_without_weight_tra
       const size_t workspace_elements = (workspace_size + sizeof(float) - 1) / sizeof(float);
 
       TVMContext ctx = input->ctx;
-      TVMType type_hint = input->dtype;
+      DLDataType type_hint = input->dtype;
 
       DeviceAPI* cpu_api = DeviceAPI::Get(ctx);
       void* workspace_buffer =

--- a/src/runtime/contrib/sort/sort.cc
+++ b/src/runtime/contrib/sort/sort.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -182,8 +182,8 @@ TVM_REGISTER_GLOBAL("tvm.contrib.sort.argsort")
   CHECK_LT(axis, input->ndim) << "Axis out of boundary for "
                                  "input ndim " << input->ndim;
 
-  auto data_dtype = TVMType2String(input->dtype);
-  auto out_dtype = TVMType2String(output->dtype);
+  auto data_dtype = DLDataType2String(input->dtype);
+  auto out_dtype = DLDataType2String(output->dtype);
 
   if (data_dtype == "float32") {
     if (out_dtype == "int32") {
@@ -333,8 +333,8 @@ TVM_REGISTER_GLOBAL("tvm.contrib.sort.topk")
   }
   CHECK(axis >= 0 && axis < input->ndim) << "Axis out of boundary for input ndim " << input->ndim;
 
-  auto data_dtype = TVMType2String(input->dtype);
-  auto out_dtype = (indices_out == nullptr) ? "int64" : TVMType2String(indices_out->dtype);
+  auto data_dtype = DLDataType2String(input->dtype);
+  auto out_dtype = (indices_out == nullptr) ? "int64" : DLDataType2String(indices_out->dtype);
 
   if (data_dtype == "float32") {
     if (out_dtype == "int32") {

--- a/src/runtime/cpu_device_api.cc
+++ b/src/runtime/cpu_device_api.cc
@@ -45,7 +45,7 @@ class CPUDeviceAPI final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t nbytes,
                        size_t alignment,
-                       TVMType type_hint) final {
+                       DLDataType type_hint) final {
     void* ptr;
 #if _MSC_VER
     ptr = _aligned_malloc(nbytes, alignment);
@@ -76,7 +76,7 @@ class CPUDeviceAPI final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final {
     memcpy(static_cast<char*>(to) + to_offset,
            static_cast<const char*>(from) + from_offset,
@@ -86,7 +86,7 @@ class CPUDeviceAPI final : public DeviceAPI {
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final {
   }
 
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final;
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final;
   void FreeWorkspace(TVMContext ctx, void* data) final;
 
   static const std::shared_ptr<CPUDeviceAPI>& Global() {
@@ -103,7 +103,7 @@ struct CPUWorkspacePool : public WorkspacePool {
 
 void* CPUDeviceAPI::AllocWorkspace(TVMContext ctx,
                                    size_t size,
-                                   TVMType type_hint) {
+                                   DLDataType type_hint) {
   return dmlc::ThreadLocalStore<CPUWorkspacePool>::Get()
       ->AllocWorkspace(ctx, size);
 }

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -111,7 +111,7 @@ class CUDADeviceAPI final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t nbytes,
                        size_t alignment,
-                       TVMType type_hint) final {
+                       DLDataType type_hint) final {
     CUDA_CALL(cudaSetDevice(ctx.device_id));
     CHECK_EQ(256 % alignment, 0U)
         << "CUDA space is aligned at 256 bytes";
@@ -132,7 +132,7 @@ class CUDADeviceAPI final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final {
     cudaStream_t cu_stream = static_cast<cudaStream_t>(stream);
     from = static_cast<const char*>(from) + from_offset;
@@ -191,7 +191,7 @@ class CUDADeviceAPI final : public DeviceAPI {
         ->stream = static_cast<cudaStream_t>(stream);
   }
 
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final {
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final {
     return CUDAThreadEntry::ThreadLocal()->pool.AllocWorkspace(ctx, size);
   }
 

--- a/src/runtime/file_util.cc
+++ b/src/runtime/file_util.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -34,7 +34,7 @@ namespace runtime {
 void FunctionInfo::Save(dmlc::JSONWriter* writer) const {
   std::vector<std::string> sarg_types(arg_types.size());
   for (size_t i = 0; i < arg_types.size(); ++i) {
-    sarg_types[i] = TVMType2String(arg_types[i]);
+    sarg_types[i] = DLDataType2String(arg_types[i]);
   }
   writer->BeginObject();
   writer->WriteObjectKeyValue("name", name);
@@ -52,7 +52,7 @@ void FunctionInfo::Load(dmlc::JSONReader* reader) {
   helper.ReadAllFields(reader);
   arg_types.resize(sarg_types.size());
   for (size_t i = 0; i < arg_types.size(); ++i) {
-    arg_types[i] = String2TVMType(sarg_types[i]);
+    arg_types[i] = String2DLDataType(sarg_types[i]);
   }
 }
 

--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -176,7 +176,7 @@ PackedFunc GraphRuntimeDebug::GetFunction(
       });
   } else if (name == "debug_get_output") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-        if (args[0].type_code() == kStr) {
+        if (args[0].type_code() == kTVMStr) {
           this->DebugGetNodeOutput(this->GetNodeIndex(args[0]), args[1]);
         } else {
           this->DebugGetNodeOutput(args[0], args[1]);

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -250,9 +250,9 @@ void GraphRuntime::ShareParams(const GraphRuntime& other, dmlc::Stream* strm) {
 
 void GraphRuntime::SetupStorage() {
   // Grab saved optimization plan from graph.
-  std::vector<TVMType> vtype;
+  std::vector<DLDataType> vtype;
   for (const std::string& s_type : attrs_.dltype) {
-    vtype.push_back(tvm::runtime::String2TVMType(s_type));
+    vtype.push_back(tvm::runtime::String2DLDataType(s_type));
   }
 
   // Size and device type of each storage pool entry.
@@ -371,7 +371,7 @@ std::pair<std::function<void()>, std::shared_ptr<GraphRuntime::OpArgs> > GraphRu
     DLTensor* t = &arg_ptr->args[i];
     v.v_handle = t;
     arg_ptr->arg_values.push_back(v);
-    arg_ptr->arg_tcodes.push_back(kArrayHandle);
+    arg_ptr->arg_tcodes.push_back(kTVMDLTensorHandle);
     if (param.flatten_data) {
       arg_ptr->shape_data[i] = std::accumulate(
           t->shape, t->shape + t->ndim, 1, std::multiplies<int64_t>());
@@ -414,7 +414,7 @@ PackedFunc GraphRuntime::GetFunction(
   // Return member functions during query.
   if (name == "set_input") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-        if (args[0].type_code() == kStr) {
+        if (args[0].type_code() == kTVMStr) {
           int in_idx = this->GetInputIndex(args[0]);
           if (in_idx >= 0) this->SetInput(in_idx, args[1]);
         } else {
@@ -423,7 +423,7 @@ PackedFunc GraphRuntime::GetFunction(
       });
   } else if (name == "set_input_zero_copy") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-      if (args[0].type_code() == kStr) {
+      if (args[0].type_code() == kTVMStr) {
         int in_idx = this->GetInputIndex(args[0]);
         if (in_idx >= 0) this->SetInputZeroCopy(in_idx, args[1]);
       } else {
@@ -441,7 +441,7 @@ PackedFunc GraphRuntime::GetFunction(
   } else if (name == "get_input") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
         int in_idx = 0;
-        if (args[0].type_code() == kStr) {
+        if (args[0].type_code() == kTVMStr) {
           in_idx = this->GetInputIndex(args[0]);
         } else {
           in_idx = args[0];

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -81,7 +81,7 @@ PackedFunc WrapPackedFunc(TVMBackendPackedCFunc faddr,
                           const ObjectPtr<Object>& sptr_to_self) {
   return PackedFunc([faddr, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
       TVMValue ret_value;
-      int ret_type_code = kNull;
+      int ret_type_code = kTVMNullptr;
       int ret = (*faddr)(
           const_cast<TVMValue*>(args.values),
           const_cast<int*>(args.type_codes),
@@ -89,7 +89,7 @@ PackedFunc WrapPackedFunc(TVMBackendPackedCFunc faddr,
           &ret_value,
           &ret_type_code);
       CHECK_EQ(ret, 0) << TVMGetLastError();
-      if (ret_type_code != kNull) {
+      if (ret_type_code != kTVMNullptr) {
         *rv = TVMRetValue::MoveFromCHost(ret_value, ret_type_code);
       }
     });

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,7 +37,7 @@ namespace runtime {
 /*! \brief function information needed by device */
 struct FunctionInfo {
   std::string name;
-  std::vector<TVMType> arg_types;
+  std::vector<DLDataType> arg_types;
   std::vector<std::string> thread_axis_tags;
 
   void Save(dmlc::JSONWriter *writer) const;

--- a/src/runtime/metal/metal_common.h
+++ b/src/runtime/metal/metal_common.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -84,7 +84,7 @@ class MetalWorkspace final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t nbytes,
                        size_t alignment,
-                       TVMType type_hint) final;
+                       DLDataType type_hint) final;
   void FreeDataSpace(TVMContext ctx, void* ptr) final;
   void CopyDataFromTo(const void* from,
                       size_t from_size,
@@ -93,10 +93,10 @@ class MetalWorkspace final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final;
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final;
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final;
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final;
   void FreeWorkspace(TVMContext ctx, void* data) final;
   // get the global workspace
   static const std::shared_ptr<MetalWorkspace>& Global();

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -62,7 +62,7 @@ void MetalWorkspace::GetAttr(
     case kMultiProcessorCount: return;
     case kMaxThreadDimensions: return;
     case kExist: break;
-    case kGcnArch: return; 
+    case kGcnArch: return;
   }
 }
 
@@ -145,7 +145,7 @@ void MetalWorkspace::SetDevice(TVMContext ctx) {
 }
 
 void* MetalWorkspace::AllocDataSpace(
-    TVMContext ctx, size_t nbytes, size_t alignment, TVMType type_hint) {
+    TVMContext ctx, size_t nbytes, size_t alignment, DLDataType type_hint) {
   this->Init();
   id<MTLDevice> dev = GetDevice(ctx);
   // GPU memory only
@@ -176,7 +176,7 @@ void MetalWorkspace::CopyDataFromTo(const void* from,
                                     size_t size,
                                     TVMContext ctx_from,
                                     TVMContext ctx_to,
-                                    TVMType type_hint,
+                                    DLDataType type_hint,
                                     TVMStreamHandle stream) {
   this->Init();
   CHECK(stream == nullptr);
@@ -261,7 +261,7 @@ void MetalWorkspace::StreamSync(TVMContext ctx, TVMStreamHandle stream) {
 
 void* MetalWorkspace::AllocWorkspace(TVMContext ctx,
                                      size_t size,
-                                     TVMType type_hint) {
+                                     DLDataType type_hint) {
   return MetalThreadEntry::ThreadLocal()->pool.AllocWorkspace(ctx, size);
 }
 

--- a/src/runtime/micro/micro_device_api.cc
+++ b/src/runtime/micro/micro_device_api.cc
@@ -48,7 +48,7 @@ class MicroDeviceAPI final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t nbytes,
                        size_t alignment,
-                       TVMType type_hint) final {
+                       DLDataType type_hint) final {
     ObjectPtr<MicroSession>& session = MicroSession::Current();
     void* data = session->AllocateInSection(SectionKind::kHeap, nbytes).cast_to<void*>();
     CHECK(data != nullptr) << "unable to allocate " << nbytes << " bytes on device heap";
@@ -72,7 +72,7 @@ class MicroDeviceAPI final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final {
     std::tuple<int, int> type_from_to(ctx_from.device_type, ctx_to.device_type);
     if (type_from_to == std::make_tuple(kDLMicroDev, kDLMicroDev)) {
@@ -123,7 +123,7 @@ class MicroDeviceAPI final : public DeviceAPI {
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final {
   }
 
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final {
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final {
     ObjectPtr<MicroSession>& session = MicroSession::Current();
 
     void* data = session->AllocateInSection(SectionKind::kWorkspace, size).cast_to<void*>();

--- a/src/runtime/micro/micro_session.cc
+++ b/src/runtime/micro/micro_session.cc
@@ -333,9 +333,9 @@ std::tuple<DevPtr, DevPtr> MicroSession::EncoderAppend(
 
   for (int i = 0; i < num_args; i++) {
     switch (type_codes[i]) {
-      case kNDArrayContainer:
-      case kArrayHandle: {
-        TVMArray* base_arr_handle = args[i];
+      case kTVMNDArrayHandle:
+      case kTVMDLTensorHandle: {
+        DLTensor* base_arr_handle = args[i];
         // All uTVM arrays store a `MicroDevSpace` struct in their `data` field,
         // which wraps the actual data and stores a reference to the session, in
         // order to prevent premature session destruction.
@@ -371,7 +371,7 @@ std::tuple<DevPtr, DevPtr> MicroSession::EncoderAppend(
 }
 
 template <typename T>
-DevPtr MicroSession::EncoderAppend(TargetDataLayoutEncoder* encoder, const TVMArray& arr) {
+DevPtr MicroSession::EncoderAppend(TargetDataLayoutEncoder* encoder, const DLTensor& arr) {
   auto tvm_arr_slot = encoder->Alloc<T>();
   auto shape_slot = encoder->Alloc<int64_t>(arr.ndim);
 
@@ -396,7 +396,7 @@ DevPtr MicroSession::EncoderAppend(TargetDataLayoutEncoder* encoder, const TVMAr
       strides_dev_addr.value(),
       TargetVal { .val64 = arr.byte_offset });
   CHECK(dev_arr.ctx.device_type == static_cast<DLDeviceType>(kDLMicroDev))
-    << "attempt to write TVMArray with non-micro device type";
+    << "attempt to write DLTensor with non-micro device type";
   // Update the device type to CPU, because from the microcontroller's
   // perspective, it is.
   dev_arr.ctx.device_type = DLDeviceType::kDLCPU;

--- a/src/runtime/micro/micro_session.h
+++ b/src/runtime/micro/micro_session.h
@@ -231,13 +231,13 @@ class MicroSession : public ModuleNode {
   std::tuple<DevPtr, DevPtr> EncoderAppend(TargetDataLayoutEncoder* encoder, const TVMArgs& args);
 
   /*!
-   * \brief appends a `TVMArray` to the host-side buffer of `encoder`
+   * \brief appends a `DLTensor` to the host-side buffer of `encoder`
    * \param encoder encoder being used to append `arr`
-   * \param arr TVMArray to be appended
-   * \return device address of the allocated `TVMArray`
+   * \param arr DLTensor to be appended
+   * \return device address of the allocated `DLTensor`
    */
   template <typename T>
-  DevPtr EncoderAppend(TargetDataLayoutEncoder* encoder, const TVMArray& arr);
+  DevPtr EncoderAppend(TargetDataLayoutEncoder* encoder, const DLTensor& arr);
 
   /*!
    * \brief checks and logs if there was an error during the device's most recent execution

--- a/src/runtime/micro/standalone/utvm_graph_runtime.cc
+++ b/src/runtime/micro/standalone/utvm_graph_runtime.cc
@@ -324,7 +324,7 @@ std::function<void()> CreateTVMOp(const DSOModule& module, const TVMOpParam& par
     void* v_handle;
   } TVMValue;
   /*typedef*/ enum {
-    kArrayHandle = 7U,
+    kTVMDLTensorHandle = 7U,
   } /*TVMTypeCode*/;
   struct OpArgs {
     DynArray<DLTensor> args;
@@ -345,7 +345,7 @@ std::function<void()> CreateTVMOp(const DSOModule& module, const TVMOpParam& par
     DLTensor* t = &(arg_ptr->args[i]);
     v.v_handle = t;
     arg_ptr->arg_values[i] = v;
-    arg_ptr->arg_tcodes[i] = kArrayHandle;
+    arg_ptr->arg_tcodes[i] = kTVMDLTensorHandle;
     if (param.flatten_data) {
       arg_ptr->shape_data[i] =
           std::accumulate(t->shape, t->shape + t->ndim, 1, std::multiplies<int64_t>());

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -193,7 +193,7 @@ class OpenCLWorkspace : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t size,
                        size_t alignment,
-                       TVMType type_hint) final;
+                       DLDataType type_hint) final;
   void FreeDataSpace(TVMContext ctx, void* ptr) final;
   void CopyDataFromTo(const void* from,
                       size_t from_offset,
@@ -202,10 +202,10 @@ class OpenCLWorkspace : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final;
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final;
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final;
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final;
   void FreeWorkspace(TVMContext ctx, void* data) final;
 
   /*!

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -118,7 +118,7 @@ void OpenCLWorkspace::GetAttr(
 }
 
 void* OpenCLWorkspace::AllocDataSpace(
-    TVMContext ctx, size_t size, size_t alignment, TVMType type_hint) {
+    TVMContext ctx, size_t size, size_t alignment, DLDataType type_hint) {
   this->Init();
   CHECK(context != nullptr) << "No OpenCL device";
   cl_int err_code;
@@ -144,7 +144,7 @@ void OpenCLWorkspace::CopyDataFromTo(const void* from,
                                      size_t size,
                                      TVMContext ctx_from,
                                      TVMContext ctx_to,
-                                     TVMType type_hint,
+                                     DLDataType type_hint,
                                      TVMStreamHandle stream) {
   this->Init();
   CHECK(stream == nullptr);
@@ -182,7 +182,7 @@ void OpenCLWorkspace::StreamSync(TVMContext ctx, TVMStreamHandle stream) {
 
 void* OpenCLWorkspace::AllocWorkspace(TVMContext ctx,
                                       size_t size,
-                                      TVMType type_hint) {
+                                      DLDataType type_hint) {
   return GetThreadEntry()->pool.AllocWorkspace(ctx, size);
 }
 

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -131,9 +131,9 @@ PackedFunc OpenCLModuleNode::GetFunction(
   OpenCLWrappedFunc f;
   std::vector<size_t> arg_size(info.arg_types.size());
   for (size_t i = 0; i < info.arg_types.size(); ++i) {
-    TVMType t = info.arg_types[i];
+    DLDataType t = info.arg_types[i];
     CHECK_EQ(t.lanes, 1U);
-    if (t.code == kHandle) {
+    if (t.code == kTVMOpaqueHandle) {
       // specially store pointer type size in OpenCL driver
       arg_size[i] = sizeof(void*);
     } else {

--- a/src/runtime/opengl/opengl_common.h
+++ b/src/runtime/opengl/opengl_common.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -184,7 +184,7 @@ class OpenGLWorkspace final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t nbytes,
                        size_t alignment,
-                       TVMType type_hint) final;
+                       DLDataType type_hint) final;
   void FreeDataSpace(TVMContext ctx, void* ptr) final;
   void CopyDataFromTo(const void* from,
                       size_t from_offset,
@@ -193,7 +193,7 @@ class OpenGLWorkspace final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final;
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final;
 
@@ -216,7 +216,7 @@ class OpenGLWorkspace final : public DeviceAPI {
    * \param nbytes Number of bytes in the array.
    * \return The OpenGL texture.
    */
-  Texture CreateTexture(TVMType type, size_t nbytes);
+  Texture CreateTexture(DLDataType type, size_t nbytes);
 
   /*!
    * \brief Upload user data into a sub-region of an OpenGL texture.
@@ -256,7 +256,7 @@ class OpenGLWorkspace final : public DeviceAPI {
    */
   void SetUniform(const Program& program,
                   const std::string& name,
-                  TVMType type,
+                  DLDataType type,
                   void* value);
 
   /*!

--- a/src/runtime/opengl/opengl_device_api.cc
+++ b/src/runtime/opengl/opengl_device_api.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -121,7 +121,7 @@ void OpenGLWorkspace::GetAttr(
 }
 
 void* OpenGLWorkspace::AllocDataSpace(
-    TVMContext ctx, size_t nbytes, size_t alignment, TVMType type_hint) {
+    TVMContext ctx, size_t nbytes, size_t alignment, DLDataType type_hint) {
   return reinterpret_cast<void*>(new Texture(CreateTexture(type_hint, nbytes)));
 }
 
@@ -136,7 +136,7 @@ void OpenGLWorkspace::CopyDataFromTo(const void* from,
                                      size_t size,
                                      TVMContext ctx_from,
                                      TVMContext ctx_to,
-                                     TVMType type_hint,
+                                     DLDataType type_hint,
                                      TVMStreamHandle stream) {
   CHECK(stream == nullptr);
 
@@ -312,7 +312,7 @@ GLuint OpenGLWorkspace::CreateShader(GLenum shader_kind,
   return shader;
 }
 
-static TextureFormat GetTextureFormat(TVMType type) {
+static TextureFormat GetTextureFormat(DLDataType type) {
   CHECK_EQ(type.lanes, 1) << "Not supporting multi-lane types.";
 
   switch (type.code) {
@@ -355,7 +355,7 @@ static TextureFormat GetTextureFormat(TVMType type) {
   return {GL_R32F, GL_RED, GL_FLOAT};
 }
 
-Texture OpenGLWorkspace::CreateTexture(TVMType type, size_t nbytes) {
+Texture OpenGLWorkspace::CreateTexture(DLDataType type, size_t nbytes) {
   // Create a texture.
   GLuint texture;
   OPENGL_CALL(gl->GenTextures(1, &texture));
@@ -555,7 +555,7 @@ void OpenGLWorkspace::SetCurrentProgram(const Program& program) {
 
 void OpenGLWorkspace::SetUniform(const Program& program,
                                  const std::string& name,
-                                 TVMType type,
+                                 DLDataType type,
                                  void* value) {
   GLint location = gl->GetUniformLocation(program.program(), name.c_str());
   switch (type.code) {

--- a/src/runtime/opengl/opengl_module.cc
+++ b/src/runtime/opengl/opengl_module.cc
@@ -120,7 +120,7 @@ PackedFunc OpenGLModuleNode::GetFunction(
 
   std::vector<size_t> arg_size(func_info.arg_types.size());
   for (size_t i = 0; i < func_info.arg_types.size(); ++i) {
-    TVMType t = func_info.arg_types[i];
+    DLDataType t = func_info.arg_types[i];
     CHECK_EQ(t.lanes, 1U);
     uint32_t bits = t.bits;
     CHECK_EQ(bits % 8, 0U);
@@ -222,14 +222,14 @@ void OpenGLWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
         break;
       }
       case OpenGLArgKind::kInputTexture: {
-        CHECK_EQ(type.code, kHandle) << "Type is not handle?";
+        CHECK_EQ(type.code, kTVMOpaqueHandle) << "Type is not handle?";
         auto texture = *static_cast<gl::Texture**>(void_args[i]);
         m_->workspace().SetInputTexture(program, name, texture_unit, texture);
         ++texture_unit;
         break;
       }
       case OpenGLArgKind::kOutputTexture: {
-        CHECK_EQ(type.code, kHandle) << "Type is not handle?";
+        CHECK_EQ(type.code, kTVMOpaqueHandle) << "Type is not handle?";
         CHECK(output == nullptr) << "Can only have one output texture.";
         output = *static_cast<gl::Texture**>(void_args[i]);
         break;
@@ -241,7 +241,7 @@ void OpenGLWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
   ThreadWorkLoad wl = thread_axis_cfg_.Extract(args);
   std::unique_ptr<GLint> thread_extent(new GLint(wl.block_dim(0)));
   m_->workspace().SetUniform(program, shader.thread_extent_var,
-                             TVMType{kDLInt, 32, 1},
+                             DLDataType{kDLInt, 32, 1},
                              static_cast<void*>(thread_extent.get()));
 
   m_->workspace().Render(output);

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -119,7 +119,7 @@ class ROCMDeviceAPI final : public DeviceAPI {
     *rv = value;
   }
   void* AllocDataSpace(TVMContext ctx, size_t nbytes, size_t alignment,
-                       TVMType type_hint) final {
+                       DLDataType type_hint) final {
     ROCM_CALL(hipSetDevice(ctx.device_id));
     CHECK_EQ(256 % alignment, 0U) << "ROCM space is aligned at 256 bytes";
     void* ret;
@@ -134,7 +134,7 @@ class ROCMDeviceAPI final : public DeviceAPI {
 
   void CopyDataFromTo(const void* from, size_t from_offset, void* to,
                       size_t to_offset, size_t size, TVMContext ctx_from,
-                      TVMContext ctx_to, TVMType type_hint,
+                      TVMContext ctx_to, DLDataType type_hint,
                       TVMStreamHandle stream) final {
     hipStream_t hip_stream = static_cast<hipStream_t>(stream);
     from = static_cast<const char*>(from) + from_offset;
@@ -169,7 +169,7 @@ class ROCMDeviceAPI final : public DeviceAPI {
     ROCMThreadEntry::ThreadLocal()->stream = static_cast<hipStream_t>(stream);
   }
 
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final {
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final {
     return ROCMThreadEntry::ThreadLocal()->pool.AllocWorkspace(ctx, size);
   }
 

--- a/src/runtime/rpc/rpc_device_api.cc
+++ b/src/runtime/rpc/rpc_device_api.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,7 +41,7 @@ class RPCDeviceAPI final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t nbytes,
                        size_t alignment,
-                       TVMType type_hint) final {
+                       DLDataType type_hint) final {
     auto sess = GetSess(ctx);
     void *data = sess->CallRemote(
             RPCCode::kDevAllocData, ctx, nbytes, alignment, type_hint);
@@ -67,7 +67,7 @@ class RPCDeviceAPI final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final {
     int from_dev_type = ctx_from.device_type;
     int to_dev_type = ctx_to.device_type;

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -187,7 +187,7 @@ class RPCModuleNode final : public ModuleNode {
 
 void* RPCWrappedFunc::UnwrapRemote(int rpc_sess_table_index,
                                    const TVMArgValue& arg) {
-  if (arg.type_code() == kModuleHandle) {
+  if (arg.type_code() == kTVMModuleHandle) {
     Module mod = arg;
     std::string tkey = mod->type_key();
     CHECK_EQ(tkey, "rpc")
@@ -211,15 +211,15 @@ void RPCWrappedFunc::WrapRemote(std::shared_ptr<RPCSession> sess,
   int tcode = args.type_codes[0];
 
   if (handle == nullptr) return;
-  if (tcode == kFuncHandle) {
+  if (tcode == kTVMPackedFuncHandle) {
     auto wf = std::make_shared<RPCWrappedFunc>(handle, sess);
     *rv = PackedFunc([wf](TVMArgs args, TVMRetValue* rv) {
         return wf->operator()(args, rv);
       });
-  } else if (tcode == kModuleHandle) {
+  } else if (tcode == kTVMModuleHandle) {
     auto n = make_object<RPCModuleNode>(handle, sess);
     *rv = Module(n);
-  } else if (tcode == kArrayHandle || tcode == kNDArrayContainer) {
+  } else if (tcode == kTVMDLTensorHandle || tcode == kTVMNDArrayHandle) {
     CHECK_EQ(args.size(), 2);
     DLTensor* tensor = args[0];
     void* nd_handle = args[1];

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -178,7 +178,7 @@ class RPCSession {
                     size_t to_offset,
                     size_t nbytes,
                     TVMContext ctx_to,
-                    TVMType type_hint);
+                    DLDataType type_hint);
   /*!
    * \brief Copy bytes from remote array content.
    * \param from The source host data.
@@ -195,7 +195,7 @@ class RPCSession {
                       size_t to_offset,
                       size_t nbytes,
                       TVMContext ctx_from,
-                      TVMType type_hint);
+                      DLDataType type_hint);
   /*!
    * \brief Get a remote timer function on ctx.
    *  This function consumes fhandle, caller should not call Free on fhandle.

--- a/src/runtime/sgx/trusted/runtime.cc
+++ b/src/runtime/sgx/trusted/runtime.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -54,10 +54,10 @@ void tvm_ecall_packed_func(int func_id,
   f->CallPacked(TVMArgs(arg_values, type_codes, num_args), &rv);
 
   int ret_type_code = rv.type_code();
-  if (ret_type_code == kNull) return;
+  if (ret_type_code == kTVMNullptr) return;
 
   TVMValue ret_value;
-  if (ret_type_code == kBytes || ret_type_code == kStr) {
+  if (ret_type_code == kTVMBytes || ret_type_code == kTVMStr) {
     // allocate a buffer in untrusted, copy the values in
     std::string bytes = rv;
 
@@ -73,7 +73,7 @@ void tvm_ecall_packed_func(int func_id,
     arr->size = bytes.size();
 
     ret_value = TVMValue{.v_handle = arr};
-    ret_type_code = kBytes;
+    ret_type_code = kTVMBytes;
   } else {
     rv.MoveToCHost(&ret_value, &ret_type_code);
   }

--- a/src/runtime/sgx/untrusted/sgx_module.cc
+++ b/src/runtime/sgx/untrusted/sgx_module.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -187,8 +187,8 @@ TVM_REGISTER_GLOBAL("__sgx_println__")
     case kDLInt: msg << static_cast<int64_t>(args[i]); break;
     case kDLUInt: msg << static_cast<uint64_t>(args[i]); break;
     case kDLFloat: msg << static_cast<double>(args[i]); break;
-    case kStr:
-    case kBytes: {
+    case kTVMStr:
+    case kTVMBytes: {
       std::string val = args[i];
       msg << val;
     }

--- a/src/runtime/stackvm/stackvm.cc
+++ b/src/runtime/stackvm/stackvm.cc
@@ -395,7 +395,7 @@ void StackVM::Run(State* s) const {
         using namespace ir;
         int index = code[pc + 1].v_int;
         int kind = code[pc + 2].v_int;
-        TVMArray* arr = static_cast<TVMArray*>(stack[sp].v_handle);
+        DLTensor* arr = static_cast<DLTensor*>(stack[sp].v_handle);
         switch (kind) {
           case intrinsic::kArrData: {
             stack[sp].v_handle = arr[index].data; break;
@@ -447,7 +447,7 @@ void StackVM::Run(State* s) const {
         using namespace ir;
         int index = code[pc + 1].v_int;
         int kind = code[pc + 2].v_int;
-        TVMArray* arr = static_cast<TVMArray*>(stack[sp - 1].v_handle);
+        DLTensor* arr = static_cast<DLTensor*>(stack[sp - 1].v_handle);
         switch (kind) {
           case intrinsic::kArrData: {
             arr[index].data = stack[sp].v_handle; break;

--- a/src/runtime/stackvm/stackvm.h
+++ b/src/runtime/stackvm/stackvm.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -358,9 +358,9 @@ class StackVM {
    * \param t the type code.
    * \return The load opcode
    */
-  static OpCode GetLoad(TVMType t) {
+  static OpCode GetLoad(DLDataType t) {
     CHECK_EQ(t.lanes, 1U);
-    if (t.code == kHandle) return ARRAY_LOAD_HANDLE;
+    if (t.code == kTVMOpaqueHandle) return ARRAY_LOAD_HANDLE;
     if (t.code == kDLInt) {
       switch (t.bits) {
         case 32 : return ARRAY_LOAD_INT32;
@@ -383,9 +383,9 @@ class StackVM {
    * \param t the type code.
    * \return The load opcode
    */
-  static OpCode GetStore(TVMType t) {
+  static OpCode GetStore(DLDataType t) {
     CHECK_EQ(t.lanes, 1U);
-    if (t.code == kHandle) return ARRAY_STORE_HANDLE;
+    if (t.code == kTVMOpaqueHandle) return ARRAY_STORE_HANDLE;
     if (t.code == kDLInt) {
       switch (t.bits) {
         case 32 : return ARRAY_STORE_INT32;

--- a/src/runtime/vm/memory_manager.h
+++ b/src/runtime/vm/memory_manager.h
@@ -82,7 +82,7 @@ class Allocator {
    *  \param type_hint A type hint to the allocator.
    *  \return A sized allocation in the form of a buffer.
   */
-  virtual Buffer Alloc(size_t nbytes, size_t alignment, TVMType type_hint) = 0;
+  virtual Buffer Alloc(size_t nbytes, size_t alignment, DLDataType type_hint) = 0;
   /*! \brief Free a buffer allocated by the allocator.
    *  \param buffer The buffer to free.
    */

--- a/src/runtime/vm/naive_allocator.h
+++ b/src/runtime/vm/naive_allocator.h
@@ -36,7 +36,7 @@ class NaiveAllocator final : public Allocator {
  public:
   explicit NaiveAllocator(TVMContext ctx) : Allocator(), used_memory_(0), ctx_(ctx) {}
 
-  Buffer Alloc(size_t nbytes, size_t alignment, TVMType type_hint) override {
+  Buffer Alloc(size_t nbytes, size_t alignment, DLDataType type_hint) override {
     Buffer buf;
     buf.ctx = ctx_;
     buf.size = nbytes;

--- a/src/runtime/vm/pooled_allocator.h
+++ b/src/runtime/vm/pooled_allocator.h
@@ -44,7 +44,7 @@ class PooledAllocator final : public Allocator {
 
   ~PooledAllocator() { ReleaseAll(); }
 
-  Buffer Alloc(size_t nbytes, size_t alignment, TVMType type_hint) override {
+  Buffer Alloc(size_t nbytes, size_t alignment, DLDataType type_hint) override {
     std::lock_guard<std::mutex> lock(mu_);
     size_t size = ((nbytes + page_size_ - 1) / page_size_) * page_size_;
     auto&& it = memory_pool_.find(size);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -46,7 +46,7 @@ namespace runtime {
 namespace vm {
 
 
-inline Storage make_storage(size_t size, size_t alignment, TVMType dtype_hint, TVMContext ctx) {
+inline Storage make_storage(size_t size, size_t alignment, DLDataType dtype_hint, TVMContext ctx) {
   // We could put cache in here, from ctx to storage allocator.
   auto storage_obj = SimpleObjAllocator().make_object<StorageObj>();
   auto alloc = MemoryManager::Global()->GetAllocator(ctx);
@@ -336,7 +336,7 @@ Instruction Instruction::AllocTensorReg(
 
 Instruction Instruction::AllocStorage(RegName size,
                                       Index alignment,
-                                      TVMType dtype_hint,
+                                      DLDataType dtype_hint,
                                       Index dst) {
   Instruction instr;
   instr.op = Opcode::AllocStorage;
@@ -587,7 +587,7 @@ void InstructionPrint(std::ostream& os, const Instruction& instr) {
         instr.dst << " $" <<
         instr.alloc_storage.allocation_size << " $" <<
         instr.alloc_storage.alignment << " " <<
-        TVMType2String(instr.alloc_storage.dtype_hint);
+        DLDataType2String(instr.alloc_storage.dtype_hint);
       break;
     }
     default:
@@ -1019,7 +1019,7 @@ void VirtualMachine::RunLoop() {
         DLOG(INFO) <<
           "AllocStorage: allocation_size=" << size <<
           "alignment=" << alignment <<
-          "dtype_hint=" << TVMType2String(instr.alloc_storage.dtype_hint);
+          "dtype_hint=" << DLDataType2String(instr.alloc_storage.dtype_hint);
 
         auto storage = make_storage(size, alignment, instr.alloc_storage.dtype_hint, ctxs_[0]);
         WriteRegister(instr.dst, storage);

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -117,7 +117,10 @@ class VulkanDeviceAPI final : public DeviceAPI {
   }
   void SetDevice(TVMContext ctx) final { VulkanThreadEntry::ThreadLocal()->ctx = ctx; }
   void GetAttr(TVMContext ctx, DeviceAttrKind kind, TVMRetValue* rv) final;
-  void* AllocDataSpace(TVMContext ctx, size_t nbytes, size_t alignment, TVMType type_hint) final {
+  void* AllocDataSpace(TVMContext ctx,
+                       size_t nbytes,
+                       size_t alignment,
+                       DLDataType type_hint) final {
     const auto& vctx = context(ctx.device_id);
     VkBufferCreateInfo info;
     info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -194,7 +197,7 @@ class VulkanDeviceAPI final : public DeviceAPI {
   }
 
   void CopyDataFromTo(const void* from, size_t from_offset, void* to, size_t to_offset, size_t size,
-                      TVMContext ctx_from, TVMContext ctx_to, TVMType type_hint,
+                      TVMContext ctx_from, TVMContext ctx_to, DLDataType type_hint,
                       TVMStreamHandle stream) final {
     CHECK(stream == nullptr);
     TVMContext ctx = ctx_from;
@@ -327,7 +330,7 @@ class VulkanDeviceAPI final : public DeviceAPI {
     return;
   }
 
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final {
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final {
     return VulkanThreadEntry::ThreadLocal()->pool.AllocWorkspace(ctx, size);
   }
 
@@ -772,8 +775,8 @@ class VulkanModuleNode final : public runtime::ModuleNode {
     {
       auto fit = fmap_.find(func_name);
       CHECK(fit != fmap_.end());
-      for (TVMType arg_type : fit->second.arg_types) {
-        if (arg_type.code == kHandle) {
+      for (DLDataType arg_type : fit->second.arg_types) {
+        if (arg_type.code == kTVMOpaqueHandle) {
           {
             VkDescriptorSetLayoutBinding bd;
             bd.binding = num_buffer;

--- a/src/runtime/workspace_pool.cc
+++ b/src/runtime/workspace_pool.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,7 +47,7 @@ class WorkspacePool::Pool {
     nbytes = (nbytes + (kWorkspacePageSize - 1)) / kWorkspacePageSize * kWorkspacePageSize;
     if (nbytes == 0) nbytes = kWorkspacePageSize;
     Entry e;
-    TVMType type;
+    DLDataType type;
     type.code = kDLUInt;
     type.bits = 8;
     type.lanes = 1;

--- a/tests/python/unittest/test_runtime_extension.py
+++ b/tests/python/unittest/test_runtime_extension.py
@@ -19,7 +19,7 @@ import numpy as np
 
 @tvm.register_extension
 class MyTensorView(object):
-    _tvm_tcode = tvm.TypeCode.ARRAY_HANDLE
+    _tvm_tcode = tvm.TypeCode.DLTENSOR_HANDLE
     def __init__(self, arr):
         self.arr = arr
 

--- a/topi/src/topi.cc
+++ b/topi/src/topi.cc
@@ -91,7 +91,7 @@ Array<Integer> ArrayOrInt(TVMArgValue arg) {
 }
 
 inline bool IsTensorType(TVMArgValue arg) {
-  return (arg.type_code() == kObjectHandle &&
+  return (arg.type_code() == kTVMObjectHandle &&
           static_cast<Object*>(
               arg.value().v_handle)->IsInstance<tvm::TensorNode>());
 }

--- a/vta/src/device_api.cc
+++ b/vta/src/device_api.cc
@@ -45,7 +45,7 @@ class VTADeviceAPI final : public DeviceAPI {
   void* AllocDataSpace(TVMContext ctx,
                        size_t size,
                        size_t alignment,
-                       TVMType type_hint) final {
+                       DLDataType type_hint) final {
     return VTABufferAlloc(size);
   }
 
@@ -60,7 +60,7 @@ class VTADeviceAPI final : public DeviceAPI {
                       size_t size,
                       TVMContext ctx_from,
                       TVMContext ctx_to,
-                      TVMType type_hint,
+                      DLDataType type_hint,
                       TVMStreamHandle stream) final {
     int kind_mask = 0;
     if (ctx_from.device_type != kDLCPU) {
@@ -77,7 +77,7 @@ class VTADeviceAPI final : public DeviceAPI {
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final {
   }
 
-  void* AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) final;
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final;
 
   void FreeWorkspace(TVMContext ctx, void* data) final;
 
@@ -93,7 +93,7 @@ struct VTAWorkspacePool : public WorkspacePool {
       WorkspacePool(kDLExtDev, VTADeviceAPI::Global()) {}
 };
 
-void* VTADeviceAPI::AllocWorkspace(TVMContext ctx, size_t size, TVMType type_hint) {
+void* VTADeviceAPI::AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) {
   return dmlc::ThreadLocalStore<VTAWorkspacePool>::Get()
       ->AllocWorkspace(ctx, size);
 }

--- a/web/tvm_runtime.js
+++ b/web/tvm_runtime.js
@@ -95,16 +95,16 @@ var tvm_runtime = tvm_runtime || {};
     var kInt = 0;
     var kUInt = 1;
     var kFloat = 2;
-    var kHandle = 3;
+    var kTVMOpaqueHandle = 3;
     var kNull = 4;
-    var kTVMType = 5;
+    var kTVMDataType = 5;
     var kTVMContext = 6;
-    var kArrayHandle = 7;
-    var kObjectHandle = 8;
-    var kModuleHandle = 9;
-    var kFuncHandle = 10;
-    var kStr = 11;
-    var kBytes = 12;
+    var kTVMDLTensorHandle = 7;
+    var kTVMObjectHandle = 8;
+    var kTVMModuleHandle = 9;
+    var kTVMPackedFuncHandle = 10;
+    var kTVMStr = 11;
+    var kTVMBytes = 12;
     //-----------------------------------------
     // TVM CWrap library
     // ----------------------------------------
@@ -427,7 +427,7 @@ var tvm_runtime = tvm_runtime || {};
           code = kUInt;
         } else if (pattern.substring(0, 6) == "handle") {
           pattern = pattern.substring(5, pattern.length);
-          code = kHandle;
+          code = kTVMOpaqueHandle;
           bits = 64;
         } else {
           throw throwError("Unknown dtype " + dtype);
@@ -453,11 +453,11 @@ var tvm_runtime = tvm_runtime || {};
       case kInt:
       case kUInt: return Module.getValue(vptr, "i64");
       case kFloat: return Module.getValue(vptr, "double");
-      case kFuncHandle: return makeTVMFunction(Module.getValue(vptr, "*"));
-      case kModuleHandle: return new TVMModule(Module.getValue(vptr, "*"));
+      case kTVMPackedFuncHandle: return makeTVMFunction(Module.getValue(vptr, "*"));
+      case kTVMModuleHandle: return new TVMModule(Module.getValue(vptr, "*"));
       case kNull: return null;
-      case kStr: return CStringToJS(Module.getValue(vptr, "*"));
-      case kBytes: return CBytesToJS(Module.getValue(vptr, "*"));
+      case kTVMStr: return CStringToJS(Module.getValue(vptr, "*"));
+      case kTVMBytes: return CBytesToJS(Module.getValue(vptr, "*"));
       default: throwError("Unsupported return type code=" + tcode);
       }
     }
@@ -497,9 +497,9 @@ var tvm_runtime = tvm_runtime || {};
       for (var i = 0; i < nargs; ++i) {
         var vptr = arg_value + i * SIZEOF_TVMVALUE;
         var tcode = Module.getValue(arg_tcode + i * SIZEOF_INT, "i32");
-        if (tcode == kObjectHandle ||
-            tcode == kFuncHandle ||
-            tcode == kModuleHandle) {
+        if (tcode == kTVMObjectHandle ||
+            tcode == kTVMPackedFuncHandle ||
+            tcode == kTVMModuleHandle) {
           TVM_CALL(TVMCbArgToReturn(vptr, tcode));
         }
         args.push(TVMRetValueToJS(vptr, tcode));
@@ -630,7 +630,7 @@ var tvm_runtime = tvm_runtime || {};
         var sdata = new CBuffer(value.length + 1);
         Module.HEAPU8.set(StringToUint8Array(value), sdata.data);
         this.temp.push(sdata);
-        Module.setValue(this.tcode + index * SIZEOF_INT, kStr, "i32");
+        Module.setValue(this.tcode + index * SIZEOF_INT, kTVMStr, "i32");
         Module.setValue(this.value + index * SIZEOF_TVMVALUE, sdata.data, "*");
       },
       setBytes : function(index, value) {
@@ -642,7 +642,7 @@ var tvm_runtime = tvm_runtime || {};
         Module.setValue(sheader.data + SIZEOF_POINTER, value.length, "i32");
         this.temp.push(sdata);
         this.temp.push(sheader);
-        Module.setValue(this.tcode + index * SIZEOF_INT, kBytes, "i32");
+        Module.setValue(this.tcode + index * SIZEOF_INT, kTVMBytes, "i32");
         Module.setValue(this.value + index * SIZEOF_TVMVALUE, sheader.data, "*");
       },
       setArguments : function(args) {
@@ -650,7 +650,7 @@ var tvm_runtime = tvm_runtime || {};
           var v = args[i];
           var tp = typeof v;
           if (v instanceof NDArray) {
-            this.setHandle(i, v.handle, kArrayHandle);
+            this.setHandle(i, v.handle, kTVMDLTensorHandle);
           } else if (v instanceof TVMConstant) {
             var code = getTVMType(v.dtype).code;
             if (code == kInt || code == kUInt) {
@@ -658,13 +658,13 @@ var tvm_runtime = tvm_runtime || {};
             } else if (code == kFloat) {
               this.setDouble(i, v.value);
             } else {
-              CHECK(code == kHandle);
-              this.setHandle(i, v.value, kHandle);
+              CHECK(code == kTVMOpaqueHandle);
+              this.setHandle(i, v.value, kTVMOpaqueHandle);
             }
           } else if (tp == "number") {
             this.setDouble(i, v);
           } else if (tp == "function" && v.hasOwnProperty("_tvm_function")) {
-            this.setString(i, v._tvm_function.handle, kFuncHandle);
+            this.setString(i, v._tvm_function.handle, kTVMPackedFuncHandle);
           } else if (v === null) {
             this.setHandle(i, 0, kNull);
           } else if (tp == "string") {
@@ -674,9 +674,9 @@ var tvm_runtime = tvm_runtime || {};
           } else if (v instanceof Function) {
             v = convertFunc(v);
             this.temp.push(v);
-            this.setHandle(i, v._tvm_function.handle, kFuncHandle);
+            this.setHandle(i, v._tvm_function.handle, kTVMPackedFuncHandle);
           } else if (v instanceof TVMModule) {
-            this.setHandle(i, v.handle, kModuleHandle);
+            this.setHandle(i, v.handle, kTVMModuleHandle);
           } else {
             throwError("Unsupported argument type " + tp);
           }


### PR DESCRIPTION
This PR introduces more clear naming prefix for C API type codes
to avoid conflict with other packages.

We also removed TVMArray and TVMType to directly use DLTensor and DLDataType.
