### PR TITLE
Fix demo dockerfile build failed

### DIFF
--- a/docker/Dockerfile.demo_cpu
+++ b/docker/Dockerfile.demo_cpu
@@ -17,7 +17,7 @@
 
 # Minimum docker image for demo purposes
 # prebuilt-image: tvmai/demo-cpu
-FROM tvmai/ci-cpu:v0.52
+FROM tvmai/ci-cpu:v0.54
 
 # Jupyter notebook.
 RUN pip3 install matplotlib Image Pillow jupyter[notebook]

--- a/docker/install/install_tvm_cpu.sh
+++ b/docker/install/install_tvm_cpu.sh
@@ -21,7 +21,7 @@ set -u
 set -o pipefail
 
 cd /usr
-git clone --depth=1 https://github.com/apache/incubator-tvm tvm --recursive
+git clone https://github.com/apache/incubator-tvm tvm --recursive
 cd /usr/tvm
 # checkout a hash-tag
 git checkout 4b13bf668edc7099b38d463e5db94ebc96c80470

--- a/docker/install/install_tvm_gpu.sh
+++ b/docker/install/install_tvm_gpu.sh
@@ -21,7 +21,7 @@ set -u
 set -o pipefail
 
 cd /usr
-git clone --depth=1 https://github.com/apache/incubator-tvm tvm --recursive
+git clone https://github.com/apache/incubator-tvm tvm --recursive
 cd /usr/tvm
 # checkout a hash-tag
 git checkout 4b13bf668edc7099b38d463e5db94ebc96c80470


### PR DESCRIPTION
Fix dockerfile build failed since branch not found 
Error message :
```
loning into '3rdparty/dmlc-core'...
Submodule path '3rdparty/dmlc-core': checked out '808f485387f9a03f78fa9f1159f387d0d91b7a28'
Cloning into '3rdparty/rang'...
Submodule path '3rdparty/rang': checked out 'cabe04d6d6b05356fa8f9741704924788f0dd762'
fatal: reference is not a tree: 4b13bf668edc7099b38d463e5db94ebc96c80470
The command '/bin/sh -c bash /install/install_tvm_cpu.sh' returned a non-zero code: 128
```