### PR TITLE
[Relay] Remove duplicated BindParamByName function in VM compiler

### DIFF
--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -115,16 +115,6 @@ class VMCompiler : public runtime::ModuleNode {
   void Codegen();
 
  protected:
-  /*!
-   * \brief Bind params to function by using name
-   * \param func Relay function
-   * \param params params dict
-   * \return relay::Function
-   */
-  relay::Function BindParamsByName(
-      relay::Function func,
-      const std::unordered_map<std::string, runtime::NDArray>& params);
-
   IRModule OptimizeModule(const IRModule& mod, const TargetsMap& targets);
 
   void PopulateGlobalMap();


### PR DESCRIPTION
`BindParamByName` function is used by both graph codegen and vm, so far they are using duplicated, identical implementations.

 On the graph codegen side, the function was pulled out of `RelayBuildModule` class and became a free function in #4751. I noticed that VM compiler is using the identical function, so I moved `BindParamByName` to backend/utils.h so that it can be used by VM as well.

please review @wweic @icemelon9 @jroesch 