### PR TITLE
[Frontend] Asymmetric padding of convolution support

### DIFF
--- a/python/tvm/relay/frontend/coreml.py
+++ b/python/tvm/relay/frontend/coreml.py
@@ -77,10 +77,7 @@ def _ConvolutionLayerParams(op, inexpr, etab):
             pad_b = valid.paddingAmounts.borderAmounts[0].endEdgeSize
             pad_r = valid.paddingAmounts.borderAmounts[1].endEdgeSize
             if not all(v == 0 for v in (pad_t, pad_l, pad_b, pad_r)):
-                inexpr = _op.nn.pad(data=inexpr, pad_width=((0, 0),
-                                                            (0, 0),
-                                                            (pad_t, pad_b),
-                                                            (pad_l, pad_r)))
+                params['padding'] = (pad_t, pad_l, pad_b, pad_r)
     elif op.WhichOneof('ConvolutionPaddingType') == 'same':
         assert op.same.asymmetryMode == 0, "Only support BOTTOM_RIGHT_HEAVY mode, " \
                                            "which is used by tf/caffe and so on"
@@ -88,11 +85,7 @@ def _ConvolutionLayerParams(op, inexpr, etab):
         strides = params['strides']
         pad_t, pad_b = get_pad_value(H, kernel[0], strides[0])
         pad_l, pad_r = get_pad_value(W, kernel[1], strides[1])
-        inexpr = _op.nn.pad(data=inexpr, pad_width=((0, 0),
-                                                    (0, 0),
-                                                    (pad_t, pad_b),
-                                                    (pad_l, pad_r)))
-
+        params['padding'] = (pad_t, pad_l, pad_b, pad_r)
     else:
         raise NotImplementedError("Valid/Same convolution padding implemented")
 

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -290,15 +290,7 @@ def _convert_convolution(inexpr, keras_layer, etab):
         in_w = keras_layer.input_shape[2]
         pad_t, pad_b = _get_pad_pair(in_h, dilated_kernel_h, stride_h)
         pad_l, pad_r = _get_pad_pair(in_w, dilated_kernel_w, stride_w)
-        if pad_t == pad_b and pad_l == pad_r:
-            params['padding'] = (pad_t, pad_l)
-        elif etab.data_layout == 'NCHW':
-            inexpr = _op.nn.pad(data=inexpr, pad_width=(
-                (0, 0), (0, 0), (pad_t, pad_b), (pad_l, pad_r)))
-        else:
-            inexpr = _op.nn.pad(data=inexpr, pad_width=(
-                (0, 0), (pad_t, pad_b), (pad_l, pad_r), (0, 0)))
-
+        params['padding'] = (pad_t, pad_l, pad_b, pad_r)
     else:
         msg = 'Padding with {} is not supported for operator Convolution ' \
               'in frontend Keras.'
@@ -424,15 +416,7 @@ def _convert_separable_convolution(inexpr, keras_layer, etab):
         in_w = keras_layer.input_shape[2]
         pad_t, pad_b = _get_pad_pair(in_h, kernel_h, stride_h)
         pad_l, pad_r = _get_pad_pair(in_w, kernel_w, stride_w)
-        if pad_t == pad_b and pad_l == pad_r:
-            params0['padding'] = (pad_t, pad_l)
-        elif etab.data_layout == 'NCHW':
-            inexpr = _op.nn.pad(data=inexpr, pad_width=(
-                (0, 0), (0, 0), (pad_t, pad_b), (pad_l, pad_r)))
-        else:
-            inexpr = _op.nn.pad(data=inexpr, pad_width=(
-                (0, 0), (pad_t, pad_b), (pad_l, pad_r), (0, 0)))
-
+        params0['padding'] = (pad_t, pad_l, pad_b, pad_r)
     else:
         msg = 'Padding with {} is not supported for operator Separable ' \
               'Convolution in frontend Keras.'

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1308,13 +1308,7 @@ class OperatorConverter(object):
             pad_left, pad_right = get_pad_value(input_w, dilated_kernel_w, stride_w)
             do_pad = not (pad_top == 0 and pad_bottom == 0 and pad_left == 0 and pad_right == 0)
             if do_pad:
-                pad_value = 0
-                if input_tensor.qnn_params:
-                    pad_value = get_scalar_from_constant(input_tensor.qnn_params['zero_point'])
-                in_expr = _op.nn.pad(data=in_expr, pad_width=((0, 0),
-                                                              (pad_top, pad_bottom),
-                                                              (pad_left, pad_right),
-                                                              (0, 0)), pad_value=float(pad_value))
+                params['padding'] = [pad_top, pad_left, pad_bottom, pad_right]
 
         else:
             raise tvm.error.OpAttributeUnImplemented(


### PR DESCRIPTION
As we have supported asymmetric padding, we could avoid extra `pad` operator in the frontend now. Our tf frontend has done this. This pr complete this support in the tflite / coreml / keras frontend. Existing test files covers new change.

Note: This is not conflict with pr https://github.com/apache/incubator-tvm/pull/4787, which could handle it and legalize it in the topi. Like our MXNet frontend could still keep 2D padding if it doesn't have asymmetric padding. However, like tflite / tf / keras / coreml has asymmetric padding, this pr could make us no extra `pad` operator now and could have better performance described in the rfc https://github.com/apache/incubator-tvm/issues/2682 

@inadob @optima2005 @anijain2305  @Huyuwei Could you help to review this? Thanks.
