### PR TITLE
[Relay] Added Merge Composite pass

### DIFF
--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -561,6 +561,8 @@ constexpr const char* kParams = "__params__";
 constexpr const char* kExternalSymbol = "ExternalSymbol";
 /*! \brief Mark if the function should be avoided being optimized. */
 constexpr const char* kSkipOptimization = "SkipOptimization";
+/*! \brief Treat the function as a composite operator. */
+constexpr const char* kComposite = "Composite";
 }  // namespace attr
 
 }  // namespace relay

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -513,6 +513,23 @@ def Legalize(legalize_map_attr_name="FTVMLegalize"):
     return _transform.Legalize(legalize_map_attr_name)
 
 
+def MergeComposite(compiler):
+    """Merge multiple operators into a single composite relay function.
+
+    Parameters
+    ----------
+    compiler : str
+        The compiler used for codegen.
+
+    Returns
+    -------
+    ret : tvm.relay.Pass
+        The registered pass that merges operators into a single composite
+        relay function.
+    """
+    return _transform.MergeComposite(compiler)
+
+
 def RewriteAnnotatedOps(fallback_device):
     """Rewrite the annotated program where annotation operators, e.g.
     `on_deivce`, mark which device an expression should be scheduled to.

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -513,13 +513,15 @@ def Legalize(legalize_map_attr_name="FTVMLegalize"):
     return _transform.Legalize(legalize_map_attr_name)
 
 
-def MergeComposite(compiler):
+def MergeComposite(pattern_table):
     """Merge multiple operators into a single composite relay function.
 
     Parameters
     ----------
-    compiler : str
-        The compiler used for codegen.
+    pattern_table : list(tuple)
+        A list of (pattern_name, pattern) tuples.
+        The order of the patterns in the list will determine the order
+        of priority in which they are matched.
 
     Returns
     -------
