### PR TITLE
[CPP RPC] Fix the compile problem of cpp_rpc

### DIFF
--- a/apps/cpp_rpc/main.cc
+++ b/apps/cpp_rpc/main.cc
@@ -31,13 +31,13 @@
 #include <vector>
 #include <sstream>
 
-#include "../../src/common/util.h"
-#include "../../src/common/socket.h"
+#include "../../src/support/util.h"
+#include "../../src/support/socket.h"
 #include "rpc_server.h"
 
 using namespace std;
 using namespace tvm::runtime;
-using namespace tvm::common;
+using namespace tvm::support;
 
 static const string kUSAGE = \
 "Command line usage\n" \

--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -36,7 +36,7 @@
 #include <cstring>
 
 #include "rpc_env.h"
-#include "../../src/common/util.h"
+#include "../../src/support/util.h"
 #include "../../src/runtime/file_util.h"
 
 namespace tvm {

--- a/apps/cpp_rpc/rpc_server.cc
+++ b/apps/cpp_rpc/rpc_server.cc
@@ -39,7 +39,7 @@
 #include "rpc_tracker_client.h"
 #include "../../src/runtime/rpc/rpc_session.h"
 #include "../../src/runtime/rpc/rpc_socket_impl.h"
-#include "../../src/common/socket.h"
+#include "../../src/support/socket.h"
 
 namespace tvm {
 namespace runtime {

--- a/apps/cpp_rpc/rpc_tracker_client.h
+++ b/apps/cpp_rpc/rpc_tracker_client.h
@@ -32,7 +32,7 @@
 #include <string>
 
 #include "../../src/runtime/rpc/rpc_session.h"
-#include "../../src/common/socket.h"
+#include "../../src/support/socket.h"
 
 namespace tvm {
 namespace runtime {


### PR DESCRIPTION
Previously, we move ``src/common`` to ``src/support``, but cpp_rpc's code doesn't be updated so that we couldn't compile cpp_rpc now.

see: https://discuss.tvm.ai/t/android-rpc-stability-issues/3241/19

@tqchen could you help to review it? Thanks.