### PR TITLE
[QNN] Add missing nullptr check

### DIFF
--- a/src/relay/qnn/op/add.cc
+++ b/src/relay/qnn/op/add.cc
@@ -55,6 +55,7 @@ Expr QnnAddCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   // Get the input dtype and shape.
   CHECK_EQ(arg_types.size(), 9);
   auto tensor_type = arg_types[0].as<TensorTypeNode>();
+  CHECK(tensor_type != nullptr);
   auto input_dtype = tensor_type->dtype;
   auto input_shape = tensor_type->shape;
 

--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -39,6 +39,7 @@ bool DequantizeRel(const Array<Type>& types,
                    const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 4);
   const auto* data = types[0].as<TensorTypeNode>();
+  CHECK(data != nullptr);
   const auto input_dtype = data->dtype;
   CHECK(input_dtype == DataType::Int(8) ||
         input_dtype == DataType::UInt(8) ||

--- a/src/relay/qnn/op/mul.cc
+++ b/src/relay/qnn/op/mul.cc
@@ -55,6 +55,7 @@ Expr QnnMulCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   // Get the input dtype and shape.
   CHECK_EQ(arg_types.size(), 9);
   auto tensor_type = arg_types[0].as<TensorTypeNode>();
+  CHECK(tensor_type != nullptr);
   auto input_dtype = tensor_type->dtype;
   auto input_shape = tensor_type->shape;
 

--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -41,6 +41,7 @@ bool QuantizeRel(const Array<Type>& types,
                  const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 4);
   const auto* data = types[0].as<TensorTypeNode>();
+  CHECK(data != nullptr);
   const auto input_dtype = data->dtype;
   CHECK(input_dtype == DataType::Float(32))
     << "Input type should be one of float32 but was " <<  input_dtype;

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -169,6 +169,7 @@ bool RequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                    const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 6);
   const auto* data = types[0].as<TensorTypeNode>();
+  CHECK(data != nullptr);
   const auto in_dtype = data->dtype;
   CHECK(in_dtype == DataType::Int(8) ||
         in_dtype == DataType::UInt(8) ||


### PR DESCRIPTION
I got segfault during my development and I had to use gdb to know that segfault came from nullptr access in requantize.

@anijain2305 @vinx13 please review