### PR TITLE
[WIP] Fixing an Infinite Loop case in UnmatchedChecker.

### DIFF
--- a/src/relay/pass/match_exhaustion.cc
+++ b/src/relay/pass/match_exhaustion.cc
@@ -168,8 +168,10 @@ Array<Pattern> ExpandWildcards(const Pattern& clause_pat,
                                const IRModule& mod) {
   if (auto clause_ctor = clause_pat.as<PatternConstructorNode>()) {
     return ExpandWildcardsConstructor(GetRef<PatternConstructor>(clause_ctor), cand, mod);
+  } else if (auto clause_tup = clause_pat.as<PatternTupleNode>()) {
+    return ExpandWildcardsTuple(GetRef<PatternTuple>(clause_tup), cand, mod);
   } else {
-    return ExpandWildcardsTuple(Downcast<PatternTuple>(clause_pat), cand, mod);
+    return {cand};
   }
 }
 
@@ -201,18 +203,9 @@ Array<Pattern> ExpandWildcardsConstructor(const PatternConstructor& clause_ctor,
   // for constructors, we will expand the wildcards in any field that is an ADT.
   Array<Array<Pattern>> values_by_field;
   for (size_t i = 0; i < ctor_cand->constructor->inputs.size(); i++) {
-    bool subpattern =
-      clause_ctor->patterns[i].as<PatternConstructorNode>() ||
-      clause_ctor->patterns[i].as<PatternTupleNode>();
-    // for non-ADT fields, we can only have a wildcard for the value.
-    if (!subpattern) {
-      values_by_field.push_back({PatternWildcardNode::make()});
-    } else {
-      // otherwise, recursively expand.
-      values_by_field.push_back(ExpandWildcards(clause_ctor->patterns[i],
-                                                ctor_cand->patterns[i],
-                                                mod));
-    }
+    values_by_field.push_back(ExpandWildcards(clause_ctor->patterns[i],
+                                              ctor_cand->patterns[i],
+                                              mod));
   }
 
   // generate new candidates using a cartesian product.
@@ -243,18 +236,9 @@ Array<Pattern> ExpandWildcardsTuple(const PatternTuple& clause_tuple,
   // for constructors, we will expand the wildcards in any field that is an ADT.
   Array<Array<Pattern>> values_by_field;
   for (size_t i = 0; i < tuple_cand->patterns.size(); i++) {
-    bool subpattern =
-      clause_tuple->patterns[i].as<PatternConstructorNode>() ||
-      clause_tuple->patterns[i].as<PatternTupleNode>();
-    // for non-ADT fields, we can only have a wildcard for the value
-    if (!subpattern) {
-      values_by_field.push_back({PatternWildcardNode::make()});
-    } else {
-      // otherwise, recursively expand
-      values_by_field.push_back(ExpandWildcards(clause_tuple->patterns[i],
-                                                tuple_cand->patterns[i],
-                                                mod));
-    }
+    values_by_field.push_back(ExpandWildcards(clause_tuple->patterns[i],
+                                              tuple_cand->patterns[i],
+                                              mod));
   }
 
   // generate new candidates using a cartesian product
@@ -297,10 +281,10 @@ Array<Pattern> UnmatchedCases(const Match& match, const IRModule& mod) {
   while (!candidates.empty()) {
     counter++;
     Pattern cand = candidates.top();
-    if (counter == 1000) {
+    if (counter == 100) {
       CHECK(false);
     }
-    std::cerr << AsText(cand) << std::endl;
+    std::cerr << candidates.size () << AsText(cand) << std::endl;
     candidates.pop();
 
     bool failure = true;
@@ -317,6 +301,7 @@ Array<Pattern> UnmatchedCases(const Match& match, const IRModule& mod) {
       if (check == MatchResult::kUnspecified) {
         auto new_candidates = ExpandWildcards(clause->lhs, cand, mod);
         for (auto candidate : new_candidates) {
+          std::cerr << "new_candidate" << candidate << std::endl;
           candidates.push(candidate);
         }
       }

--- a/src/relay/pass/match_exhaustion.cc
+++ b/src/relay/pass/match_exhaustion.cc
@@ -293,8 +293,14 @@ Array<Pattern> UnmatchedCases(const Match& match, const IRModule& mod) {
 
   Array<Pattern> failures;
 
+  size_t counter = 0;
   while (!candidates.empty()) {
+    counter++;
     Pattern cand = candidates.top();
+    if (counter == 1000) {
+      CHECK(false);
+    }
+    std::cerr << AsText(cand) << std::endl;
     candidates.pop();
 
     bool failure = true;

--- a/src/relay/pass/match_exhaustion.cc
+++ b/src/relay/pass/match_exhaustion.cc
@@ -277,14 +277,8 @@ Array<Pattern> UnmatchedCases(const Match& match, const IRModule& mod) {
 
   Array<Pattern> failures;
 
-  size_t counter = 0;
   while (!candidates.empty()) {
-    counter++;
     Pattern cand = candidates.top();
-    if (counter == 100) {
-      CHECK(false);
-    }
-    std::cerr << candidates.size () << AsText(cand) << std::endl;
     candidates.pop();
 
     bool failure = true;
@@ -301,7 +295,6 @@ Array<Pattern> UnmatchedCases(const Match& match, const IRModule& mod) {
       if (check == MatchResult::kUnspecified) {
         auto new_candidates = ExpandWildcards(clause->lhs, cand, mod);
         for (auto candidate : new_candidates) {
-          std::cerr << "new_candidate" << candidate << std::endl;
           candidates.push(candidate);
         }
       }

--- a/tests/python/relay/test_pass_unmatched_cases.py
+++ b/tests/python/relay/test_pass_unmatched_cases.py
@@ -19,6 +19,7 @@ import tvm
 from tvm import relay
 from tvm.relay.prelude import Prelude
 from tvm.relay.analysis import unmatched_cases
+import pytest
 
 def test_empty_match_block():
     # empty match block will not match anything, so it should return a wildcard pattern
@@ -273,3 +274,27 @@ def test_tuple_match():
     clause = relay.Clause(relay.PatternTuple([relay.PatternVar(a), relay.PatternVar(b)]), a + b)
     x = relay.Match(relay.Tuple([relay.const(1), relay.const(1)]), [clause])
     assert len(unmatched_cases(x)) == 0
+
+
+def test_inf_loop_case():
+    code = """
+v0.0.4
+type Arith[A] {
+    Zero,
+    Const(A),
+    Plus(Arith[A], Arith[A])
+}
+
+def @shallow_opt[A](%a: Arith[A]) -> Arith[A] {
+    match (%a) {
+        Plus(Zero, %r) => %r,
+        Plus(%l, Zero) => %l,
+        _ => %a
+    }
+}
+"""
+    relay.fromtext(code)
+    # fromtext parse the module, then checked it (which include strictness checking).
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
the below code will cause the unmatched case in type checker to hang. The problem is that the expand function will contract but it shouldnt. Will upload a fix tmr.
![%P~A9741EKF$9@6LAV{B ZA](https://user-images.githubusercontent.com/3397377/74515489-837fc700-4ec3-11ea-9513-90fae8a4f428.png)
![W E(V~9 E4DM`BU_U3@GBOE](https://user-images.githubusercontent.com/3397377/74515490-837fc700-4ec3-11ea-9d2d-969511a9be3a.png)
