### PR TITLE
[Relay] Ignore Primitive functions in Visitors

### DIFF
--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -181,6 +181,7 @@ class ExprVisitor
  protected:
   // Internal visiting counter
   std::unordered_map<const Object*, size_t> visit_counter_;
+  bool enter_primitives_ = false;
 };
 
 /*!
@@ -231,6 +232,7 @@ class ExprMutator
  protected:
   /*! \brief Internal map used for memoization. */
   std::unordered_map<Expr, Expr, ObjectHash, ObjectEqual> memo_;
+  bool enter_primitives_ = false;
 };
 
 /*!

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -604,6 +604,7 @@ class TypeInferencer::Resolver : public ExprMutator, PatternMutator {
   Resolver(const std::unordered_map<Expr, ResolvedTypeInfo, ObjectHash, ObjectEqual>& tmap,
            TypeSolver* solver)
     : tmap_(tmap), solver_(solver) {
+    enter_primitives_ = true;
   }
 
   Expr VisitExpr_(const VarNode* op) final {


### PR DESCRIPTION
Primitive functions are not to be modified by passes and as such should be ignored. This commit makes Visitor patterns ignore Primitive functions by default, although this can be overridden by setting enter_primitives=true. One case in which this overriding is necessary is in the type_infer pass.

This is motivated by the discussions [external-codegen-ensure-fuseops-ignores-partitioned-subgraphs](https://discuss.tvm.ai/t/external-codegen-ensure-fuseops-ignores-partitioned-subgraphs/5507) and [external-codegen-how-to-prevent-batch-norm-from-being-decomposed](https://discuss.tvm.ai/t/external-codegen-how-to-prevent-batch-norm-from-being-decomposed/5449).