### PR TITLE
[Topi] Missing header

### DIFF
--- a/topi/include/topi/x86/default.h
+++ b/topi/include/topi/x86/default.h
@@ -27,6 +27,7 @@
 #include <topi/tags.h>
 #include <topi/detail/fuse.h>
 #include <tvm/te/operation.h>
+#include <tvm/te/schedule_pass.h>
 #include <tvm/target/generic_func.h>
 
 namespace topi {


### PR DESCRIPTION
Fix compilation error with clang:
```
tvm/tvm/topi/include/topi/x86/default.h:58:14: error: no type named 'AutoInlineInjective' in namespace 'tvm::te'
    tvm::te::AutoInlineInjective(s);
    ~~~~~~~~~^
1 error generated.
```