### PR TITLE
[TIR] Create a StringImm reference type

### DIFF
--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -337,6 +337,11 @@ class StringImmNode : public PrimExprNode {
   TVM_DECLARE_FINAL_OBJECT_INFO(StringImmNode, PrimExprNode);
 };
 
+class StringImm : public PrimExpr {
+ public:
+  TVM_DEFINE_OBJECT_REF_METHODS(StringImm, PrimExpr, StringImmNode);
+};
+
 /*!
  * \brief Cast value from one data type to another.
  * \note The lanes of value should keep fixed.


### PR DESCRIPTION
This is motivated by the want to send an array of strings across the python/C++ boundary. Arrays only support ObjectRef types and so can't carry StringImmNodes. This creates a string reference type, StringImm, which can be used with tvm::Arrays.