### PR TITLE
[Fix] Fix dense x86 schedule

### DIFF
--- a/topi/python/topi/x86/dense.py
+++ b/topi/python/topi/x86/dense.py
@@ -191,7 +191,6 @@ def _schedule_dense_pack_template(cfg, s, C):
     z, y, x = s[packedB].op.axis
     s[packedB].reorder(z, x, y)
     s[packedB].parallel(z)
-    s[packedB].vectorize(y)
     return s
 
 


### PR DESCRIPTION
Remove the vectorize on `y` axis as it could be very large, causing llvm codegen hangs.

https://discuss.tvm.ai/t/relay-build-hangs-for-5d-max-pool3d-reshape-matmul/5398/5

@apivovarov @yzhliu 