### PR TITLE
Change color channel from BGR to RGB for darknet preprocessing

### DIFF
--- a/python/tvm/relay/testing/darknet.py
+++ b/python/tvm/relay/testing/darknet.py
@@ -60,6 +60,7 @@ def _resize_image(img, w_in, h_in):
 def load_image_color(test_image):
     """To load the image using opencv api and do preprocessing."""
     imagex = cv2.imread(test_image)
+    imagex = cv2.cvtColor(imagex, cv2.COLOR_BGR2RGB)
     imagex = np.array(imagex)
     imagex = imagex.transpose((2, 0, 1))
     imagex = np.divide(imagex, 255.0)


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

In the preprocessing for images in darknet we need to change the color channel from bgr to rgb.