### PR TITLE
[Frontend, ONNX] Add Resize op converter

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1395,6 +1395,44 @@ class LSTM(OnnxOpConverter):
         return _expr.TupleWrapper(_expr.Tuple((output, H_t, C_t)), 3)
 
 
+class Resize(OnnxOpConverter):
+    """Operator converter for Resize
+    """
+    @classmethod
+    def _impl_v11(cls, inputs, attr, params):
+        mode = attr.get('mode')
+        if mode == b'nearest':
+            method = "nearest_neighbor"
+        elif mode == b'linear':
+            method = "bilinear"
+        else:
+            raise tvm.error.OpAttributeInvalid(
+                'Value {} in attribute "mode" of operator Resize is not valid.'.format(mode))
+
+        in_size = np.array(infer_shape(inputs[0]))
+        scale = infer_value_simulated(inputs[2], params).asnumpy()
+        if len(inputs) == 4:
+            assert len(scale) == 0, "One of scale or size should be passed, not both."
+            size = infer_value_simulated(inputs[3], params).asnumpy().astype(np.int32)
+        else:
+            assert len(scale) != 0, "One of scale or size should be passed."
+            size = (in_size * scale).astype(np.int32)
+
+        coord_trans = attr.get('coordinate_transformation_mode')
+        if coord_trans in [b'pytorch_half_pixel', b'half_pixel']:
+            coord_trans = "half_pixel"
+        elif coord_trans == b'align_corners':
+            coord_trans = "align_corners"
+        elif coord_trans == b'asymmetric' or method == "nearest_neighbor":
+            coord_trans = "asymmetric"
+        else:
+            raise tvm.error.OpAttributeInvalid(
+                'Unsupported coordinate_transformation_mode: {}'.format(coord_trans))
+        layout = "NCHW"  # ONNX assumes NCHW layout
+        out_size = (size[2], size[3])
+        return _op.image.resize(inputs[0], out_size, layout, method, coord_trans)
+
+
 # compatible operators that do NOT require any conversion.
 _identity_list = []
 
@@ -1523,6 +1561,7 @@ def _get_convert_map(opset):
         'Erf': Erf.get_converter(opset),
         'Where': Where.get_converter(opset),
         'Or': Or.get_converter(opset),
+        'Resize': Resize.get_converter(opset),
     }
 
 


### PR DESCRIPTION
This is a reopening of #4536 now that CI is updated. Parts of #4536 were already merged in #4610, so this PR contains only ONNX resize conversion and tests.

[Here](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Resize) is the spec for ONNX Resize op.

please review @jwfromm @soiferj @icemelon9 @yzhliu 