### PR TITLE
[LLVM] Fix build breaks with StringRef changes

### DIFF
--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -236,7 +236,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
     llvm::SMDiagnostic err;
     std::unique_ptr<llvm::Module> mlib = llvm::parseIRFile(path, err, *ctx);
     if (mlib.get() == nullptr) {
-      std::string msg = err.getMessage();
+      std::string msg(err.getMessage());
       LOG(FATAL) << "Fail to load bitcode file " << path << "\n"
                  << "line " << err.getLineNo() << ":" << msg;
     }

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -215,7 +215,7 @@ runtime::Module BuildNVPTX(Array<LoweredFunc> funcs, std::string target) {
       llvm::SMDiagnostic err;
       std::unique_ptr<llvm::Module> mlib = llvm::parseIRFile(path, err, *ctx);
       if (mlib.get() == nullptr) {
-        std::string msg = err.getMessage();
+        std::string msg(err.getMessage());
         LOG(FATAL) << "Fail to load bitcode file " << path << "\n"
                    << "line " << err.getLineNo() << ":" << msg;
       }

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -239,7 +239,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
     if (mtarget != nullptr) {
       llvm::MDString* pstr = llvm::dyn_cast<llvm::MDString>(mtarget);
       CHECK(pstr != nullptr);
-      target_ = pstr->getString();
+      target_ = pstr->getString().str();
     } else {
       std::ostringstream os;
       os << "llvm -target " << module_->getTargetTriple();


### PR DESCRIPTION
- llvm::StringRef to std::string conversion is explicit now.

Signed-off-by: Wei Pan <wpan11nv@nvidia.com>

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
