### PR TITLE
Bump prebuilt-image version in demo dockerfile

### DIFF
--- a/docker/Dockerfile.demo_cpu
+++ b/docker/Dockerfile.demo_cpu
@@ -17,7 +17,7 @@
 
 # Minimum docker image for demo purposes
 # prebuilt-image: tvmai/demo-cpu
-FROM tvmai/ci-cpu:v0.54
+FROM tvmai/ci-cpu:v0.55
 
 # Jupyter notebook.
 RUN pip3 install matplotlib Image Pillow jupyter[notebook]

--- a/docker/Dockerfile.demo_gpu
+++ b/docker/Dockerfile.demo_gpu
@@ -18,7 +18,7 @@
 # Minimum docker image for demo purposes
 # CI docker GPU env
 # tag: v0.54
-FROM tvmai/ci-gpu:v0.54
+FROM tvmai/ci-gpu:v0.55
 
 # Jupyter notebook.
 RUN pip3 install matplotlib Image "Pillow<7" jupyter[notebook]


### PR DESCRIPTION
Update prebuild image version to v0.55 due to v0.54 can't find ppa:jonathonf/python-3.6
This ppa has been removed from public. https://launchpad.net/~jonathonf/+archive/ubuntu/python-3.6

error message :
```
Ign:22 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main all Packages    
Err:25 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages  
  403  Forbidden [IP: 91.189.95.83 80]
Fetched 4461 kB in 11s (400 kB/s)                                                       
Reading package lists... Done
W: The repository 'http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial Release' does not have a Release file.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: Failed to fetch http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu/dists/xenial/main/binary-amd64/Packages  403  Forbidden [IP: 91.189.95.83 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
```