### PR TITLE
[AutoTVM] Support to pass additional compiler options

### DIFF
--- a/python/tvm/autotvm/measure/measure.py
+++ b/python/tvm/autotvm/measure/measure.py
@@ -34,7 +34,8 @@ class MeasureInput(namedtuple("MeasureInput", ["target", "task", "config"])):
     """
 
 
-class MeasureResult(namedtuple("MeasureResult", ["costs", "error_no", "all_cost", "timestamp"])):
+class MeasureResult(namedtuple("MeasureResult", ["costs", "error_no", "all_cost", "timestamp",
+                                                 "options"])):
     """
     Stores all the results of a measurement
 
@@ -49,7 +50,10 @@ class MeasureResult(namedtuple("MeasureResult", ["costs", "error_no", "all_cost"
         All cost of this measure, including rpc, compilation, test runs
     timestamp: float
         The absolute time stamp when we finish measurement.
+    options: list of str
+        The compiler option of building
     """
+MeasureResult.__new__.__defaults__ = (None,) * len(MeasureResult._fields)
 
 
 class MeasureErrorNo(object):

--- a/tests/python/unittest/test_autotvm_database.py
+++ b/tests/python/unittest/test_autotvm_database.py
@@ -54,7 +54,7 @@ def test_db_hash():
     res2l = list(tuple(res1))
 
     # set timestamp
-    res2l[-1] = -1
+    res2l[-2] = -1
     res2 = MeasureResult(*res2l)
     _db = database.DummyDatabase()
     _db.flush()
@@ -75,9 +75,9 @@ def test_db_latest_all():
     lis3 = list(tuple(res1))
 
     # set timestamp
-    lis1[-1] = 0.0
-    lis2[-1] = 1.1
-    lis3[-1] = 9999.9999
+    lis1[-2] = 0.0
+    lis2[-2] = 1.1
+    lis3[-2] = 9999.9999
     res1 = MeasureResult(*lis1)
     res2 = MeasureResult(*lis2)
     res3 = MeasureResult(*lis3)


### PR DESCRIPTION
Currently, AutoTVM doesn't support to pass additional compiler options to builder. It works fine on most cases. However, if we use NDK CC, some times we want to specify additional compiler options. For example, another `sysroot`.

After this PR, the user could do like this:

```python
os.environ['TVM_NDK_CC'] = /path/to/ndk_cc
options=['--sysroot=/path/to/sysroot', '-shared', '-fPIC']

tuning_option = {
    // ...
    'measure_option': autotvm.measure_option(
        builder=autotvm.LocalBuilder(
            build_func='ndk' if use_android else 'default', options=options),
       ...
    ),
}
```
@merrymercy @tqchen @ajtulloch would you like to help review it? Thanks.