### PR TITLE
[WIP][Relay][fix] fix alpha_equal commutativity

### DIFF
--- a/src/relay/ir/alpha_equal.cc
+++ b/src/relay/ir/alpha_equal.cc
@@ -153,8 +153,9 @@ class AlphaEqualHandler:
       if (it != equal_map_.end()) {
         return it->second.same_as(rhs);
       }
-      if (this->VisitExpr(lhs, rhs)) {
+      if (this->VisitExpr(lhs, rhs) && equal_map_.find(rhs) == equal_map_.end()) {
         equal_map_[lhs] = rhs;
+        equal_map_[rhs] = lhs;
         return true;
       } else {
         return false;

--- a/tests/python/relay/test_pass_alpha_equal.py
+++ b/tests/python/relay/test_pass_alpha_equal.py
@@ -670,6 +670,18 @@ def test_fn_attribute():
     assert not relay.analysis.alpha_equal(add_1_fn, add_fn)
     assert not relay.analysis.alpha_equal(add_fn, add_1_fn)
 
+def test_commutative():
+    # create function performs add
+    x = relay.var('x', shape=(10,10))
+    y1 = relay.add(x, x)
+    z1 = relay.add(y1, y1)
+
+    # create function that is computationally the same, structually different
+    y2 = relay.add(x, x)
+    y3 = relay.add(x, x)
+    z2 = relay.add(y2, y3)
+
+    assert relay.analysis.alpha_equal(z1, z2) == relay.analysis.alpha_equal(z2, z1)
 
 if __name__ == "__main__":
     test_tensor_type_alpha_equal()
@@ -695,3 +707,4 @@ if __name__ == "__main__":
     test_graph_equal()
     test_hash_unequal()
     test_fn_attribute()
+    test_commutative()


### PR DESCRIPTION
This PR fixes commutativity in alpha equality passing.

The discussion can be found here: https://discuss.tvm.ai/t/relay-analysis-alpha-equal-questions-and-potential-issues/5704

It is the second issue listed in the discussion. This enforces 1-1 mapping so that alpha_equal(a,b) == alpha_equal(b,a)