### PR TITLE
[Relay][Frontend][ONNX] Broadcast condition, x, and y for Where op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1117,13 +1117,13 @@ class Where(OnnxOpConverter):
         shapes = [condition_shape, x_shape, y_shape]
         shape_lens = [len(shape) for shape in shapes]
         max_size = max(shape_lens)
-        max_size_idxs = [i for i,x in enumerate(shape_lens) if x == max_size]
+        max_size_idxs = [i for i, x in enumerate(shape_lens) if x == max_size]
         broadcast_idx = max_size_idxs[0]
         if len(max_size_idxs) > 1:
             for idx in max_size_idxs:
                 if 1 not in shapes[idx]:
                     broadcast_idx = idx
-        
+
         broadcast_shape = shapes[broadcast_idx]
 
         if condition_shape != broadcast_shape:

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1684,6 +1684,17 @@ def test_where():
     outdata = np.where(condition, x, y)
     verify_where(condition, x, y, TensorProto.FLOAT, outdata)
 
+    x = np.array([2], dtype=np.float32)
+    y = np.array(1, dtype=np.float32)
+    outdata = np.where(condition, x, y)
+    verify_where(condition, x, y, TensorProto.FLOAT, outdata)
+
+    condition = np.array(1, dtype=np.bool)
+    x = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    y = np.array([[9, 8], [7, 6]], dtype=np.float32)
+    outdata = np.where(condition, x, y)
+    verify_where(condition, x, y, TensorProto.FLOAT, outdata)
+
 
 def verify_or(indata, dtype):
     x = indata[0].astype(dtype)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1691,7 +1691,12 @@ def test_where():
 
     condition = np.array(1, dtype=np.bool)
     x = np.array([[1, 2], [3, 4]], dtype=np.float32)
-    y = np.array([[9, 8], [7, 6]], dtype=np.float32)
+    y = np.array([[5, 6], [7, 8]], dtype=np.float32)
+    outdata = np.where(condition, x, y)
+    verify_where(condition, x, y, TensorProto.FLOAT, outdata)
+
+    x = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    y = np.array([[1], [7]], dtype=np.float32)
     outdata = np.where(condition, x, y)
     verify_where(condition, x, y, TensorProto.FLOAT, outdata)
 


### PR DESCRIPTION
ONNX's `Where` operator can broadcast the condition, x, and y tensors. The current implementation will only broadcast x and y.

This change will try to find the best shape to broadcast to (longest and doesn't have 1 as a dimension), and will broadcast all tensors to that shape.

@jwfromm would you be able to take a look?