### PR TITLE
[Python] Replace os.path.exists with try...except...else

### DIFF
--- a/python/tvm/contrib/pickle_memoize.py
+++ b/python/tvm/contrib/pickle_memoize.py
@@ -40,8 +40,12 @@ class Cache(object):
     cache_by_key = {}
     def __init__(self, key, save_at_exit):
         cache_dir = ".pkl_memoize_py{0}".format(sys.version_info[0])
-        if not os.path.exists(cache_dir):
+        try:
             os.mkdir(cache_dir)
+        except FileExistsError:
+            pass
+        else:
+            self.cache = {}
         self.path = os.path.join(cache_dir, key)
         if os.path.exists(self.path):
             try:


### PR DESCRIPTION
Hit this error when I was running tests on servers.
```
FileExistsError: [Errno 17] File exists: '.pkl_memoize_py3'
```
From the Python documentation of (os.path.exists())[https://docs.python.org/dev/library/os.path.html#os.path.exists], it says that there are specific cases in which a file or folder exists but os.path.exists() returns false:
```
Return True if path refers to an existing path or an open file descriptor. Returns False for broken symbolic links. On some platforms, this function may return False if permission is not granted to execute os.stat() on the requested file, even if the path physically exists.
```
The error went away after I changed it to `try...except...else`.