### PR TITLE
[Frontend][ONNX] LSTM Support

### DIFF
--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -16,6 +16,8 @@
 # under the License.
 import numpy as np
 import math
+import onnx
+from onnx import helper, TensorProto, mapping
 import torch
 import torchvision
 import topi
@@ -24,8 +26,6 @@ import tvm
 from tvm import relay
 from tvm.contrib import graph_runtime
 from tvm.relay.testing.config import ctx_list
-import onnx
-from onnx import helper, TensorProto, mapping
 import scipy
 
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1962,6 +1962,80 @@ def test_pooling():
                        auto_pad='SAME_UPPER')
 
 
+def verify_lstm(seq_length, batch_size, input_size, hidden_size, use_bias=False):
+    x_np = np.random.uniform(size=(seq_length, batch_size, input_size)).astype('float32')
+    w_np = np.random.uniform(size=(1, 4*hidden_size, input_size)).astype('float32')
+    r_np = np.random.uniform(size=(1, 4*hidden_size, hidden_size)).astype('float32')
+    if use_bias:
+        b_np = np.random.uniform(size=(1, 8*hidden_size)).astype('float32')
+
+    Y_shape = [seq_length, 1, batch_size, hidden_size]
+    Y_h_shape = [1, batch_size, hidden_size]
+    Y_c_shape = [1, batch_size, hidden_size]
+
+    lstm_node = helper.make_node('LSTM',
+                                 inputs=["X", "W", "R"],
+                                 outputs=["Y", "Y_h", "Y_c"],
+                                 hidden_size=hidden_size)
+
+    graph = helper.make_graph([lstm_node],
+                              "lstm_test",
+                              inputs=[helper.make_tensor_value_info("X", TensorProto.FLOAT, list(x_np.shape)),
+                                      helper.make_tensor_value_info("W", TensorProto.FLOAT, list(w_np.shape)),
+                                      helper.make_tensor_value_info("R", TensorProto.FLOAT, list(r_np.shape))],
+                              outputs=[helper.make_tensor_value_info("Y", TensorProto.FLOAT, list(Y_shape)),
+                                       helper.make_tensor_value_info("Y_h", TensorProto.FLOAT, list(Y_h_shape)),
+                                       helper.make_tensor_value_info("Y_c", TensorProto.FLOAT, list(Y_c_shape))])
+
+    model = helper.make_model(graph, producer_name='lstm_test')
+
+    for target, ctx in ctx_list():
+        onnx_out = get_onnxruntime_output(model, [x_np, w_np, r_np], 'float32')
+        tvm_out = get_tvm_output(
+            model, [x_np, w_np, r_np], target, ctx, [Y_shape, Y_h_shape, Y_c_shape], output_dtype=['float32', 'float32', 'float32'])
+        for o_out, t_out in zip(onnx_out, tvm_out):
+            tvm.testing.assert_allclose(o_out, t_out, rtol=1e-4, atol=1e-4)
+
+
+def test_lstm():
+    # No bias.
+    verify_lstm(seq_length=2,
+                batch_size=1,
+                input_size=16,
+                hidden_size=32,
+                use_bias=False)
+    # large batch.
+    verify_lstm(seq_length=4,
+                batch_size=8,
+                input_size=16,
+                hidden_size=32,
+                use_bias=True)
+    # Non power of two.
+    verify_lstm(seq_length=3,
+                batch_size=3,
+                input_size=16,
+                hidden_size=40,
+                use_bias=True)
+    # Long sequence.
+    verify_lstm(seq_length=8,
+                batch_size=1,
+                input_size=16,
+                hidden_size=32,
+                use_bias=True)
+    # Large hidden.
+    verify_lstm(seq_length=2,
+                batch_size=1,
+                input_size=16,
+                hidden_size=128,
+                use_bias=True)
+    # Large input.
+    verify_lstm(seq_length=2,
+                batch_size=1,
+                input_size=64,
+                hidden_size=32,
+                use_bias=True)
+        
+
 if __name__ == '__main__':
     test_flatten()
     test_reshape()
@@ -2020,3 +2094,4 @@ if __name__ == '__main__':
     test_convtranspose()
     test_unsqueeze_constant()
     test_pooling()
+    test_lstm()

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -16,8 +16,6 @@
 # under the License.
 import numpy as np
 import math
-import onnx
-from onnx import helper, TensorProto, mapping
 import torch
 import torchvision
 import topi
@@ -26,6 +24,8 @@ import tvm
 from tvm import relay
 from tvm.contrib import graph_runtime
 from tvm.relay.testing.config import ctx_list
+import onnx
+from onnx import helper, TensorProto, mapping
 import scipy
 
 


### PR DESCRIPTION
This PR adds LSTM support to the relay Onnx frontend. 

Besides adding the LSTM parser itself, we encountered an issue where for some Onnx operations (like LSTMs) arguments are optional. The current method for passing arguments to converters is just to pack them into a list however as some arguments are optional the position of each input is inconsistent. Instead, we should be using a dictionary mapping input names to their value. However, changing all inputs to a dictionary would require changing all the current operators and present problems with direct Onnx to relay conversions. Our workaround here is to add the `onnx_input` class that can be accessed as a list as we previously did or with input name dictionary style lookup.