### PR TITLE
Expose relay BindParamsByName to Python

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -42,6 +42,43 @@ using TargetsMap = Map<tvm::Integer, tvm::Target>;
 using namespace tvm::relay::transform;
 
 /*!
+ * \brief Bind params to function by using name
+ * \param func Relay function
+ * \param params params dict
+ * \return relay::Function
+ */
+relay::Function BindParamsByName(relay::Function func,
+                                 const std::unordered_map<std::string, runtime::NDArray>& params) {
+  std::unordered_map<std::string, relay::Var> name_dict;
+  std::unordered_set<relay::Var, ObjectHash, ObjectEqual> repeat_var;
+  for (auto arg : func->params) {
+    const auto& name = arg->name_hint();
+    if (name_dict.count(name)) {
+      repeat_var.insert(arg);
+    } else {
+      name_dict[name] = arg;
+    }
+  }
+
+  std::unordered_map<relay::Var, Expr, ObjectHash, ObjectEqual> bind_dict;
+  for (auto& kv : params) {
+    if (name_dict.count(kv.first) == 0) {
+      continue;
+    }
+    auto arg = name_dict.at(kv.first);
+    if (repeat_var.count(arg)) {
+      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
+    }
+    bind_dict[arg] = ConstantNode::make(kv.second);
+  }
+  Expr bound_expr = relay::Bind(func, bind_dict);
+  Function ret = Downcast<Function>(bound_expr);
+  CHECK(ret.defined()) << "The returning type is expected to be a Relay Function."
+                       << "\n";
+  return ret;
+}
+
+/*!
  * \brief Output of building module
  *
  */
@@ -248,45 +285,6 @@ class RelayBuildModule : public runtime::ModuleNode {
   }
 
  protected:
-  /*!
-   * \brief Bind params to function by using name
-   * \param func Relay function
-   * \param params params dict
-   * \return relay::Function
-   */
-  relay::Function BindParamsByName(
-      relay::Function func,
-      const std::unordered_map<std::string, runtime::NDArray>& params) {
-    std::unordered_map<std::string, relay::Var> name_dict;
-    std::unordered_set<relay::Var, ObjectHash, ObjectEqual> repeat_var;
-    for (auto arg : func->params) {
-      const auto &name = arg->name_hint();
-      if (name_dict.count(name)) {
-        repeat_var.insert(arg);
-      } else {
-        name_dict[name] = arg;
-      }
-    }
-
-    std::unordered_map<relay::Var, Expr, ObjectHash, ObjectEqual> bind_dict;
-    for (auto &kv : params) {
-      if (name_dict.count(kv.first) == 0) {
-        continue;
-      }
-      auto arg = name_dict.at(kv.first);
-      if (repeat_var.count(arg)) {
-        LOG(FATAL) << "Multiple args in the function have name " << kv.first;
-      }
-      bind_dict[arg] = ConstantNode::make(kv.second);
-    }
-    Expr bound_expr = relay::Bind(func, bind_dict);
-    Function ret = Downcast<Function>(bound_expr);
-    CHECK(ret.defined())
-        << "The returning type is expected to be a Relay Function."
-        << "\n";
-    return ret;
-  }
-
   /*!
    * \brief Optimize a Relay Function.
    *
@@ -520,6 +518,16 @@ runtime::Module RelayBuildCreate() {
 TVM_REGISTER_GLOBAL("relay.build_module._BuildModule")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = RelayBuildCreate();
+});
+
+TVM_REGISTER_GLOBAL("relay.build_module.BindParamsByName")
+.set_body([](TVMArgs args, TVMRetValue* rv) {
+  Map<std::string, Constant> params = args[1];
+  std::unordered_map<std::string, runtime::NDArray> params_;
+  for (const auto& kv : params) {
+    params_[kv.first] = kv.second->data;
+  }
+  *rv = BindParamsByName(args[0], params_);
 });
 
 }  // namespace backend

--- a/tests/python/relay/test_pass_fold_constant.py
+++ b/tests/python/relay/test_pass_fold_constant.py
@@ -18,6 +18,7 @@ import numpy as np
 import tvm
 from tvm import relay
 from tvm.relay import transform
+from tvm.relay.build_module import bind_params_by_name
 
 
 def run_opt_pass(expr, opt_pass):
@@ -161,6 +162,33 @@ def test_fold_full():
     assert relay.analysis.graph_equal(zz, zexpected)
 
 
+def test_fold_batch_norm():
+    remove_bn_pass = transform.Sequential([
+        relay.transform.InferType(),
+        relay.transform.SimplifyInference(),
+        relay.transform.FoldConstant(),
+        relay.transform.FoldScaleAxis(),
+    ])
+
+    data = relay.var("data", relay.TensorType((1, 3, 224, 224), "float32"))
+    weight = relay.var("weight")
+    bn_gamma = relay.var("bn_gamma")
+    bn_beta = relay.var("bn_beta")
+    bn_mmean = relay.var("bn_mean")
+    bn_mvar = relay.var("bn_var")
+
+    conv = relay.nn.conv2d(data=data, weight=weight, kernel_size=(3, 3),
+                           channels=16, padding=(1, 1))
+    bn_output = relay.nn.batch_norm(conv, bn_gamma, bn_beta,
+                                    bn_mmean, bn_mvar)
+
+    mod, params = tvm.relay.testing.create_workload(bn_output[0])
+    mod["main"] = bind_params_by_name(mod["main"], params)
+
+    with relay.build_config(opt_level=3):
+        mod = remove_bn_pass(mod)
+
+
 if __name__ == "__main__":
     test_fold_const()
     test_fold_let()
@@ -168,3 +196,4 @@ if __name__ == "__main__":
     test_fold_concat()
     test_fold_shape_of()
     test_fold_full()
+    test_fold_batch_norm()


### PR DESCRIPTION
Extracted from #4741 per @mbarrett97's suggestion

Expose BindParamsByName in C++ build_module to python. This is run during relay.build_module.optimize, but it is also useful to have in python when assembling custom optimization passes that involve constant folding. This is required for Conv + BN folding to remove BN entirely. 

please review @tqchen @vinx13 @yzhliu @mbarrett97 