### PR TITLE
[External codegen] Add test cases for fused ops with manual annotation

### DIFF
--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -158,7 +158,6 @@ class BuildModule(object):
 
         return mod, params
 
-
     def _set_params(self, params):
         self._set_params_func(_convert_param_map(params))
 
@@ -318,6 +317,10 @@ def bind_params_by_name(func, params):
     -------
     func : relay.Function
         The function with parameters bound
+<<<<<<< HEAD
+=======
+
+>>>>>>> introduce bind_params_by_name as reusable api
     """
     inputs = _convert_param_map(params)
     return _build_module.BindParamsByName(func, inputs)

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -317,10 +317,6 @@ def bind_params_by_name(func, params):
     -------
     func : relay.Function
         The function with parameters bound
-<<<<<<< HEAD
-=======
-
->>>>>>> introduce bind_params_by_name as reusable api
     """
     inputs = _convert_param_map(params)
     return _build_module.BindParamsByName(func, inputs)

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -146,6 +146,43 @@ struct GraphCodegen {
 };
 
 /*!
+ * \brief Bind params to function by using name
+ * \param func Relay function
+ * \param params params dict
+ * \return relay::Function
+ */
+relay::Function BindParamsByName(relay::Function func,
+                                 const std::unordered_map<std::string, runtime::NDArray>& params) {
+  std::unordered_map<std::string, relay::Var> name_dict;
+  std::unordered_set<relay::Var, ObjectHash, ObjectEqual> repeat_var;
+  for (auto arg : func->params) {
+    const auto& name = arg->name_hint();
+    if (name_dict.count(name)) {
+      repeat_var.insert(arg);
+    } else {
+      name_dict[name] = arg;
+    }
+  }
+
+  std::unordered_map<relay::Var, Expr, ObjectHash, ObjectEqual> bind_dict;
+  for (auto& kv : params) {
+    if (name_dict.count(kv.first) == 0) {
+      continue;
+    }
+    auto arg = name_dict.at(kv.first);
+    if (repeat_var.count(arg)) {
+      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
+    }
+    bind_dict[arg] = ConstantNode::make(kv.second);
+  }
+  Expr bound_expr = relay::Bind(func, bind_dict);
+  Function ret = Downcast<Function>(bound_expr);
+  CHECK(ret.defined()) << "The returning type is expected to be a Relay Function."
+                       << "\n";
+  return ret;
+}
+
+/*!
  * \brief Relay build module
  *
  */

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -146,43 +146,6 @@ struct GraphCodegen {
 };
 
 /*!
- * \brief Bind params to function by using name
- * \param func Relay function
- * \param params params dict
- * \return relay::Function
- */
-relay::Function BindParamsByName(relay::Function func,
-                                 const std::unordered_map<std::string, runtime::NDArray>& params) {
-  std::unordered_map<std::string, relay::Var> name_dict;
-  std::unordered_set<relay::Var, ObjectHash, ObjectEqual> repeat_var;
-  for (auto arg : func->params) {
-    const auto& name = arg->name_hint();
-    if (name_dict.count(name)) {
-      repeat_var.insert(arg);
-    } else {
-      name_dict[name] = arg;
-    }
-  }
-
-  std::unordered_map<relay::Var, Expr, ObjectHash, ObjectEqual> bind_dict;
-  for (auto& kv : params) {
-    if (name_dict.count(kv.first) == 0) {
-      continue;
-    }
-    auto arg = name_dict.at(kv.first);
-    if (repeat_var.count(arg)) {
-      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
-    }
-    bind_dict[arg] = ConstantNode::make(kv.second);
-  }
-  Expr bound_expr = relay::Bind(func, bind_dict);
-  Function ret = Downcast<Function>(bound_expr);
-  CHECK(ret.defined()) << "The returning type is expected to be a Relay Function."
-                       << "\n";
-  return ret;
-}
-
-/*!
  * \brief Relay build module
  *
  */

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -152,13 +152,13 @@ class CodegenDNNL : public ExprVisitor, public CodegenCBase {
   const CallNode* DetectFusedConv2DBiasReLU(const CallNode* call) {
     if (!IsOp(call, "nn.relu")) return nullptr;
     auto relu_arg = call->args[0];
-    // TODO: a better way to get CallNode* from Expr?
-    const CallNode* add_call = Downcast<Call>(relu_arg).operator->();
+    const CallNode* add_call = relu_arg.as<CallNode>();
     if (!add_call || !IsOp(add_call, "add")) return nullptr;
     auto add_arg = add_call->args[0];
-    const CallNode* conv_call = Downcast<Call>(add_arg).operator->();
+    const CallNode* conv_call = add_arg.as<CallNode>();
     if (!conv_call || !IsOp(conv_call, "nn.conv2d")) return nullptr;
-    ext_fused_func_args_.push_back("dnnl_input_bias");
+    auto bias_name = "dnnl_fused_input" + std::to_string(ext_fused_func_args_.size());
+    ext_fused_func_args_.push_back(bias_name);
     LOG(INFO) << "fused op found";
     return conv_call;
   }

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -346,9 +346,7 @@ class DNNLModuleCodegen : public CSourceModuleCodegenBase {
  */
 runtime::Module DNNLCompiler(const ObjectRef& ref) {
   DNNLModuleCodegen dnnl;
-  LOG(INFO) << "Invoking DNNLCompiler";
   auto ret = dnnl.CreateCSourceModule(ref);
-  LOG(INFO) << "Done invoking DNNLCompiler";
   return ret;
 }
 

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -334,8 +334,7 @@ class DNNLModuleCodegen : public CSourceModuleCodegenBase {
  */
 runtime::Module DNNLCompiler(const ObjectRef& ref) {
   DNNLModuleCodegen dnnl;
-  auto ret = dnnl.CreateCSourceModule(ref);
-  return ret;
+  return dnnl.CreateCSourceModule(ref);
 }
 
 TVM_REGISTER_GLOBAL("relay.ext.dnnl").set_body_typed(DNNLCompiler);

--- a/src/runtime/contrib/dnnl/dnnl.cc
+++ b/src/runtime/contrib/dnnl/dnnl.cc
@@ -52,10 +52,10 @@ inline void read_from_dnnl_memory(void* handle, const memory& mem) {
   std::copy(src, src + bytes, reinterpret_cast<uint8_t*>(handle));
 }
 
-extern "C" void dnnl_conv2d(float* data, float* weights, float* out, int p_N_,
-                            int p_C_, int p_H_, int p_W_, int p_O_, int p_G_,
-                            int p_Ph_, int p_Pw_, int p_Kh_, int p_Kw_,
-                            int p_Sh_, int p_Sw_) {
+void dnnl_conv2d_common(float* data, float* weights, float* bias, float* out,
+                        int p_N_, int p_C_, int p_H_, int p_W_,
+                        int p_O_, int p_G_, int p_Ph_, int p_Pw_, int p_Kh_,
+                        int p_Kw_, int p_Sh_, int p_Sw_, primitive_attr attr) {
   using tag = memory::format_tag;
   using dt = memory::data_type;
   engine eng(engine::kind::cpu, 0);
@@ -65,21 +65,16 @@ extern "C" void dnnl_conv2d(float* data, float* weights, float* out, int p_N_,
   memory::dims conv2d_weights_tz = {p_O_, p_C_, p_Kh_, p_Kw_};
   if (p_G_ > 1) conv2d_weights_tz = {p_G_, 1, p_C_ / p_G_, p_Kh_, p_Kw_};
   memory::dims conv2d_bias_tz = {p_O_};
-  memory::dims conv2d_dst_tz = {p_N_, p_O_,
-                                (p_H_ - p_Kh_ + 2 * p_Ph_ + p_Sh_) / p_Sh_,
+  memory::dims conv2d_dst_tz = {p_N_, p_O_, (p_H_ - p_Kh_ + 2 * p_Ph_ + p_Sh_) / p_Sh_,
                                 (p_W_ - p_Kw_ + 2 * p_Pw_ + p_Sw_) / p_Sw_};
   memory::dims conv2d_strides = {p_Sh_, p_Sw_};
   memory::dims conv2d_padding = {p_Ph_, p_Pw_};
 
-  std::vector<float> conv2d_bias(p_O_, 0);
-
-  auto user_src_memory =
-      memory({{conv2d_src_tz}, dt::f32, tag::nchw}, eng, data);
-  auto user_weights_memory = memory(
-      {{conv2d_weights_tz}, dt::f32, (p_G_ > 1) ? tag::goihw : tag::oihw}, eng,
-      weights);
+  auto user_src_memory = memory({{conv2d_src_tz}, dt::f32, tag::nchw}, eng, data);
+  auto user_weights_memory =
+      memory({{conv2d_weights_tz}, dt::f32, (p_G_ > 1) ? tag::goihw : tag::oihw}, eng, weights);
   auto conv2d_user_bias_memory =
-      memory({{conv2d_bias_tz}, dt::f32, tag::x}, eng, conv2d_bias.data());
+      memory({{conv2d_bias_tz}, dt::f32, tag::x}, eng, bias);
 
   auto conv2d_src_md = memory::desc({conv2d_src_tz}, dt::f32, tag::any);
   auto conv2d_bias_md = memory::desc({conv2d_bias_tz}, dt::f32, tag::any);
@@ -87,10 +82,9 @@ extern "C" void dnnl_conv2d(float* data, float* weights, float* out, int p_N_,
   auto conv2d_dst_md = memory::desc({conv2d_dst_tz}, dt::f32, tag::nchw);
 
   auto conv2d_desc = convolution_forward::desc(
-      prop_kind::forward_inference, algorithm::convolution_direct,
-      conv2d_src_md, conv2d_weights_md, conv2d_bias_md, conv2d_dst_md,
-      conv2d_strides, conv2d_padding, conv2d_padding);
-  auto conv2d_prim_desc = convolution_forward::primitive_desc(conv2d_desc, eng);
+      prop_kind::forward_inference, algorithm::convolution_direct, conv2d_src_md, conv2d_weights_md,
+      conv2d_bias_md, conv2d_dst_md, conv2d_strides, conv2d_padding, conv2d_padding);
+  auto conv2d_prim_desc = convolution_forward::primitive_desc(conv2d_desc, attr, eng);
 
   auto conv2d_src_memory = user_src_memory;
   auto conv2d_weights_memory = user_weights_memory;
@@ -103,6 +97,39 @@ extern "C" void dnnl_conv2d(float* data, float* weights, float* out, int p_N_,
                    {DNNL_ARG_DST, conv2d_dst_memory}});
   s.wait();
   read_from_dnnl_memory(out, conv2d_dst_memory);
+}
+
+extern "C" void dnnl_conv2d(float* data, float* weights, float* out,
+                            int p_N_, int p_C_, int p_H_, int p_W_,
+                            int p_O_, int p_G_, int p_Ph_, int p_Pw_,
+                            int p_Kh_, int p_Kw_, int p_Sh_, int p_Sw_) {
+  primitive_attr attr;
+  std::vector<float> bias(p_O_, 0);
+  return dnnl_conv2d_common(data, weights, bias.data(), out,
+                            p_N_, p_C_, p_H_, p_W_, p_O_, p_G_,
+                            p_Ph_, p_Pw_, p_Kh_, p_Kw_, p_Sh_, p_Sw_,
+                            attr);
+}
+
+primitive_attr create_attr_with_relu_post_op() {
+  post_ops ops;
+  ops.append_eltwise(1.f, algorithm::eltwise_relu, 0.f, 0.f);
+
+  primitive_attr attr;
+  attr.set_post_ops(ops);
+
+  return attr;
+}
+
+extern "C" void dnnl_fused_conv2d_bias_relu(float* data, float* weights, float* bias, float* out,
+                                            int p_N_, int p_C_, int p_H_, int p_W_, int p_O_,
+                                            int p_G_, int p_Ph_, int p_Pw_, int p_Kh_, int p_Kw_,
+                                            int p_Sh_, int p_Sw_) {
+  return dnnl_conv2d_common(data, weights, bias, out,
+                            p_N_, p_C_, p_H_, p_W_,
+                            p_O_, p_G_, p_Ph_, p_Pw_,
+                            p_Kh_, p_Kw_, p_Sh_, p_Sw_,
+                            create_attr_with_relu_post_op());
 }
 
 extern "C" void dnnl_dense(float* data, float* weight, float* out, int p_B_,

--- a/src/runtime/contrib/dnnl/dnnl_kernel.h
+++ b/src/runtime/contrib/dnnl/dnnl_kernel.h
@@ -38,6 +38,12 @@ extern "C" TVM_DLL void dnnl_conv2d(float* data, float* weights, float* out, int
                                     int p_H_, int p_W_, int p_O_, int p_G_, int p_Ph_, int p_Pw_,
                                     int p_Kh_, int p_Kw_, int p_Sh_, int p_Sw_);
 
+extern "C" TVM_DLL void dnnl_fused_conv2d_bias_relu(float* data, float* weights, float* bias,
+                                                    float* out, int p_N_, int p_C_, int p_H_,
+                                                    int p_W_, int p_O_, int p_G_, int p_Ph_,
+                                                    int p_Pw_, int p_Kh_, int p_Kw_, int p_Sh_,
+                                                    int p_Sw_);
+
 extern "C" TVM_DLL void dnnl_dense(float* data, float* weight, float* out, int p_B_, int p_I_,
                                    int p_O_);
 

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -186,12 +186,6 @@ class ConvBiasAddReLUAnnotator(ExprMutator):
             new_args.append(new_arg)
         return relay.Call(call.op, new_args, call.attrs, call.type_args)
 
-    # def visit_function(self, func):
-    #     print("visiting function")
-    #     new_body = super().visit(func.body)
-    #     return relay.Function(func.params, new_body,
-    #                           func.ret_type, func.type_params, func.attrs)
-
     def visit_call(self, call):
         if call.op.name == "nn.conv2d":
             if self.current_state == self.state.Bias:

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -477,11 +477,11 @@ def test_partition_conv_bias_relu():
 
     def get_layers(prefix, data, in_channel, out_channel,
                    include_bn=True, include_sigmoid=False):
-        weight = relay.const(np.random.randn(out_channel, in_channel, 3, 3))
-        bn_gamma = relay.const(np.random.randn(out_channel))
-        bn_beta = relay.const(np.random.randn(out_channel))
-        bn_mmean = relay.const(np.random.randn(out_channel))
-        bn_mvar = relay.const(np.random.randn(out_channel))
+        weight = relay.var(prefix + "weight")
+        bn_gamma = relay.var(prefix + "bn_gamma")
+        bn_beta = relay.var(prefix + "bn_beta")
+        bn_mmean = relay.var(prefix + "bn_mean")
+        bn_mvar = relay.var(prefix + "bn_var")
 
         layer = relay.nn.conv2d(data=data, weight=weight, kernel_size=(3, 3),
                                 channels=out_channel, padding=(1, 1))
@@ -511,7 +511,7 @@ def test_partition_conv_bias_relu():
         ])
 
         if params != {}:
-            # This is required for constant folding on mobilenet
+            # This is required for constant folding
             mod["main"] = bind_params_by_name(mod["main"], params)
 
         with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
@@ -572,7 +572,7 @@ def test_partition_conv_bias_relu():
     net = get_net()
     mod, params = tvm.relay.testing.create_workload(net)
     ref_mod, ref_params = tvm.relay.testing.create_workload(net)
-    # test_exec(mod, params, ref_mod, ref_params, (1, 16, 224, 224))
+    test_exec(mod, params, ref_mod, ref_params, (1, 16, 224, 224))
 
     mod, params = relay.testing.mobilenet.get_workload()
     ref_mod, ref_params = relay.testing.mobilenet.get_workload()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -555,27 +555,29 @@ def test_partition_conv_bias_relu():
         assert(len(get_partitions(mod)) == 27)
 
     test_partition()
-    test_partition_mobilenet()
+    # test_partition_mobilenet()
 
     # TODO: Enable executor check once the runtime signature issue is resolved
-    # net = get_net()
-    # mod, params = get_partitoned_mod(net)
+    net = get_net()
+    mod, params = tvm.relay.testing.create_workload(net)
+    mod = pre_optimize(mod, params)
+    mod = get_partitoned_mod(mod)
 
-    # ref_mod, params = tvm.relay.testing.create_workload(net)
-    # ishape = (1, 3, 224, 224)
-    # i_data = np.random.randn(*ishape).astype(np.float32)
-    # ref_ex = relay.create_executor("graph", mod=ref_mod, ctx=tvm.cpu(0))
-    # ref_res = ref_ex.evaluate()(i_data, **params)
+    ref_mod, params = tvm.relay.testing.create_workload(net)
+    ishape = (1, 3, 224, 224)
+    i_data = np.random.randn(*ishape).astype(np.float32)
+    ref_ex = relay.create_executor("graph", mod=ref_mod, ctx=tvm.cpu(0))
+    ref_res = ref_ex.evaluate()(i_data, **params)
 
-    # check_result(mod, {"data": i_data},
-    #              ishape, ref_res.asnumpy(), tol=1e-5, params=params)
+    check_result(mod, {"data": i_data},
+                 ishape, ref_res.asnumpy(), tol=1e-5, params=params)
 
 
 if __name__ == "__main__":
-    test_multi_node_compiler()
-    test_extern_ccompiler_single_op()
-    test_extern_ccompiler_default_ops()
-    test_extern_ccompiler()
-    test_extern_dnnl()
-    test_extern_dnnl_mobilenet()
+    # test_multi_node_compiler()
+    # test_extern_ccompiler_single_op()
+    # test_extern_ccompiler_default_ops()
+    # test_extern_ccompiler()
+    # test_extern_dnnl()
+    # test_extern_dnnl_mobilenet()
     test_partition_conv_bias_relu()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -574,10 +574,10 @@ def test_partition_conv_bias_relu():
 
 
 if __name__ == "__main__":
-    # test_multi_node_compiler()
-    # test_extern_ccompiler_single_op()
-    # test_extern_ccompiler_default_ops()
-    # test_extern_ccompiler()
-    # test_extern_dnnl()
-    # test_extern_dnnl_mobilenet()
+    test_multi_node_compiler()
+    test_extern_ccompiler_single_op()
+    test_extern_ccompiler_default_ops()
+    test_extern_ccompiler()
+    test_extern_dnnl()
+    test_extern_dnnl_mobilenet()
     test_partition_conv_bias_relu()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -245,7 +245,6 @@ def check_result(mod, map_inputs, out_shape, result, tol=1e-5, target="llvm",
     def check_graph_runtime_result():
         with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
             json, lib, param = relay.build(mod, target=target, params=params)
-        # print(json)
         lib = update_lib(lib)
         rt_mod = tvm.contrib.graph_runtime.create(json, lib, ctx)
 
@@ -258,7 +257,7 @@ def check_result(mod, map_inputs, out_shape, result, tol=1e-5, target="llvm",
 
         tvm.testing.assert_allclose(out.asnumpy(), result, rtol=tol, atol=tol)
 
-    # check_vm_result()
+    check_vm_result()
     check_graph_runtime_result()
 
 

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -179,7 +179,6 @@ class ConvBiasAddReLUAnnotator(ExprMutator):
 
     def annotate_call(self, call):
         new_args = []
-        has_arg = "nn.conv2d"
         for arg in call.args:
             new_arg = super().visit(arg)
             if call.op.name == "nn.conv2d" or isinstance(new_arg, (relay.expr.Var, relay.expr.Constant)):
@@ -571,9 +570,9 @@ def test_partition_conv_bias_relu():
     test_partition()
     test_partition_mobilenet()
 
-    # net = get_net()
-    # mod, params = tvm.relay.testing.create_workload(net)
-    # ref_mod, ref_params = tvm.relay.testing.create_workload(net)
+    net = get_net()
+    mod, params = tvm.relay.testing.create_workload(net)
+    ref_mod, ref_params = tvm.relay.testing.create_workload(net)
     # test_exec(mod, params, ref_mod, ref_params, (1, 16, 224, 224))
 
     mod, params = relay.testing.mobilenet.get_workload()
@@ -582,10 +581,10 @@ def test_partition_conv_bias_relu():
 
 
 if __name__ == "__main__":
-    # test_multi_node_compiler()
-    # test_extern_ccompiler_single_op()
-    # test_extern_ccompiler_default_ops()
-    # test_extern_ccompiler()
-    # test_extern_dnnl()
-    # test_extern_dnnl_mobilenet()
+    test_multi_node_compiler()
+    test_extern_ccompiler_single_op()
+    test_extern_ccompiler_default_ops()
+    test_extern_ccompiler()
+    test_extern_dnnl()
+    test_extern_dnnl_mobilenet()
     test_partition_conv_bias_relu()


### PR DESCRIPTION
This PR contains
* A custom annotator which detects conv + bias add + relu ops
* An example of applying FoldScaleAxis and FoldConstant to layers of conv + bn + relu to get conv + bias add + relu ops which the annotator can detect (before partitioning)
* dnnl runtime support for conv + bias add + relu op using its [post_ops](https://intel.github.io/mkl-dnn/dev_guide_attributes_post_ops.html) feature.
* Updates on CodegenDNNL which enable translating fused Relay conv + bias add + relu ops to dnnl counterpart.
* Test cases on a simple network and mobilenet which demonstrate features above.

The result of partitioning mobilenet is dumped [here](https://gist.github.com/masahi/df0619d860b61b3cf9d7faad36e43fd7). 

please review @zhiics @comaniac 
