### PR TITLE
Make sure to visit the arguments of inlined functions

### DIFF
--- a/src/relay/backend/vm/inline_primitives.cc
+++ b/src/relay/backend/vm/inline_primitives.cc
@@ -87,12 +87,22 @@ struct PrimitiveInliner : ExprMutator {
 
     if (auto func = op.as<FunctionNode>()) {
       if (func->IsPrimitive()) {
-        return CallNode::make(GetRef<Function>(func), call->args, call->attrs, call->type_args);
+        tvm::Array<Expr> call_args;
+        for (auto arg : call->args) {
+          auto new_arg = VisitExpr(arg);
+          call_args.push_back(new_arg);
+        }
+        return CallNode::make(GetRef<Function>(func), call_args, call->attrs, call->type_args);
       }
     }
 
     if (auto global = op.as<GlobalVarNode>()) {
-      return CallNode::make(GetRef<GlobalVar>(global), call->args, call->attrs, call->type_args);
+      tvm::Array<Expr> call_args;
+      for (auto arg : call->args) {
+        auto new_arg = VisitExpr(arg);
+        call_args.push_back(new_arg);
+      }
+      return CallNode::make(GetRef<GlobalVar>(global), call_args, call->attrs, call->type_args);
     }
 
     return ExprMutator::VisitExpr_(call);


### PR DESCRIPTION
This is a potential fix for #4758 

I found out what causes the issue.  The module I test with has two CallNode expressions that reference the match clause: `%5 = @fn(%4);` and  `add(%2, %5)`.

One of these uses the GlobalVarNode path at line https://github.com/apache/incubator-tvm/blob/master/src/relay/backend/vm/inline_primitives.cc#L94 which doesn't visit its arguments but just uses them directly from the original expression.

The other uses the default path at the end of the CallNode visitor which does visit its arguments, clones the match and uses it for the new call node it returns.

My fix is to always visit the arguments so that all path use the same "version" of the expressions.