### PR TITLE
pooling.cc improvements

### DIFF
--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -134,10 +134,7 @@ bool Pool2DRel(const Array<Type>& types,
     return false;
   }
 
-  std::vector<IndexExpr> oshape;
-  for (const auto& e : dshape) {
-    oshape.push_back(e);
-  }
+  std::vector<IndexExpr> oshape(dshape.begin(), dshape.end());
 
   if (dshape[hidx].as<tir::AnyNode>()) {
     oshape[hidx] = dshape[hidx];
@@ -775,10 +772,7 @@ bool Pool1DRel(const Array<Type>& types,
     return false;
   }
 
-  std::vector<IndexExpr> oshape;
-  for (const auto& e : dshape) {
-    oshape.push_back(e);
-  }
+  std::vector<IndexExpr> oshape(dshape.begin(), dshape.end());
 
   if (dshape[widx].as<tir::AnyNode>()) {
     oshape[widx] = dshape[widx];
@@ -966,12 +960,9 @@ bool Pool3DRel(const Array<Type>& types,
     return false;
   }
 
-  std::vector<IndexExpr> oshape;
-  for (const auto& e : dshape) {
-    oshape.push_back(e);
-  }
+  std::vector<IndexExpr> oshape(dshape.begin(), dshape.end());
 
-  std::vector<int> idxes = {didx, hidx, widx};
+  int idxes[3] = {didx, hidx, widx};
   for (int i = 0; i < 3; i++) {
     int ii = idxes[i];
     if (dshape[ii].as<tir::AnyNode>()) {


### PR DESCRIPTION
Improvements:
1. construct `oshape` vector using `iter.begin()` and `iter.end()` constructor
2. use stack array instead of dyn mem alloc vector if possible.