### PR TITLE
[REFACTOR] driver.h -> driver_api.h

### DIFF
--- a/include/tvm/driver/driver_api.h
+++ b/include/tvm/driver/driver_api.h
@@ -18,16 +18,16 @@
  */
 
 /*!
- * \file tvm/driver/driver.h
- * \brief Compiler driver utilities.
+ * \file tvm/driver/driver_api.h
+ * \brief Compiler driver APIs to drive the compilation.
  *
  * This module provides end-to-end utils to drive the compilation process.
  * We adopt the term "compiler driver" in common compiler infrastructures.
  * Note that a compiler driver is different from "runtime drivers".
  * Most of runtime related code are defined in the runtime folder instead.
  */
-#ifndef TVM_DRIVER_DRIVER_H_
-#define TVM_DRIVER_DRIVER_H_
+#ifndef TVM_DRIVER_DRIVER_API_H_
+#define TVM_DRIVER_DRIVER_API_H_
 
 #include <tvm/runtime/packed_func.h>
 #include <tvm/target/target.h>
@@ -115,4 +115,4 @@ TVM_DLL runtime::Module build(const Map<std::string, Array<tir::LoweredFunc>>& i
                               const BuildConfig& config);
 }  // namespace tvm
 
-#endif  // TVM_DRIVER_DRIVER_H_
+#endif  // TVM_DRIVER_DRIVER_API_H_

--- a/src/README.md
+++ b/src/README.md
@@ -26,9 +26,10 @@ There can be internal header files within each module that sit in src.
 - node: base infra for IR/AST nodes that is dialect independent.
 - ir: Common IR infrastructure.
 - tir: Tensor-level IR.
+- te: tensor expression DSL
 - arith: Arithmetic expression and set simplification.
-- top: tensor operation DSL for compute and schedule.
 - relay: Relay IR, high-level optimization.
 - autotvm: The auto-tuning module.
 - contrib: Contrib extension libraries.
 - api: API function registration.
+- driver: Compilation driver APIs.

--- a/src/api/api_lang.cc
+++ b/src/api/api_lang.cc
@@ -29,7 +29,7 @@
 #include <tvm/te/schedule.h>
 #include <tvm/runtime/registry.h>
 
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/tir/data_layout.h>
 
 

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -19,10 +19,10 @@
 
 /*!
  *  Compile executable modules.
- * \file driver.cc
+ * \file driver_api.cc
  */
 #include <dmlc/thread_local.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/te/operation.h>
 #include <tvm/tir/ir_pass.h>
 #include <tvm/target/codegen.h>

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -22,7 +22,7 @@
  * \brief Code generation for TVM's graph runtime.
  */
 #include <tvm/relay/analysis.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/vm.h>
 #include <tvm/relay/expr.h>

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -32,7 +32,7 @@
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/op.h>
 #include <tvm/relay/op_attr_types.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 
 #include <topi/tags.h>
 #include <utility>

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -30,7 +30,7 @@
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/attrs/debug.h>
 #include <tvm/relay/feature.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 
 #include "compile_engine.h"
 

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -27,7 +27,7 @@
 #include <dmlc/json.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/type.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/target/codegen.h>
 #include <tvm/tir/ir_pass.h>
 #include <tvm/te/operation.h>

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -31,7 +31,7 @@
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/vm.h>
 #include <tvm/relay/attrs/memory.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 
 #include <iostream>
 #include <memory>

--- a/tests/cpp/build_module_test.cc
+++ b/tests/cpp/build_module_test.cc
@@ -22,7 +22,7 @@
 #include <topi/cuda/injective.h>
 #include <tvm/te/operation.h>
 #include <tvm/runtime/registry.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 
 #include <string>
 #include <cmath>

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -18,7 +18,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/te/operation.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/type.h>

--- a/tests/cpp/relay_transform_sequential.cc
+++ b/tests/cpp/relay_transform_sequential.cc
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <topi/generic/injective.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/relay/expr.h>
 #include <tvm/ir/module.h>
 #include <tvm/relay/analysis.h>

--- a/tests/cpp/utvm_runtime_standalone_test.cc
+++ b/tests/cpp/utvm_runtime_standalone_test.cc
@@ -31,7 +31,7 @@
 
 #include <gtest/gtest.h>
 #include <topi/generic/injective.h>
-#include <tvm/driver/driver.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/te/operation.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr.h>


### PR DESCRIPTION
"driver" normally refers to the "main" function.
Rationale: the header exposes set of APIs to drive compilation
and should be named as driver api to best reflect its usage.

Thanks @u99127 for suggestion, cc @FrozenGene @zhiics @ZihengJiang @yzhliu @liangfu 