### PR TITLE
[AutoTVM] Ignore error when removing tmpdir

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -93,7 +93,7 @@ class LocalBuilder(Builder):
     def build(self, measure_inputs):
         results = []
 
-        shutil.rmtree(self.tmp_dir)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
         self.tmp_dir = tempfile.mkdtemp()
 
         for i in range(0, len(measure_inputs), self.n_parallel):


### PR DESCRIPTION
Sometimes the tmpdir drops for some reasons. For example, /tmp is cleaned by someone or similar situations. Anyhow, it seems to me that the use of `rmtree` should be error-free.

@merrymercy could you help review? Thanks.