@@ -527,7 +529,13 @@ def MergeComposite(compiler):
         The registered pass that merges operators into a single composite
         relay function.
     """
-    return _transform.MergeComposite(compiler)
+    pattern_names = []
+    patterns = []
+    for pattern_name, pattern in pattern_table:
+        pattern_names.append(pattern_name)
+        patterns.append(pattern)
+
+    return _transform.MergeComposite(pattern_names, patterns)
 
 
 def RewriteAnnotatedOps(fallback_device):

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -140,12 +140,9 @@ class MergeCompositeWrapper : public ExprMutator {
     if (!call->op->IsInstance<OpNode>())
       return std::move(call);
 
-    Op op = Downcast<Op>(call->op);
-    CHECK(op.defined());
+    // only call patterns are currently supported
     Call pattern = Downcast<Call>(pattern_);
-    if (Downcast<Op>(pattern->op)->name != op->name)
-      return std::move(call);
-
+    CHECK(pattern.defined());
     if (MatchPattern(pattern, call)) {
       Map<std::string, Array<Expr>> args_map;
       auto extract = ExtractPattern(pattern, call, &args_map);

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -140,7 +140,7 @@ class MergeCompositeWrapper : public ExprMutator {
     if (!call->op->IsInstance<OpNode>())
       return std::move(call);
 
-    // only call patterns are currently supported
+    // only call patterns are supported
     Call pattern = Downcast<Call>(pattern_);
     CHECK(pattern.defined());
     if (MatchPattern(pattern, call)) {

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/pass/merge_composite.cc
+ * \brief Merges expressions matching patterns into functions marked
+ * as 'composite'.
+ */
+
+#include <tvm/te/operation.h>
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
+
+namespace tvm {
+namespace relay {
+namespace merge_composite {
+
+
+class MergeCompositeWrapper : public ExprMutator {
+ public:
+  explicit MergeCompositeWrapper(const tvm::Map<std::string, Expr>& pattern_map)
+    : pattern_map_(pattern_map) {}
+
+  bool MatchPattern(const Call& pattern, const Call& root) {
+    if (!pattern->op->IsInstance<OpNode>() || !root->op->IsInstance<OpNode>())
+      return false;
+    if (pattern->op.as<OpNode>()->name != root->op.as<OpNode>()->name)
+      return false;
+    if (pattern->args.size() != root->args.size())
+      return false;
+
+    unsigned int i = 0;
+    for (const auto& arg : pattern->args) {
+      if (arg->IsInstance<CallNode>()) {
+        if (!root->args[i]->IsInstance<CallNode>())
+          return false;
+        if (!MatchPattern(Downcast<Call>(arg), Downcast<Call>(root->args[i])))
+          return false;
+      }
+      i++;
+    }
+    return true;
+  }
+
+  Expr ExtractPattern(const Var& pattern, const Expr& root,
+          Map<std::string, Array<Expr>>* var_map) {
+    if (var_map->find(pattern->name_hint()) == var_map->end()) {
+      auto free_var = VarNode::make(pattern->name_hint(), Type());
+      var_map->Set(pattern->name_hint(), Array<Expr>({free_var, root}));
+      return std::move(free_var);
+    } else {
+      return (*var_map)[pattern->name_hint()][0];
+    }
+  }
+
+  Expr ExtractPattern(const Constant& pattern, const Expr& root,
+          Map<std::string, Array<Expr>>* var_map) {
+    return root;
+  }
+
+  Expr ExtractPattern(const Call& pattern, const Call& root,
+          Map<std::string, Array<Expr>>* var_map) {
+    Expr expr;
+    Expr empty_expr;
+    if (!pattern->op->IsInstance<OpNode>() || !root->op->IsInstance<OpNode>())
+      return empty_expr;
+    if (pattern->op.as<OpNode>()->name != root->op.as<OpNode>()->name)
+      return empty_expr;
+    if (pattern->args.size() != root->args.size())
+      return empty_expr;
+
+    unsigned int i = 0;
+    Array<Expr> new_args;
+    for (const auto& arg : pattern->args) {
+      if (arg->IsInstance<CallNode>()) {
+        new_args.push_back(ExtractPattern(Downcast<Call>(arg),
+                                          Downcast<Call>(root->args[i]),
+                                          var_map));
+      }
+      if (arg->IsInstance<VarNode>()) {
+        new_args.push_back(ExtractPattern(Downcast<Var>(arg),
+                                          root->args[i],
+                                          var_map));
+      }
+      if (arg->IsInstance<ConstantNode>()) {
+        new_args.push_back(ExtractPattern(Downcast<Constant>(arg),
+                                          root->args[i],
+                                          var_map));
+      }
+      i++;
+    }
+
+    auto new_call = CallNode::make(root->op, new_args, root->attrs);
+    return std::move(new_call);
+  }
+
+  Expr VisitExpr_(const CallNode* cn) {
+    Call call = GetRef<Call>(cn);
+    if (call->op->IsInstance<FunctionNode>()) {
+      Function func = Downcast<Function>(call->op);
+      CHECK(func.defined());
+      const auto name_node = FunctionGetAttr(func, attr::kComposite).as<tir::StringImmNode>();
+      if (name_node->value != "") {
+        tvm::Array<tvm::relay::Expr> new_args;
+        for (const auto& arg : call->args) {
+          auto new_e = this->Mutate(arg);
+          new_args.push_back(new_e);
+        }
+        return CallNode::make(call->op, new_args, call->attrs);
+      }
+    }
+
+    Expr expr = ExprMutator::VisitExpr_(cn);
+    call = Downcast<Call>(expr);
+    if (!call->op->IsInstance<OpNode>())
+      return std::move(call);
+
+    Op op = Downcast<Op>(call->op);
+    CHECK(op.defined());
+    for (const auto& x : pattern_map_) {
+      Call pattern = Downcast<Call>(x.second);
+      if (Downcast<Op>(pattern->op)->name != op->name)
+        continue;
+
+      if (MatchPattern(pattern, call)) {
+        Map<std::string, Array<Expr>> args_map;
+        auto extract = ExtractPattern(pattern, call, &args_map);
+        auto free_vars = FreeVars(extract);
+        Function new_func = FunctionNode::make(free_vars, extract,
+                call->checked_type_, {}, Attrs());
+        new_func = FunctionSetAttr(new_func, attr::kComposite,
+                                   tir::StringImmNode::make(x.first));
+        new_func = FunctionSetAttr(new_func, attr::kPrimitive,
+            tvm::Integer(1));
+        Array<Expr> args;
+        for (const auto& free_var : free_vars) {
+          args.push_back(args_map[free_var->name_hint()][1]);
+        }
+        auto new_call = CallNode::make(new_func, args);
+        return std::move(new_call);
+      }
+    }
+
+    return std::move(call);
+  }
+
+ private:
+  tvm::Map<std::string, Expr> pattern_map_;
+};
+
+Expr MergeComposite(const Expr& expr, const tvm::Map<std::string, Expr>& pattern) {
+  return MergeCompositeWrapper(pattern).Mutate(expr);
+}
+
+}  // namespace merge_composite
+
+namespace transform {
+
+Pass MergeComposite(const tvm::Map<std::string, Expr>& pattern) {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        return Downcast<Function>(relay::merge_composite::MergeComposite(f, pattern));
+      };
+  auto func_pass = CreateFunctionPass(pass_func, 0, "MergeComposite", {});
+  return func_pass;
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.MergeComposite")
+.set_body_typed(MergeComposite);
+
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -50,6 +50,13 @@ class MergeCompositeWrapper : public ExprMutator {
       return std::move(free_var);
     } else {
       // if we have encountered this var already, return the free var that was created
+      auto vars = (*var_map)[pattern->name_hint()];
+      auto free_var = vars[0];
+      auto graph_expr = vars[1];
+      // make sure to first check they both map to the same node in the graph
+      if (graph_expr != root) {
+        return Expr();
+      }
       return (*var_map)[pattern->name_hint()][0];
     }
   }

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -122,7 +122,7 @@ class MergeCompositeWrapper : public ExprMutator {
       CHECK(func.defined());
       const auto name_node = FunctionGetAttr(func, attr::kComposite).as<tir::StringImmNode>();
       // don't step into existing composite functions
-      if (name_node->value != "") {
+      if (name_node && name_node->value != "") {
         tvm::Array<tvm::relay::Expr> new_args;
         for (const auto& arg : call->args) {
           auto new_e = this->Mutate(arg);

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -59,7 +59,14 @@ class MergeCompositeWrapper : public ExprMutator {
     return root;
   }
 
-  /* How does this work?
+  /*!
+   * \brief Try and extract a given pattern from a graph as a subgraph.
+   * \param pattern The pattern to extract.
+   * \param root The graph to extract from.
+   * \param var_map A map between free vars in the subgraph and nodes in the graph.
+   * \return The extracted subgraph.
+   *
+   * \note How does this work?
    *
    * A pattern consists of Relay expression containing only operator call nodes, constants
    * and free variables. The free variables indicate where the pattern can 'attach' in your

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -131,7 +131,6 @@ class MergeCompositeWrapper : public ExprMutator {
       auto new_call = CallNode::make(f, args);
       return std::move(new_call);
     }
-
     return std::move(call);
   }
 

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -85,7 +85,6 @@ class MergeCompositeWrapper : public ExprMutator {
 
   Expr ExtractPattern(const Call& pattern, const Call& root,
           Map<std::string, Array<Expr>>* var_map) {
-    Expr expr;
     Expr empty_expr;
     if (!pattern->op->IsInstance<OpNode>() || !root->op->IsInstance<OpNode>())
       return empty_expr;

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -86,6 +86,10 @@ class MergeCompositeWrapper : public ExprMutator {
     for (const auto& arg : pattern->args) {
       Expr new_arg;
       if (arg->IsInstance<CallNode>()) {
+        // fail if the root argument is not also a call node
+        if (!root->args[i]->IsInstance<CallNode>()) {
+          return Expr();
+        }
         // if it's a call node, recursively call this function
         new_arg = ExtractPattern(Downcast<Call>(arg),
                                  Downcast<Call>(root->args[i]),

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -35,7 +35,6 @@ namespace tvm {
 namespace relay {
 namespace merge_composite {
 
-
 class MergeCompositeWrapper : public ExprMutator {
  public:
   explicit MergeCompositeWrapper(const std::string& pattern_name, const Expr& pattern)

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -147,17 +147,15 @@ class MergeCompositeWrapper : public ExprMutator {
       Map<std::string, Array<Expr>> args_map;
       auto extract = ExtractPattern(pattern, call, &args_map);
       auto free_vars = FreeVars(extract);
-      Function new_func = FunctionNode::make(free_vars, extract,
-              call->checked_type_, {}, Attrs());
-      new_func = FunctionSetAttr(new_func, attr::kComposite,
-                                 tir::StringImmNode::make(pattern_name_));
-      new_func = FunctionSetAttr(new_func, attr::kPrimitive,
-          tvm::Integer(1));
+      // make the composite function
+      auto f = FunctionNode::make(free_vars, extract, call->checked_type_, {}, Attrs());
+      f = FunctionSetAttr(f, attr::kComposite, tir::StringImmNode::make(pattern_name_));
+      f = FunctionSetAttr(f, attr::kPrimitive, tvm::Integer(1));
       Array<Expr> args;
       for (const auto& free_var : free_vars) {
         args.push_back(args_map[free_var->name_hint()][1]);
       }
-      auto new_call = CallNode::make(new_func, args);
+      auto new_call = CallNode::make(f, args);
       return std::move(new_call);
     }
 

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -169,7 +169,7 @@ class MergeCompositeWrapper : public ExprMutator {
 
 Expr MergeComposite(const Expr& expr,
     const Array<tir::StringImm>& pattern_names, const Array<Expr>& patterns) {
-  CHECK(pattern_names.size() == patterns.size());
+  CHECK_EQ(pattern_names.size(), patterns.size());
   Expr merged_expr = expr;
   // merge the patterns one-by-one in order
   for (size_t i = 0; i < patterns.size(); i++) {

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -114,7 +114,6 @@ class MergeCompositeWrapper : public ExprMutator {
       new_args.push_back(new_arg);
       i++;
     }
-
     return CallNode::make(root->op, new_args, root->attrs);
   }
 

--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -85,11 +85,10 @@ class MergeCompositeWrapper : public ExprMutator {
 
   Expr ExtractPattern(const Call& pattern, const Call& root,
           Map<std::string, Array<Expr>>* var_map) {
+    // check to make sure both calls are to operators (not functions)
     if (!pattern->op->IsInstance<OpNode>() || !root->op->IsInstance<OpNode>())
       return Expr();
     if (pattern->op.as<OpNode>()->name != root->op.as<OpNode>()->name)
-      return Expr();
-    if (pattern->args.size() != root->args.size())
       return Expr();
 
     unsigned int i = 0;

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -268,7 +268,7 @@ def test_multiple_patterns():
         add_node = relay.add(relu_node, a)
         relu_node_2 = relay.nn.relu(add_node)
         r = relay.multiply(relu_node_2, b)
-        return relay.Function([data, kernel, bias], r)
+        return relay.Function([data, kernel, bias, a, b], r)
 
     def expected():
         data = relay.var('data', shape=(1, 512, 28, 28))

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for merge composite."""
+from tvm import relay
+from tvm.relay.testing import run_opt_pass
+
+
+def make_add_sub_mul_pattern():
+    """Create a pattern to match the following graph.
+
+        add  sub
+         \   /
+          \ /
+          mul
+    """
+    x = relay.var('x')
+    y = relay.var('y')
+    add_node = relay.add(x, y)
+    sub_node = relay.subtract(x, y)
+    mul_node = relay.multiply(add_node, sub_node)
+    return mul_node
+
+
+def make_add_relu_pattern():
+    """Create a pattern to match the following graph.
+
+        add
+         |
+       ReLu
+    """
+    x = relay.var('x')
+    y = relay.var('y')
+    add_node = relay.add(x, y)
+    r = relay.nn.relu(add_node)
+    return r
+
+
+def test_simple_merge():
+    """Test composite function is correctly produced from simple graph.
+
+    We could expect the pattern `make_add_relu_pattern` to be merged
+    into a single op `add_relu`.
+
+        a  b
+        \ /               a  b
+        add    ====>      \ /
+         |             add_relu
+       ReLu
+
+    """
+    pattern_table = {
+        "add_sub_mul": make_add_relu_pattern()
+    }
+
+    def before():
+        a = relay.var('a', shape=(10, 10))
+        b = relay.var('b', shape=(10, 10))
+        add_node = relay.add(a, b)
+        r = relay.nn.relu(add_node)
+        return relay.Function([a, b], r)
+
+    def expected():
+        a = relay.var('a', shape=(10, 10))
+        b = relay.var('b', shape=(10, 10))
+
+        # add_relu function
+        in_1 = relay.var('in_1', shape=(10, 10))
+        in_2 = relay.var('in_2', shape=(10, 10))
+        add_node = relay.add(in_1, in_2)
+        relu_node = relay.nn.relu(add_node)
+        add_relu = relay.Function([in_1, in_2], relu_node)
+
+        # merged function
+        r = relay.Call(add_relu, [a, b])
+        return relay.Function([a, b], r)
+
+    result = run_opt_pass(before(), relay.transform.MergeComposite(pattern_table))
+    expected = run_opt_pass(expected(), relay.transform.InferType())
+    assert relay.analysis.alpha_equal(result, expected)
+
+
+def test_branch_merge():
+    """Test composite function is correctly produced from branching graph.
+
+    We would expect the pattern `make_add_sub_mul_pattern` to be merged
+    into a single op `add_sub_mul`.
+
+       a  b  a  b
+        \/    \/
+        add  sub                       a  b
+         \   /                          \/
+          \ /                      add_sub_mul
+          mul                     c     |
+          /  \                     \    |
+       c /  c |       ====>        add_sub_mul
+       \/   \/                          |
+       add  sub                         |
+        \   /                         ReLu
+         \ /
+         mul
+          |
+          |
+        ReLu
+    """
+
+    pattern_table = {
+        "add_sub_mul": make_add_sub_mul_pattern()
+    }
+
+    def before():
+        a = relay.var('a', shape=(10, 10))
+        b = relay.var('b', shape=(10, 10))
+        c = relay.var('c', shape=(10, 10))
+        add_node = relay.add(a, b)
+        sub_node = relay.subtract(a, b)
+        mul_node = relay.multiply(add_node, sub_node)
+        add_node_2 = relay.add(c, mul_node)
+        sub_node_2 = relay.subtract(c, mul_node)
+        mul_node_2 = relay.multiply(add_node_2, sub_node_2)
+        r = relay.nn.relu(mul_node_2)
+        return relay.Function([a, b, c], r)
+
+    def expected():
+        a = relay.var('a', shape=(10, 10))
+        b = relay.var('b', shape=(10, 10))
+        c = relay.var('c', shape=(10, 10))
+
+        # add_sub_mul function
+        in_1 = relay.var('in_1', shape=(10, 10))
+        in_2 = relay.var('in_2', shape=(10, 10))
+        add_node = relay.add(in_1, in_2)
+        sub_node = relay.subtract(in_1, in_2)
+        mul_node = relay.multiply(add_node, sub_node)
+        add_sub_mul = relay.Function([in_1, in_2], mul_node)
+
+        # merged function
+        add_sub_mul_1 = relay.Call(add_sub_mul, [a, b])
+        add_sub_mul_2 = relay.Call(add_sub_mul, [c, add_sub_mul_1])
+        r = relay.nn.relu(add_sub_mul_2)
+        return relay.Function([a, b, c], r)
+
+    result = run_opt_pass(before(), relay.transform.MergeComposite(pattern_table))
+    expected = run_opt_pass(expected(), relay.transform.InferType())
+    assert relay.analysis.alpha_equal(result, expected)


### PR DESCRIPTION
This adds a pass, MergeComposite, which merges patterns (expressed as Relay expressions). The detected patterns are wrapped in a function call which is marked with a 'Composite' attribute that names the pattern.

This is primarily for use with the external codegen infrastructure in the case where a combination of Relay ops map to a single external codegen op. It is not the same as fusion.

Further discussion on this PR can be found at https://discuss.tvm.ai/t/rfc-external-codegen-defining-composite-relay-operators/5470.