### PR TITLE
Fixed process termination routine in windows

### DIFF
--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -403,7 +403,10 @@ class Server(object):
         """Terminate the server process"""
         if self.use_popen:
             if self.proc:
-                os.killpg(self.proc.pid, signal.SIGTERM)
+                if platform.system() == "Windows":
+                    os.kill(self.proc.pid, signal.CTRL_C_EVENT)
+                else:
+                    os.killpg(self.proc.pid, signal.SIGTERM) 
                 self.proc = None
         else:
             if self.proc:

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -406,7 +406,7 @@ class Server(object):
                 if platform.system() == "Windows":
                     os.kill(self.proc.pid, signal.CTRL_C_EVENT)
                 else:
-                    os.killpg(self.proc.pid, signal.SIGTERM) 
+                    os.killpg(self.proc.pid, signal.SIGTERM)
                 self.proc = None
         else:
             if self.proc:


### PR DESCRIPTION
This PR addresses and fixes the following error in #4821 
```python
AttributeError: module 'os' has no attribute 'killpg' 
```

