### PR TITLE
improve antlr import error message

### DIFF
--- a/python/tvm/relay/_parser.py
+++ b/python/tvm/relay/_parser.py
@@ -48,19 +48,20 @@ from . import op
 
 PYTHON_VERSION = sys.version_info.major
 try:
-    from .grammar.py3.RelayVisitor import RelayVisitor
-    from .grammar.py3.RelayParser import RelayParser
-    from .grammar.py3.RelayLexer import RelayLexer
-except ImportError:
-    raise Exception("Couldn't find ANTLR parser. Try building with USE_ANTLR=ON.")
-
-try:
     from antlr4 import InputStream, CommonTokenStream
     from antlr4.error.ErrorListener import ErrorListener
 except ImportError:
     raise Exception("Couldn't find ANTLR runtime." +
                     "Try running `pip{version} install antlr4-python{version}-runtime`."
                     .format(version=PYTHON_VERSION))
+
+try:
+    from .grammar.py3.RelayVisitor import RelayVisitor
+    from .grammar.py3.RelayParser import RelayParser
+    from .grammar.py3.RelayLexer import RelayLexer
+except ImportError:
+    raise Exception("Couldn't find ANTLR parser. Try building with USE_ANTLR=ON.")
+
 
 sys.setrecursionlimit(10000)
 


### PR DESCRIPTION
Currently, the error message I get from the parser import failure is confusing.

If I try to use VM functionality, I get an error `Couldn't find ANTLR parser. Try building with USE_ANTLR=ON.` But even if I rebuild TVM with USE_ANTLR=ON, I still get the same error because the generated parser try to import the antlr4 python package that I haven't installed, but the error still says `Try building with USE_ANTLR=ON`. 

This is confusing, I think 
```Python
try:
    from antlr4 import InputStream, CommonTokenStream
    from antlr4.error.ErrorListener import ErrorListener
except ImportError:
    raise Exception("Couldn't find ANTLR runtime." +
                    "Try running `pip{version} install antlr4-python{version}-runtime`."
                    .format(version=PYTHON_VERSION))
```

should come before

```Python
try:
    from .grammar.py3.RelayVisitor import RelayVisitor
    from .grammar.py3.RelayParser import RelayParser
    from .grammar.py3.RelayLexer import RelayLexer
except ImportError:
    raise Exception("Couldn't find ANTLR parser. Try building with USE_ANTLR=ON.")
```
because the latter depends on the antlr4 python package.

please review @wweic @zhiics @icemelon9 