### PR TITLE
[REFACTOR] Move support related code to include/tvm/support

### DIFF
--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -164,7 +164,7 @@ void LinuxShared(const std::string output,
     }
     cmd += " " + options;
     std::string err_msg;
-    auto executed_status = common::Execute(cmd, &err_msg);
+    auto executed_status = support::Execute(cmd, &err_msg);
     if (executed_status) {
       LOG(FATAL) << err_msg;
     }
@@ -195,22 +195,22 @@ void CreateShared(const std::string output, const std::vector<std::string> &file
  */
 Module Load(std::string *fileIn, const std::string fmt) {
   std::string file = *fileIn;
-  if (common::EndsWith(file, ".so")) {
+  if (support::EndsWith(file, ".so")) {
       return Module::LoadFromFile(file, fmt);
   }
 
   #if defined(__linux__) || defined(__ANDROID__)
     std::string file_name = file + ".so";
-    if (common::EndsWith(file, ".o")) {
+    if (support::EndsWith(file, ".o")) {
       std::vector<std::string> files;
       files.push_back(file);
       CreateShared(file_name, files);
-    } else if (common::EndsWith(file, ".tar")) {
+    } else if (support::EndsWith(file, ".tar")) {
       std::string tmp_dir = "./rpc/tmp/";
       mkdir(&tmp_dir[0], 0777);
       std::string cmd = "tar -C " + tmp_dir + " -zxf " + file;
       std::string err_msg;
-      int executed_status = common::Execute(cmd, &err_msg);
+      int executed_status = support::Execute(cmd, &err_msg);
       if (executed_status) {
         LOG(FATAL) << err_msg;
       }

--- a/apps/cpp_rpc/rpc_server.cc
+++ b/apps/cpp_rpc/rpc_server.cc
@@ -122,8 +122,8 @@ class RPCServer {
   void ListenLoopProc() {
     TrackerClient tracker(tracker_addr_, key_, custom_addr_);
     while (true) {
-      common::TCPSocket conn;
-      common::SockAddr addr("0.0.0.0", 0);
+      support::TCPSocket conn;
+      support::SockAddr addr("0.0.0.0", 0);
       std::string opts;
       try {
         // step 1: setup tracker and report to tracker
@@ -221,8 +221,8 @@ class RPCServer {
    * \param ping_period Timeout for select call waiting
    */
   void AcceptConnection(TrackerClient* tracker,
-                        common::TCPSocket* conn_sock,
-                        common::SockAddr* addr,
+                        support::TCPSocket* conn_sock,
+                        support::SockAddr* addr,
                         std::string* opts,
                         int ping_period = 2) {
     std::set <std::string> old_keyset;
@@ -233,7 +233,7 @@ class RPCServer {
 
     while (true) {
       tracker->WaitConnectionAndUpdateKey(listen_sock_, my_port_, ping_period, &matchkey);
-      common::TCPSocket conn = listen_sock_.Accept(addr);
+      support::TCPSocket conn = listen_sock_.Accept(addr);
 
       int code = kRPCMagic;
       CHECK_EQ(conn.RecvAll(&code, sizeof(code)), sizeof(code));
@@ -289,7 +289,7 @@ class RPCServer {
    * \param sock The socket information
    * \param addr The socket address information
    */
-  void ServerLoopProc(common::TCPSocket sock, common::SockAddr addr) {
+  void ServerLoopProc(support::TCPSocket sock, support::SockAddr addr) {
       // Server loop
       auto env = RPCEnv();
       RPCServerLoop(sock.sockfd);
@@ -308,7 +308,7 @@ class RPCServer {
 
     if (opts.find(option) == 0) {
       cmd = opts.substr(opts.find_last_of(option) + 1);
-      CHECK(common::IsNumber(cmd)) << "Timeout is not valid";
+      CHECK(support::IsNumber(cmd)) << "Timeout is not valid";
       return std::stoi(cmd);
     }
     return 0;
@@ -321,8 +321,8 @@ class RPCServer {
   std::string tracker_addr_;
   std::string key_;
   std::string custom_addr_;
-  common::TCPSocket listen_sock_;
-  common::TCPSocket tracker_sock_;
+  support::TCPSocket listen_sock_;
+  support::TCPSocket tracker_sock_;
 };
 
 /*!

--- a/apps/cpp_rpc/rpc_tracker_client.h
+++ b/apps/cpp_rpc/rpc_tracker_client.h
@@ -132,7 +132,7 @@ class TrackerClient {
    * \param ping_period Select wait time.
    * \param matchkey Random match key output.
   */
-  void WaitConnectionAndUpdateKey(common::TCPSocket listen_sock,
+  void WaitConnectionAndUpdateKey(support::TCPSocket listen_sock,
                                   int port,
                                   int ping_period,
                                   std::string *matchkey) {
@@ -140,7 +140,7 @@ class TrackerClient {
     int unmatch_timeout = 4;
     while (true) {
       if (!tracker_sock_.IsClosed()) {
-        common::PollHelper poller;
+        support::PollHelper poller;
         poller.WatchRead(listen_sock.sockfd);
         poller.Poll(ping_period * 1000);
         if (!poller.CheckRead(listen_sock.sockfd)) {
@@ -189,11 +189,11 @@ class TrackerClient {
    * \param retry_period Number of seconds before we retry again.
    * \return TCPSocket The socket information if connect is success.
    */
-  common::TCPSocket ConnectWithRetry(int timeout = 60, int retry_period = 5) {
+  support::TCPSocket ConnectWithRetry(int timeout = 60, int retry_period = 5) {
     auto tbegin = std::chrono::system_clock::now();
     while (true) {
-      common::SockAddr addr(tracker_addr_);
-      common::TCPSocket sock;
+      support::SockAddr addr(tracker_addr_);
+      support::TCPSocket sock;
       sock.Create();
       LOG(INFO) << "Tracker connecting to " << addr.AsString();
       if (sock.Connect(addr)) {
@@ -235,7 +235,7 @@ class TrackerClient {
   std::string tracker_addr_;
   std::string key_;
   std::string custom_addr_;
-  common::TCPSocket tracker_sock_;
+  support::TCPSocket tracker_sock_;
   std::set <std::string> old_keyset_;
   std::mt19937 gen_;
   std::uniform_real_distribution<float> dis_;

--- a/include/tvm/arithmetic.h
+++ b/include/tvm/arithmetic.h
@@ -24,6 +24,8 @@
 #ifndef TVM_ARITHMETIC_H_
 #define TVM_ARITHMETIC_H_
 
+#include <tvm/support/with.h>
+
 #include <vector>
 #include <unordered_map>
 #include <memory>

--- a/include/tvm/buffer.h
+++ b/include/tvm/buffer.h
@@ -26,7 +26,6 @@
 
 #include <string>
 
-#include "base.h"
 #include "expr.h"
 #include "expr_operator.h"
 #include "tvm/node/container.h"

--- a/include/tvm/codegen.h
+++ b/include/tvm/codegen.h
@@ -25,7 +25,6 @@
 #define TVM_CODEGEN_H_
 
 #include <string>
-#include "base.h"
 #include "expr.h"
 #include "lowered_func.h"
 #include "runtime/packed_func.h"

--- a/include/tvm/data_layout.h
+++ b/include/tvm/data_layout.h
@@ -25,7 +25,7 @@
 #ifndef TVM_DATA_LAYOUT_H_
 #define TVM_DATA_LAYOUT_H_
 
-#include <tvm/base.h>
+
 #include <tvm/expr.h>
 
 #include <string>

--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <unordered_map>
 #include <iostream>
-#include "base.h"
 #include "node/node.h"
 #include "node/container.h"
 #include "node/functor.h"

--- a/include/tvm/ir.h
+++ b/include/tvm/ir.h
@@ -29,7 +29,6 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include "base.h"
 #include "expr.h"
 #include "runtime/util.h"
 

--- a/include/tvm/ir/op.h
+++ b/include/tvm/ir/op.h
@@ -391,6 +391,14 @@ class OpMap {
   const GenericOpMap& map_;
 };
 
+#define TVM_STRINGIZE_DETAIL(x) #x
+#define TVM_STRINGIZE(x) TVM_STRINGIZE_DETAIL(x)
+#define TVM_DESCRIBE(...) describe(__VA_ARGS__ "\n\nFrom:" __FILE__ ":" TVM_STRINGIZE(__LINE__))
+/*!
+ * \brief Macro to include current line as string
+ */
+#define TVM_ADD_FILELINE "\n\nDefined in " __FILE__ ":L" TVM_STRINGIZE(__LINE__)
+
 // internal macros to make
 #define TVM_OP_REGISTER_VAR_DEF \
   static DMLC_ATTRIBUTE_UNUSED ::tvm::OpRegistry& __make_##Op

--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -56,7 +56,7 @@
 #ifndef TVM_IR_TRANSFORM_H_
 #define TVM_IR_TRANSFORM_H_
 
-#include <tvm/base.h>
+#include <tvm/support/with.h>
 #include <tvm/node/container.h>
 #include <tvm/ir/error.h>
 #include <tvm/ir/module.h>

--- a/include/tvm/lowered_func.h
+++ b/include/tvm/lowered_func.h
@@ -27,7 +27,6 @@
 
 #include <string>
 
-#include "base.h"
 #include "expr.h"
 #include "tensor.h"
 #include "tvm/node/container.h"

--- a/include/tvm/packed_func_ext.h
+++ b/include/tvm/packed_func_ext.h
@@ -30,7 +30,6 @@
 #include <limits>
 #include <type_traits>
 
-#include "base.h"
 #include "expr.h"
 #include "tensor.h"
 #include "runtime/packed_func.h"

--- a/include/tvm/schedule.h
+++ b/include/tvm/schedule.h
@@ -27,7 +27,6 @@
 
 #include <string>
 #include <unordered_map>
-#include "base.h"
 #include "expr.h"
 #include "tensor.h"
 #include "tensor_intrin.h"

--- a/include/tvm/schedule_pass.h
+++ b/include/tvm/schedule_pass.h
@@ -28,7 +28,6 @@
 #ifndef TVM_SCHEDULE_PASS_H_
 #define TVM_SCHEDULE_PASS_H_
 
-#include "base.h"
 #include "schedule.h"
 
 namespace tvm {

--- a/include/tvm/support/logging.h
+++ b/include/tvm/support/logging.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file tvm/logging.h
+ * \file tvm/support/logging.h
  * \brief logging utilities on top of dmlc-core
  */
-#ifndef TVM_LOGGING_H_
-#define TVM_LOGGING_H_
+#ifndef TVM_SUPPORT_LOGGING_H_
+#define TVM_SUPPORT_LOGGING_H_
 
 // a technique that enables overriding macro names on the number of parameters. This is used
 // to define other macros below
@@ -114,4 +114,4 @@
 #define COND_CHECK_2(quit_on_assert, x) COND_CHECK_3(quit_on_assert, x, return false)
 #define COND_LOG_2(quit_on_assert, x) COND_LOG_3(quit_on_assert, x, return false)
 
-#endif   // TVM_LOGGING_H_
+#endif   // TVM_SUPPORT_LOGGING_H_

--- a/include/tvm/support/with.h
+++ b/include/tvm/support/with.h
@@ -18,11 +18,12 @@
  */
 
 /*!
- * \file tvm/base.h
- * \brief Base utilities
+ * \file tvm/support/with.h
+ * \brief RAII wrapper function to enter and exit a context object
+ *        similar to python's with syntax.
  */
-#ifndef TVM_BASE_H_
-#define TVM_BASE_H_
+#ifndef TVM_SUPPORT_WITH_H_
+#define TVM_SUPPORT_WITH_H_
 
 #include <dmlc/logging.h>
 #include <utility>
@@ -73,14 +74,5 @@ class With {
   ContextType ctx_;
 };
 
-#define TVM_STRINGIZE_DETAIL(x) #x
-#define TVM_STRINGIZE(x) TVM_STRINGIZE_DETAIL(x)
-#define TVM_DESCRIBE(...) describe(__VA_ARGS__ "\n\nFrom:" __FILE__ ":" TVM_STRINGIZE(__LINE__))
-/*!
- * \brief Macro to include current line as string
- */
-#define TVM_ADD_FILELINE "\n\nDefined in " __FILE__ ":L" TVM_STRINGIZE(__LINE__)
-
-
 }  // namespace tvm
-#endif  // TVM_BASE_H_
+#endif  // TVM_SUPPORT_WITH_H_

--- a/include/tvm/target_info.h
+++ b/include/tvm/target_info.h
@@ -25,7 +25,6 @@
 #define TVM_TARGET_INFO_H_
 
 #include <string>
-#include "base.h"
 #include "expr.h"
 
 namespace tvm {

--- a/include/tvm/tensor.h
+++ b/include/tvm/tensor.h
@@ -30,7 +30,6 @@
 #include <utility>
 #include <type_traits>
 
-#include "base.h"
 #include "expr.h"
 #include "expr_operator.h"
 #include "arithmetic.h"

--- a/src/README.md
+++ b/src/README.md
@@ -21,7 +21,7 @@ Header files in include are public APIs that share across modules.
 There can be internal header files within each module that sit in src.
 
 ## Modules
-- common: Internal common utilities.
+- support: Internal support utilities.
 - runtime: Minimum runtime related codes.
 - node: base infra for IR/AST nodes that is dialect independent.
 - api: API function registration.

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -20,7 +20,7 @@
 /*!
  * \file codegen_cuda.cc
  */
-#include <tvm/base.h>
+
 #include <tvm/runtime/registry.h>
 #include <tvm/packed_func_ext.h>
 #include <cmath>

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,7 +22,7 @@
  */
 #ifdef TVM_LLVM_VERSION
 
-#include <tvm/base.h>
+#include <dmlc/logging.h>
 #include <atomic>
 #include <mutex>
 #include <memory>

--- a/src/codegen/opt/build_cuda_on.cc
+++ b/src/codegen/opt/build_cuda_on.cc
@@ -27,7 +27,7 @@
 #include <sys/stat.h>
 #endif
 #include <cuda_runtime.h>
-#include <tvm/base.h>
+
 #include <nvrtc.h>
 #include <cstdlib>
 

--- a/src/lang/expr.cc
+++ b/src/lang/expr.cc
@@ -20,7 +20,7 @@
 /*!
  * \file expr.cc
  */
-#include <tvm/base.h>
+
 #include <tvm/expr.h>
 #include <tvm/ir.h>
 #include <tvm/expr_operator.h>

--- a/src/lang/expr_operator.cc
+++ b/src/lang/expr_operator.cc
@@ -20,7 +20,7 @@
 /*!
  * \file expr_operator.cc
  */
-#include <tvm/base.h>
+
 #include <tvm/ir.h>
 #include <tvm/expr_operator.h>
 #include <cmath>

--- a/src/lang/ir.cc
+++ b/src/lang/ir.cc
@@ -20,7 +20,7 @@
 /*!
  * \file ir.cc
  */
-#include <tvm/base.h>
+
 #include <tvm/expr.h>
 #include <tvm/ir.h>
 #include <tvm/ir_pass.h>

--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -34,7 +34,7 @@
 #include <string>
 #include <map>
 
-#include "../common/base64.h"
+#include "../support/base64.h"
 
 namespace tvm {
 
@@ -392,7 +392,7 @@ struct JSONGraph {
     for (DLTensor* tensor : indexer.tensor_list_) {
       std::string blob;
       dmlc::MemoryStringStream mstrm(&blob);
-      common::Base64OutStream b64strm(&mstrm);
+      support::Base64OutStream b64strm(&mstrm);
       runtime::SaveDLTensor(&b64strm, tensor);
       b64strm.Finish();
       g.b64ndarrays.emplace_back(std::move(blob));
@@ -420,7 +420,7 @@ ObjectRef LoadJSON(std::string json_str) {
   // load in tensors
   for (const std::string& blob : jgraph.b64ndarrays) {
     dmlc::MemoryStringStream mstrm(const_cast<std::string*>(&blob));
-    common::Base64InStream b64strm(&mstrm);
+    support::Base64InStream b64strm(&mstrm);
     b64strm.InitPosition();
     runtime::NDArray temp;
     CHECK(temp.Load(&b64strm));

--- a/src/relay/backend/graph_plan_memory.cc
+++ b/src/relay/backend/graph_plan_memory.cc
@@ -25,7 +25,7 @@
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/analysis.h>
-#include "../../common/arena.h"
+#include "../../support/arena.h"
 
 namespace tvm {
 namespace relay {
@@ -130,7 +130,7 @@ class StorageAllocaBaseVisitor : public ExprVisitor {
 
 class StorageAllocaInit : protected StorageAllocaBaseVisitor {
  public:
-  explicit StorageAllocaInit(common::Arena* arena)
+  explicit StorageAllocaInit(support::Arena* arena)
       : arena_(arena) {}
 
   /*! \return The internal token map */
@@ -183,7 +183,7 @@ class StorageAllocaInit : protected StorageAllocaBaseVisitor {
 
  private:
   // allocator
-  common::Arena* arena_;
+  support::Arena* arena_;
   Map<Expr, Integer> node_device_map_;
 };
 
@@ -374,7 +374,7 @@ class StorageAllocator : public StorageAllocaBaseVisitor {
 
  private:
   // allocator
-  common::Arena arena_;
+  support::Arena arena_;
   // scale used for rough match
   size_t match_range_{16};
   // free list of storage entry

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -27,7 +27,7 @@
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/interpreter.h>
 #include <tvm/relay/qnn/transform.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/vm.h>
 #include <tvm/relay/attrs/memory.h>

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -28,7 +28,7 @@
 #include <tvm/ir/error.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/interpreter.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/vm.h>
 #include <iostream>

--- a/src/relay/backend/vm/inline_primitives.cc
+++ b/src/relay/backend/vm/inline_primitives.cc
@@ -24,7 +24,7 @@
 
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/vm.h>
 #include <iostream>

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -24,7 +24,7 @@
 
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/vm.h>

--- a/src/relay/backend/vm/removed_unused_funcs.cc
+++ b/src/relay/backend/vm/removed_unused_funcs.cc
@@ -24,7 +24,7 @@
 
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/vm.h>

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -887,7 +887,7 @@ class PrettyPrinter :
   /*! \brief whether the printer is currently in an ADT definition */
   bool in_adt_def_;
   /*! \brief arena for dependency graph */
-  common::Arena arena_;
+  support::Arena arena_;
   /*! \brief dependency graph of the expr */
   DependencyGraph dg_;
   class AttrPrinter;

--- a/src/relay/pass/dependency_graph.cc
+++ b/src/relay/pass/dependency_graph.cc
@@ -32,7 +32,7 @@ namespace relay {
 // Creator of DependencyGraph
 class DependencyGraph::Creator : private ExprFunctor<void(const Expr& e)> {
  public:
-  explicit Creator(common::Arena* arena)
+  explicit Creator(support::Arena* arena)
     : arena_(arena) {}
 
   DependencyGraph Create(const Expr& body) {
@@ -42,7 +42,7 @@ class DependencyGraph::Creator : private ExprFunctor<void(const Expr& e)> {
 
  private:
   /*! \brief allocator of all the internal node object */
-  common::Arena* arena_;
+  support::Arena* arena_;
   // The output.
   DependencyGraph graph_;
   // Update the message stored at the node.
@@ -175,7 +175,7 @@ class DependencyGraph::Creator : private ExprFunctor<void(const Expr& e)> {
   void VisitExpr_(const ConstructorNode* c) final { }
 };
 
-DependencyGraph DependencyGraph::Create(common::Arena* arena, const Expr& body) {
+DependencyGraph DependencyGraph::Create(support::Arena* arena, const Expr& body) {
   return Creator(arena).Create(body);
 }
 

--- a/src/relay/pass/dependency_graph.h
+++ b/src/relay/pass/dependency_graph.h
@@ -28,13 +28,13 @@
 #include <unordered_map>
 #include <vector>
 #include "let_list.h"
-#include "../../common/arena.h"
+#include "../../support/arena.h"
 
 namespace tvm {
 namespace relay {
 
-using common::LinkNode;
-using common::LinkedList;
+using support::LinkNode;
+using support::LinkedList;
 
 /* DependencyGraph track input and output of an Expr.
  * Additionally, dummy scope is created to model scope.
@@ -64,7 +64,7 @@ class DependencyGraph {
    * \param arena The arena used for data allocation.
    * \param body The body of the expression to create a graph.
    */
-  static DependencyGraph Create(common::Arena* arena, const Expr& body);
+  static DependencyGraph Create(support::Arena* arena, const Expr& body);
 
  private:
   class Creator;

--- a/src/relay/pass/to_a_normal_form.cc
+++ b/src/relay/pass/to_a_normal_form.cc
@@ -29,7 +29,7 @@
 #include <tvm/relay/expr_functor.h>
 #include <tvm/support/logging.h>
 #include "let_list.h"
-#include "../../common/arena.h"
+#include "../../support/arena.h"
 #include "pass_util.h"
 #include "dependency_graph.h"
 
@@ -275,7 +275,7 @@ Expr ToANormalFormAux(const Expr& e) {
    *
    * So we calculate all the dependency between nodes.
    */
-  common::Arena arena;
+  support::Arena arena;
   DependencyGraph dg = DependencyGraph::Create(&arena, e);
   /* In order to model new subscopes created by lambda, if else and pattern matching,
    * we also assign scope to edge as well.

--- a/src/relay/pass/to_a_normal_form.cc
+++ b/src/relay/pass/to_a_normal_form.cc
@@ -27,7 +27,7 @@
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/transform.h>
 #include <tvm/relay/expr_functor.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include "let_list.h"
 #include "../../common/arena.h"
 #include "pass_util.h"

--- a/src/relay/pass/type_solver.h
+++ b/src/relay/pass/type_solver.h
@@ -32,14 +32,14 @@
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
-#include "../../common/arena.h"
+#include "../../support/arena.h"
 
 
 namespace tvm {
 namespace relay {
 
-using common::LinkNode;
-using common::LinkedList;
+using support::LinkNode;
+using support::LinkedList;
 
 /*!
  * \brief Interface of type solver used in type inference.
@@ -171,7 +171,7 @@ class TypeSolver {
   /*! \brief Internal queue to update the relation */
   std::queue<RelationNode*> update_queue_;
   /*! \brief allocator of all the internal node obhect*/
-  common::Arena arena_;
+  support::Arena arena_;
   /*! \brief Reporter that reports back to self */
   TypeReporter reporter_;
   /*! \brief The global representing the current function. */

--- a/src/runtime/micro/openocd_low_level_device.cc
+++ b/src/runtime/micro/openocd_low_level_device.cc
@@ -45,7 +45,7 @@ class OpenOCDLowLevelDevice final : public LowLevelDevice {
     server_addr_ = server_addr;
     port_ = port;
 
-    socket_.Connect(tvm::common::SockAddr(server_addr_.c_str(), port_));
+    socket_.Connect(tvm::support::SockAddr(server_addr_.c_str(), port_));
     socket_.cmd_builder() << "halt 0";
     socket_.SendCommand();
   }

--- a/src/runtime/micro/tcl_socket.cc
+++ b/src/runtime/micro/tcl_socket.cc
@@ -37,7 +37,7 @@ TclSocket::~TclSocket() {
   tcp_socket_.Close();
 }
 
-void TclSocket::Connect(tvm::common::SockAddr addr) {
+void TclSocket::Connect(tvm::support::SockAddr addr) {
   CHECK(tcp_socket_.Connect(addr)) << "failed to connect";
 }
 

--- a/src/runtime/micro/tcl_socket.h
+++ b/src/runtime/micro/tcl_socket.h
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-#include "../../common/socket.h"
+#include "../../support/socket.h"
 
 namespace tvm {
 namespace runtime {
@@ -55,7 +55,7 @@ class TclSocket {
    * \brief open connection with server
    * \param addr server address
    */
-  void Connect(tvm::common::SockAddr addr);
+  void Connect(tvm::support::SockAddr addr);
 
   /*
    * \brief send the built command to the server and await a reply
@@ -76,7 +76,7 @@ class TclSocket {
 
  private:
   /*! \brief underlying TCP socket being wrapped */
-  tvm::common::TCPSocket tcp_socket_;
+  tvm::support::TCPSocket tcp_socket_;
   /*! \brief buffer used to receive messages from the socket */
   std::vector<uint8_t> reply_buf_;
   /*! \brief string stream used to build current command */

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -36,8 +36,8 @@
 #include <algorithm>
 #include "rpc_session.h"
 #include "../object_internal.h"
-#include "../../common/ring_buffer.h"
-#include "../../common/socket.h"
+#include "../../support/ring_buffer.h"
+#include "../../support/socket.h"
 
 namespace tvm {
 namespace runtime {
@@ -73,8 +73,8 @@ struct RPCArgBuffer {
 // Event handler for RPC events.
 class RPCSession::EventHandler : public dmlc::Stream {
  public:
-  EventHandler(common::RingBuffer* reader,
-               common::RingBuffer* writer,
+  EventHandler(support::RingBuffer* reader,
+               support::RingBuffer* writer,
                int rpc_sess_table_index,
                std::string name,
                std::string* remote_key)
@@ -819,9 +819,9 @@ class RPCSession::EventHandler : public dmlc::Stream {
   // Number of pending bytes requests
   size_t pending_request_bytes_;
   // The ring buffer to read data from.
-  common::RingBuffer* reader_;
+  support::RingBuffer* reader_;
   // The ringr buffer to write reply to.
-  common::RingBuffer* writer_;
+  support::RingBuffer* writer_;
   // Session table index.
   int rpc_sess_table_index_;
   // Name of session.
@@ -1336,7 +1336,7 @@ size_t CallbackChannel::Send(const void* data, size_t size) {
   bytes.size = size;
   int64_t n = fsend_(bytes);
   if (n == -1) {
-    common::Socket::Error("CallbackChannel::Send");
+    support::Socket::Error("CallbackChannel::Send");
   }
   return static_cast<size_t>(n);
 }
@@ -1344,7 +1344,7 @@ size_t CallbackChannel::Send(const void* data, size_t size) {
 size_t CallbackChannel::Recv(void* data, size_t size) {
   TVMRetValue ret = frecv_(size);
   if (ret.type_code() != kBytes) {
-    common::Socket::Error("CallbackChannel::Recv");
+    support::Socket::Error("CallbackChannel::Recv");
   }
   std::string* bytes = ret.ptr<std::string>();
   memcpy(static_cast<char*>(data), bytes->c_str(), bytes->length());

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -30,7 +30,7 @@
 #include <string>
 #include <memory>
 #include <utility>
-#include "../../common/ring_buffer.h"
+#include "../../support/ring_buffer.h"
 
 namespace tvm {
 namespace runtime {
@@ -270,7 +270,7 @@ class RPCSession {
   // Internal mutex
   std::recursive_mutex mutex_;
   // Internal ring buffer.
-  common::RingBuffer reader_, writer_;
+  support::RingBuffer reader_, writer_;
   // Event handler.
   std::shared_ptr<EventHandler> handler_;
   // call remote with specified function code.

--- a/src/runtime/rpc/rpc_socket_impl.cc
+++ b/src/runtime/rpc/rpc_socket_impl.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,14 +24,14 @@
 #include <tvm/runtime/registry.h>
 #include <memory>
 #include "rpc_session.h"
-#include "../../common/socket.h"
+#include "../../support/socket.h"
 
 namespace tvm {
 namespace runtime {
 
 class SockChannel final : public RPCChannel {
  public:
-  explicit SockChannel(common::TCPSocket sock)
+  explicit SockChannel(support::TCPSocket sock)
       : sock_(sock) {}
   ~SockChannel() {
     if (!sock_.BadSocket()) {
@@ -41,26 +41,26 @@ class SockChannel final : public RPCChannel {
   size_t Send(const void* data, size_t size) final {
     ssize_t n = sock_.Send(data, size);
     if (n == -1) {
-      common::Socket::Error("SockChannel::Send");
+      support::Socket::Error("SockChannel::Send");
     }
     return static_cast<size_t>(n);
   }
   size_t Recv(void* data, size_t size) final {
     ssize_t n = sock_.Recv(data, size);
     if (n == -1) {
-      common::Socket::Error("SockChannel::Recv");
+      support::Socket::Error("SockChannel::Recv");
     }
     return static_cast<size_t>(n);
   }
 
  private:
-  common::TCPSocket sock_;
+  support::TCPSocket sock_;
 };
 
 std::shared_ptr<RPCSession>
 RPCConnect(std::string url, int port, std::string key) {
-  common::TCPSocket sock;
-  common::SockAddr addr(url.c_str(), port);
+  support::TCPSocket sock;
+  support::SockAddr addr(url.c_str(), port);
   sock.Create(addr.ss_family());
   CHECK(sock.Connect(addr))
       << "Connect to " << addr.AsString() << " failed";
@@ -101,8 +101,8 @@ Module RPCClientConnect(std::string url, int port, std::string key) {
 }
 
 void RPCServerLoop(int sockfd) {
-  common::TCPSocket sock(
-      static_cast<common::TCPSocket::SockType>(sockfd));
+  support::TCPSocket sock(
+      static_cast<support::TCPSocket::SockType>(sockfd));
   RPCSession::Create(
       std::unique_ptr<SockChannel>(new SockChannel(sock)),
       "SockServerLoop", "")->ServerLoop();

--- a/src/runtime/vm/object.cc
+++ b/src/runtime/vm/object.cc
@@ -21,7 +21,7 @@
  * \file src/runtime/vm/object.cc
  * \brief VM related objects.
  */
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/runtime/container.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/vm.h>

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -23,7 +23,7 @@
  */
 
 #include <dmlc/memory_io.h>
-#include <tvm/logging.h>
+#include <tvm/support/logging.h>
 #include <tvm/runtime/container.h>
 #include <tvm/runtime/vm.h>
 #include <tvm/runtime/memory.h>

--- a/src/support/arena.h
+++ b/src/support/arena.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,14 +23,14 @@
  * \brief Arena allocator that allocates
  *  memory chunks and frees them all during destruction time.
  */
-#ifndef TVM_COMMON_ARENA_H_
-#define TVM_COMMON_ARENA_H_
+#ifndef TVM_SUPPORT_ARENA_H_
+#define TVM_SUPPORT_ARENA_H_
 
 #include <utility>
 #include <type_traits>
 
 namespace tvm {
-namespace common {
+namespace support {
 
 const constexpr int kArenaPageSize = 16 << 10;
 
@@ -162,6 +162,6 @@ struct LinkedList {
   }
 };
 
-}  // namespace common
+}  // namespace support
 }  // namespace tvm
-#endif  // TVM_COMMON_ARENA_H_
+#endif  // TVM_SUPPORT_ARENA_H_

--- a/src/support/base64.h
+++ b/src/support/base64.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,8 +23,8 @@
  * \brief data stream support to input and output from/to base64 stream
  *   base64 is easier to store and pass as text format in mapreduce
  */
-#ifndef TVM_COMMON_BASE64_H_
-#define TVM_COMMON_BASE64_H_
+#ifndef TVM_SUPPORT_BASE64_H_
+#define TVM_SUPPORT_BASE64_H_
 
 #include <dmlc/logging.h>
 #include <dmlc/logging.h>
@@ -33,7 +33,7 @@
 #include <string>
 
 namespace tvm {
-namespace common {
+namespace support {
 /*! \brief namespace of base64 decoding and encoding table */
 namespace base64 {
 // decoding table
@@ -297,6 +297,6 @@ class Base64OutStream: public dmlc::Stream {
     }
   }
 };
-}  // namespace common
+}  // namespace support
 }  // namespace tvm
-#endif  // TVM_COMMON_BASE64_H_
+#endif  // TVM_SUPPORT_BASE64_H_

--- a/src/support/pipe.h
+++ b/src/support/pipe.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,8 +21,8 @@
  * \file pipe.h
  * \brief Platform independent pipe, used for IPC.
  */
-#ifndef TVM_COMMON_PIPE_H_
-#define TVM_COMMON_PIPE_H_
+#ifndef TVM_SUPPORT_PIPE_H_
+#define TVM_SUPPORT_PIPE_H_
 
 #include <dmlc/logging.h>
 #include <dmlc/io.h>
@@ -37,7 +37,7 @@
 #endif
 
 namespace tvm {
-namespace common {
+namespace support {
 
 /*! \brief Platform independent pipe */
 class Pipe : public dmlc::Stream {
@@ -118,7 +118,7 @@ class Pipe : public dmlc::Stream {
  private:
   PipeHandle handle_;
 };
-}  // namespace common
+}  // namespace support
 }  // namespace tvm
 
-#endif  // TVM_COMMON_PIPE_H_
+#endif  // TVM_SUPPORT_PIPE_H_

--- a/src/support/ring_buffer.h
+++ b/src/support/ring_buffer.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,15 +21,15 @@
  * \file ring_buffer.h
  * \brief this file aims to provide a wrapper of sockets
  */
-#ifndef TVM_COMMON_RING_BUFFER_H_
-#define TVM_COMMON_RING_BUFFER_H_
+#ifndef TVM_SUPPORT_RING_BUFFER_H_
+#define TVM_SUPPORT_RING_BUFFER_H_
 
 #include <vector>
 #include <cstring>
 #include <algorithm>
 
 namespace tvm {
-namespace common {
+namespace support {
 /*!
  * \brief Ring buffer class for data buffering in IO.
  *  Enables easy usage for sync and async mode.
@@ -173,6 +173,6 @@ class RingBuffer {
   // The internald ata ring.
   std::vector<char> ring_;
 };
-}  // namespace common
+}  // namespace support
 }  // namespace tvm
-#endif  // TVM_COMMON_RING_BUFFER_H_
+#endif  // TVM_SUPPORT_RING_BUFFER_H_

--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,8 +22,8 @@
  * \brief this file aims to provide a wrapper of sockets
  * \author Tianqi Chen
  */
-#ifndef TVM_COMMON_SOCKET_H_
-#define TVM_COMMON_SOCKET_H_
+#ifndef TVM_SUPPORT_SOCKET_H_
+#define TVM_SUPPORT_SOCKET_H_
 
 #if defined(_WIN32)
 #define NOMINMAX
@@ -50,7 +50,7 @@ using ssize_t = int;
 #include <cstring>
 #include <vector>
 #include <unordered_map>
-#include "../common/util.h"
+#include "../support/util.h"
 
 #if defined(_WIN32)
 static inline int poll(struct pollfd *pfd, int nfds,
@@ -62,7 +62,7 @@ static inline int poll(struct pollfd *pfd, int nfds,
 #endif  // defined(_WIN32)
 
 namespace tvm {
-namespace common {
+namespace support {
 /*!
  * \brief Get current host name.
  * \return The hostname.
@@ -648,6 +648,6 @@ struct PollHelper {
   std::unordered_map<TCPSocket::SockType, pollfd> fds;
 };
 
-}  // namespace common
+}  // namespace support
 }  // namespace tvm
-#endif  // TVM_COMMON_SOCKET_H_
+#endif  // TVM_SUPPORT_SOCKET_H_

--- a/src/support/util.h
+++ b/src/support/util.h
@@ -21,8 +21,8 @@
  * \file util.h
  * \brief Defines some common utility function..
  */
-#ifndef TVM_COMMON_UTIL_H_
-#define TVM_COMMON_UTIL_H_
+#ifndef TVM_SUPPORT_UTIL_H_
+#define TVM_SUPPORT_UTIL_H_
 
 #include <stdio.h>
 #ifndef _WIN32
@@ -38,7 +38,7 @@
 #include <memory>
 
 namespace tvm {
-namespace common {
+namespace support {
 /*!
  * \brief TVMPOpen wrapper of popen between windows / unix.
  * \param command executed command
@@ -153,6 +153,6 @@ inline int Execute(std::string cmd, std::string* err_msg) {
   return 255;
 }
 
-}  // namespace common
+}  // namespace support
 }  // namespace tvm
-#endif  // TVM_COMMON_UTIL_H_
+#endif  // TVM_SUPPORT_UTIL_H_


### PR DESCRIPTION
- tvm/logging.h -> tvm/support/logging.h
- remove tvm/base.h, move with into tvm/support/with.h
- src/common -> src/support for consistency

The term "support" follows llvm terminology of basic support utilities