### PR TITLE
[RUNTIME] Fix memory leakage of TVMByteArray

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -875,7 +875,7 @@ class TVMRetValue : public TVMPODValue_ {
   void Clear() {
     if (type_code_ == kTVMNullptr) return;
     switch (type_code_) {
-      case kTVMStr: delete ptr<std::string>(); break;
+      case kTVMStr: case kTVMBytes: delete ptr<std::string>(); break;
       case kTVMPackedFuncHandle: delete ptr<PackedFunc>(); break;
       case kTVMNDArrayHandle: {
         NDArray::FFIDecRef(static_cast<TVMArrayHandle>(value_.v_handle));


### PR DESCRIPTION
TVMByteArray is heavily used to transfer feature data from c++ to python in autotvm.
If you meet out-of-memory error during tuning, it is very likely due to this bug.

cc @tqchen 
