### PR TITLE
[LLVM] Explicit llvm::StringRef to std::string conversion

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -88,7 +88,7 @@ void CodeGenLLVM::InitTarget(llvm::TargetMachine* tm) {
       native_vector_bits_ = 128;
     } else {
       native_vector_bits_ = 128;
-      std::string arch_name = tm->getTargetTriple().getArchName();
+      std::string arch_name = std::string(tm->getTargetTriple().getArchName());
       LOG(WARNING) << "Set native vector bits to be 128 for " << arch_name;
     }
   }
@@ -186,7 +186,7 @@ void CodeGenLLVM::HandleImport(const std::string& code) {
        code.substr(code.length() - 3) == ".bc")) {
     mlib = llvm::parseIRFile(code, err, *ctx_);
     if (mlib.get() == nullptr) {
-      std::string msg = err.getMessage();
+      std::string msg = std::string(err.getMessage());
       LOG(FATAL) << "Fail to load bitcode file " << code << "\n"
                  << "line " << err.getLineNo() << ":" << msg;
     }
@@ -195,7 +195,7 @@ void CodeGenLLVM::HandleImport(const std::string& code) {
         llvm::MemoryBuffer::getMemBuffer(code);
     mlib = llvm::parseIR(*buf, err, *ctx_);
     if (mlib.get() == nullptr) {
-      std::string msg = err.getMessage();
+      std::string msg = std::string(err.getMessage());
       LOG(FATAL) << "Fail to load llvm ir "
                  << "line " << err.getLineNo() << ":" << msg
                  << "\ncontent:\n"  << code;

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -231,7 +231,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
     llvm::SMDiagnostic err;
     module_ = std::move(module);
     if (module_ == nullptr) {
-      std::string msg = err.getMessage();
+      std::string msg = std::string(err.getMessage());
       LOG(FATAL) << "Fail to load module: " << msg;
     }
     std::string target_;
@@ -254,7 +254,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
     llvm::SMDiagnostic err;
     auto module = llvm::parseIRFile(file_name, err, *ctx);
     if (module == nullptr) {
-      std::string msg = err.getMessage();
+      std::string msg = std::string(err.getMessage());
       LOG(FATAL) << "Fail to load ir file " << file_name << "\n"
                  << "line " << err.getLineNo() << ":" << msg;
     }


### PR DESCRIPTION
LLVM recently made the conversion from llvm::StringRef to std::string explicit. See

https://github.com/llvm/llvm-project/commit/adcd02683856c30ba6f349279509acecd90063df
