### PR TITLE
[Relay] Fix VM compiler for while loop with free vars 

### DIFF
--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -637,6 +637,9 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
       // emit invoke closure here.
       VisitExpr(GetRef<Var>(var_node));
       Emit(Instruction::InvokeClosure(last_register_, args_registers, NewRegister()));
+    } else if (auto inner_call_node = op.as<CallNode>()) {
+      VisitExpr(GetRef<Call>(inner_call_node));
+      Emit(Instruction::InvokeClosure(last_register_, args_registers, NewRegister()));
     } else {
       // Finally if there are any other cases this is a bug.
       LOG(FATAL) << "internal error: unreachable code,"


### PR DESCRIPTION
This is a fix to the issue reported in 
https://discuss.tvm.ai/t/a-relay-vm-question-while-loop-and-free-vars/5541/

It seems if a recursive function contains free variables, the lambda lift pass (or others) generates nested call nodes, which is not handled by the VM compiler currently. See the test case for a concrete example (`body_with_free_var` triggers the bug).

Actually, the test case added in #4432 by @icemelon9 also triggers the same bug if I create the vm executor on the module in #4432.

please review @icemelon9 @wweic @zhiics @MarisaKirisame 