### PR TITLE
[TOPI][x86] Injective schedule improvement

### DIFF
--- a/topi/python/topi/x86/injective.py
+++ b/topi/python/topi/x86/injective.py
@@ -45,10 +45,12 @@ def schedule_injective_from_existing(sch, out):
         sch[out].parallel(fused)
     elif len(sch[out].op.axis) >= 1:
         sch[out].parallel(sch[out].op.axis[0])
+
     # Vectorize the inner most for loop. Tiling first to get a const extent
-    l = sch[out].op.axis[-1]
-    _, li = sch[out].split(l, factor=16)
-    sch[out].vectorize(li)
+    if len(sch[out].op.axis) >= 1:
+        l = sch[out].op.axis[-1]
+        _, li = sch[out].split(l, factor=16)
+        sch[out].vectorize(li)
     return sch
 
 @generic.schedule_injective.register(["cpu"])

--- a/topi/python/topi/x86/injective.py
+++ b/topi/python/topi/x86/injective.py
@@ -45,8 +45,10 @@ def schedule_injective_from_existing(sch, out):
         sch[out].parallel(fused)
     elif len(sch[out].op.axis) >= 1:
         sch[out].parallel(sch[out].op.axis[0])
-    # Vectorize the inner most for loop
-    sch[out].vectorize(sch[out].op.axis[-1])
+    # Vectorize the inner most for loop. Tiling first to get a const extent
+    l = sch[out].op.axis[-1]
+    _, li = sch[out].split(l, factor=16)
+    sch[out].vectorize(li)
     return sch
 
 @generic.schedule_injective.register(["cpu"])

--- a/topi/python/topi/x86/injective.py
+++ b/topi/python/topi/x86/injective.py
@@ -45,6 +45,8 @@ def schedule_injective_from_existing(sch, out):
         sch[out].parallel(fused)
     elif len(sch[out].op.axis) >= 1:
         sch[out].parallel(sch[out].op.axis[0])
+    # Vectorize the inner most for loop
+    sch[out].vectorize(sch[out].op.axis[-1])
     return sch
 
 @generic.schedule_injective.register(["cpu"])


### PR DESCRIPTION
While working on quantized mobilenet V2, I saw that pad operator was taking around 25% of total time on cascade lake machine. This PR optimizes the injective schedule by performing vectorization

For following test

Before PR - 80 us
After PR - 5 us

~~~
import numpy as np
import tvm
from tvm import relay
from tvm.relay.op import register_pattern, OpPattern
from tvm.contrib import graph_runtime
from tvm.contrib.debugger import debug_runtime

dtype='uint8'
dshape=(1, 6, 114, 114, 16)

x1 = relay.var("x1", shape=dshape, dtype=dtype)
x2 = relay.nn.pad(x1, pad_width=((0, 0), (0, 0), (1, 1), (1, 1), (0, 0)))

func = relay.Function([x1], x2)
mod = relay.Module.from_expr(func)

with relay.build_config(opt_level=3):
    graph, lib, params = relay.build(mod, target="llvm -mcpu=cascadelake")

ctx = tvm.cpu()
# module = graph_runtime.create(graph, lib, ctx)
module = debug_runtime.create(graph, lib, ctx)
module.run()
~~~


@yzhliu @vinx13 @shoubhik @yidawang please review