### PR TITLE
[Relay] Invoke tvm::build from relay compile_engine and interpreter

### DIFF
--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -599,12 +599,13 @@ class CompileEngineImpl : public CompileEngineNode {
     CCacheValue value = LowerInternal(key);
     if (value->packed_func != nullptr) return value->packed_func;
     // build the function.
+    tvm::runtime::Module m;
     if (const auto* f = runtime::Registry::Get("relay.backend.build")) {
-      tvm::runtime::Module m = (*f)(value->cached_func->funcs, key->target);
-      value->packed_func = m.GetFunction(value->cached_func->func_name);
+      m = (*f)(value->cached_func->funcs, key->target);
     } else {
-      LOG(FATAL) << "relay.backend.build is not registered";
+      m = build(value->cached_func->funcs, key->target, Target(nullptr), BuildConfig::Current());
     }
+    value->packed_func = m.GetFunction(value->cached_func->func_name);
     return value->packed_func;
   }
 

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -418,13 +418,14 @@ class Interpreter :
       << "Shape function output sizes mismatch";
 
     PackedFunc shape_func;
+    Module m;
     TVMRetValue rv;
     if (const auto* f = runtime::Registry::Get("relay.backend.build")) {
-      tvm::runtime::Module m = (*f)(cfunc->funcs, cfunc->target);
-      shape_func = m.GetFunction(cfunc->func_name);
+      m = (*f)(cfunc->funcs, cfunc->target);
     } else {
-      LOG(FATAL) << "relay.backend.build is not registered";
+      m = build(cfunc->funcs, cfunc->target, Target(nullptr), BuildConfig::Current());
     }
+    shape_func = m.GetFunction(cfunc->func_name);
     shape_func.CallPacked(TVMArgs(values.data(), codes.data(), arity), &rv);
 
     // Get output shapes


### PR DESCRIPTION
`relay.backend.build` is implemented in python and is used in C++ in https://github.com/apache/incubator-tvm/blob/c69092ae0d39f9a5161f098d933d0a2ec570a2c5/src/relay/backend/interpreter.cc#L422 and https://github.com/apache/incubator-tvm/blob/ce807fe83825bce666ed1834ab24b5d6ddfa6bca/src/relay/backend/compile_engine.cc#L602

Similar to `relay.backend.lower` https://github.com/apache/incubator-tvm/blob/ce807fe83825bce666ed1834ab24b5d6ddfa6bca/src/relay/backend/compile_engine.cc#L731-L738 

invoke tvm::build instead of `LOG(FATAL)` when `relay.backend.build` cannot be found, for example, in pure C++ environment. 

@jroesch, @MarisaKirisame please review :)  