### PR TITLE
[AUTOTVM] Fix a bug in generating the search space

### DIFF
--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -226,7 +226,9 @@ class SplitSpace(TransformSpace):
     def _generate_space(self, now, tmp_stack, enforce_no_tail=False):
         """Generate space by DFS"""
         if now == self.num_output - 1:
-            prod = np.prod(tmp_stack, dtype=np.int64)
+            prod = functools.reduce(lambda x, y: x * y, tmp_stack)
+            if prod > self.product:
+                return
             if self.product % prod == 0 or (not enforce_no_tail and prod < self.product):
                 self.entities.append(SplitEntity([-1] + tmp_stack[::-1]))
         else:

--- a/tests/python/unittest/test_autotvm_space.py
+++ b/tests/python/unittest/test_autotvm_space.py
@@ -62,6 +62,21 @@ def test_split():
     cfg.define_split('tile_c', cfg.axis(224), policy='verbose', num_outputs=3)
     assert len(cfg.space_map['tile_c']) == 84
 
+    # Count the number of non-negative integer solutions of a + b + c + d = n
+    def count4(n):
+        cnt = 0
+        for a in range(0, n + 1):
+            for b in range(0, n - a + 1):
+                cnt += n - a - b + 1
+        return cnt
+
+    # test overflow
+    n = 25
+    cfg = ConfigSpace()
+    cfg.define_split('x', cfg.axis(2**n), policy='factors', num_outputs=4)
+    # count4(25) is 3276.
+    assert len(cfg.space_map['x']) == count4(n)
+
     # test fallback
     cfg = FallbackConfigEntity()
     cfg.define_split('tile_n', cfg.axis(128), num_outputs=3)


### PR DESCRIPTION
- Do not use numpy.prod which ignores integer (64 bits) overflows.
  This leads to an incorrect number of points in the search space.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
