### PR TITLE
[Relay][SimplifyInference] Express Softmax as sequence of Relay ops

### DIFF
--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -533,6 +533,15 @@ static inline Expr Sum(Expr data, Array<Integer> axis, bool keepdims, bool exclu
   return CallNode::make(op, {data}, Attrs(attrs), {});
 }
 
+static inline Expr Max(Expr data, Array<Integer> axis, bool keepdims, bool exclude) {
+  auto attrs = make_object<ReduceAttrs>();
+  attrs->axis = std::move(axis);
+  attrs->keepdims = keepdims;
+  attrs->exclude = exclude;
+  static const Op& op = Op::Get("max");
+  return CallNode::make(op, {data}, Attrs(attrs), {});
+}
+
 static inline Expr Reshape(Expr data, Array<Integer> newshape) {
   auto attrs = make_object<ReshapeAttrs>();
   attrs->newshape = std::move(newshape);


### PR DESCRIPTION
Discuss - https://discuss.tvm.ai/t/softmax-sequence-of-relay-ops/5686

@soiferj @yzhliu @kevinthesun 

Given that there were previous efforts focused on this. I have done some more comparison

All latencies are in ms.

----------------

CPU - Intel x86 - C5.12x large cascade lake


Case 1 - soiferj@ shape = 1, 12, 128, 128, axis = -1


TVM_NUM_THREADS | Master branch | This PR | Speedup
--|--|--|--
1 | 3.21702 | 3.17762 | 1.0124
2 | 1.60521 | 1.7153 | 0.93582
4 | 0.80477 | 0.98914 | 0.81361
8 | 0.40417 | 0.74009 | 0.54611
16 | 0.4064 | 0.50405 | 0.80626
24 | 0.27334 | 0.50603 | 0.54016

Case 2 - masahi@ shape=(1, 16, 256, 256), axis = 1


TVM_NUM_THREADS | Master branch | This PR | Speedup
--|--|--|--
1 | 2.693 | 2.67314 | 1.00743
2 | 2.69968 | 1.57623 | 1.71274
4 | 2.69336 | 1.0563 | 2.54981
8 | 2.68942 | 0.69915 | 3.84669
16 | 2.68757 | 0.5541 | 4.85034
24 | 2.69724 | 0.43987 | 6.13197



Case 3 - VGG_SSD, shape = (1, 21, 8732), axis = 1


TVM_NUM_THREADS | Master branch | This PR | Speedup
--|--|--|--
1 | 14.81728 | 16.54284 | 0.89569
2 | 14.84842 | 8.9006 | 1.66825
4 | 14.80945 | 5.14822 | 2.87661
8 | 14.78083 | 3.26143 | 4.532
16 | 14.83476 | 2.30334 | 6.44054
24 | 14.86773 | 2.31514 | 6.42196




-----------------



GPU - EC2 G4 instance

Edit - Earlier, I made a mistake in measuring GPU perf.

  | Master branch | This PR | Speedup
-- | -- | -- | --
Case 1 | 0.37284 | 0.03726 | 10.00503
Case 2 | 0.10329 | 0.26443 | 0.39061
Case 3 | 0.02241 | 0.04395 | 0.50989



-------

## Summary
For case 1 on CPU and case 2/3 on GPU, master branch is better performing.

My take on this - We might want to think about design. I think the optimizations that were done for softmax might be possible to do in Relay fusion pass (maybe with some pain).

