### PR TITLE
Split node min range is not stringent.

### DIFF
--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -87,10 +87,11 @@ void PassDownDomain(const Stage& stage,
                Range::make_by_min_extent(
                    0, ceil_div(range_parent->extent, r->factor)), actx);
       } else {
-        Update(p_state, r->outer, Range::make_by_min_extent(0, r->nparts), actx);
-        Update(p_state, r->inner,
+        Update(p_state, r->outer,
                Range::make_by_min_extent(
-                   0, ceil_div(range_parent->extent, r->nparts)), actx);
+                   0, minimum_or_later(range_parent->extent, r->nparts)), actx);
+        Update(p_state, r->inner,
+               Range::make_by_min_extent(0, ceil_div(range_parent->extent, r->nparts)), actx);
       }
     } else if (const FuseNode* r = rel.as<FuseNode>()) {
       if (!state.count(r->outer) || !state.count(r->inner)) {

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -62,7 +62,7 @@ void PassDownDomain(const Stage& stage,
     return actx->Simplify(indexdiv(a + (b - 1), b));
   };
 
-  auto minimum = [actx](PrimExpr a, PrimExpr b) {
+  auto minimum_or_later  = [actx](PrimExpr a, PrimExpr b) {
     if (actx->CanProve(a < b)) {
       return actx->Simplify(a);
     }
@@ -82,7 +82,7 @@ void PassDownDomain(const Stage& stage,
       if (r->factor.defined()) {
         Update(p_state, r->inner,
                Range::make_by_min_extent(
-                   0, minimum(range_parent->extent, r->factor)), actx);
+                   0, minimum_or_later(range_parent->extent, r->factor)), actx);
         Update(p_state, r->outer,
                Range::make_by_min_extent(
                    0, ceil_div(range_parent->extent, r->factor)), actx);

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -62,6 +62,13 @@ void PassDownDomain(const Stage& stage,
     return actx->Simplify(indexdiv(a + (b - 1), b));
   };
 
+  auto minimum = [actx](PrimExpr a, PrimExpr b) {
+    if (actx->CanProve(a < b)) {
+      return actx->Simplify(a);
+    }
+    return actx->Simplify(b);
+  };
+
   auto& state = *p_state;
   // forwar iteration on relations
   for (IterVarRelation rel : stage->relations) {
@@ -74,7 +81,8 @@ void PassDownDomain(const Stage& stage,
       const Range& range_parent = state.at(r->parent);
       if (r->factor.defined()) {
         Update(p_state, r->inner,
-               Range::make_by_min_extent(0, r->factor), actx);
+               Range::make_by_min_extent(
+                   0, minimum(range_parent->extent, r->factor)), actx);
         Update(p_state, r->outer,
                Range::make_by_min_extent(
                    0, ceil_div(range_parent->extent, r->factor)), actx);

--- a/tests/python/unittest/test_schedule_bound_inference.py
+++ b/tests/python/unittest/test_schedule_bound_inference.py
@@ -81,6 +81,19 @@ def test_bound_split_divisible():
     assert bounds[xo].extent == m
     assert bounds[xi].extent.value == 8
 
+def test_bound_split_ext_less_than_factor():
+    m = 8
+    I = tvm.placeholder((m,), name='I')
+    EF = tvm.compute((m,), lambda i: I[i] * 2, name = "EF")
+    E = tvm.compute((m,), lambda i: EF[i] * 2, name = "E")
+    s = tvm.create_schedule([E.op])
+    xo, xi = s[E].split(s[E].op.axis[0], factor = 32)
+    s[EF].compute_at(s[E], xo)
+
+    bounds = tvm.schedule.InferBound(s)
+    assert isinstance(bounds, tvm.container.Map)
+    assert bounds[xi].extent.value == m
+
 def test_bound_tile_divisible():
     m = tvm.var('m')
     l = tvm.var('l')
@@ -423,4 +436,5 @@ if __name__ == "__main__":
     test_bound_fusesplit1()
     test_bound_fusesplit2()
     test_bound_split_divisible()
+    test_bound_split_ext_less_than_factor()
     test_bound_tile_divisible()

--- a/tests/python/unittest/test_schedule_tensor_core.py
+++ b/tests/python/unittest/test_schedule_tensor_core.py
@@ -339,8 +339,6 @@ def test_tensor_core_batch_conv():
     ty, yo = s[AS].split(xo, nparts=block_col_warps)
     t = s[AS].fuse(nn, ii)
     to, ti = s[AS].split(t, factor=warp_size)
-    s[AS].bind(tx, thread_y)
-    s[AS].bind(ty, thread_z)
     s[AS].bind(ti, thread_x)
 
     kh, kw, ic, o, ii, oo = WS.op.axis
@@ -348,8 +346,6 @@ def test_tensor_core_batch_conv():
     ty, yo = s[WS].split(xo, nparts=block_col_warps)
     t = s[WS].fuse(ii, oo)
     to, ti = s[WS].split(t, nparts=warp_size)
-    s[WS].bind(tx, thread_y)
-    s[WS].bind(ty, thread_z)
     s[WS].bind(to, thread_x)
     s[WS].vectorize(ti)
 

--- a/topi/python/topi/cuda/conv2d_direct.py
+++ b/topi/python/topi/cuda/conv2d_direct.py
@@ -106,7 +106,6 @@ def schedule_direct_cuda(cfg, s, conv):
         tx, fused = s[load].split(fused, nparts=cfg["tile_x"].size[2])
         s[load].bind(tz, tvm.thread_axis("threadIdx.z"))
         s[load].bind(ty, tvm.thread_axis("threadIdx.y"))
-        s[load].bind(tx, tvm.thread_axis("threadIdx.x"))
 
     # unroll
     s[output].pragma(kernel_scope, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)


### PR DESCRIPTION
Previously, PassDownDomain always sets inner IterVar's extent to the split factor, even when the parent extent is less than the factor (usually happens the parent has been reduced to a single point).  Although predicates are added to guard bounds, unnecessary likely statements are inserted.  They are road blocks for tensorization/intrinsic.
The fix is simple -- set the inner IterVar's ext w/ min(r->factor, parent->range).  Here is an example from the new test:
Before:
```
// attr [EF] storage_scope = "global"
allocate EF[float32 * 8]
produce E {
  produce EF {
    for (i, 0, 8) {
      EF[i] = (I[i]*2f)
    }
  }
  for (i.inner, 0, 32) {
    if (likely((i.inner < 8))) {
      if (likely((i.inner < 8))) {
        EF[i.inner] = (EF[i.inner]*2f)
      }
    }
  }
}
```

After:
```
// attr [EF] storage_scope = "global"
allocate EF[float32 * 8]
produce E {
  produce EF {
    for (i, 0, 8) {
      EF[i] = (I[i]*2f)
    }
  }
  for (i.inner, 0, 8) {
    EF[i.inner] = (EF[i.inner]*2f)
  }
}
```

I also have to update an existing test.  I have confirmed that the test generates expected and even cleaner code (many if statements are gone) with the fix.

