### PR TITLE
[Frontend] [MXNet] make_loss operator support

### DIFF
--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -648,6 +648,8 @@ def _mx_arange(inputs, attrs):
 
 # pylint: disable=unused-argument
 def _mx_make_loss(inputs, attrs):
+    # while doing inference make_loss does not have any effect
+    # and should be mapped to identity  
     return inputs[0]
 
 

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -646,6 +646,11 @@ def _mx_arange(inputs, attrs):
     return _op.arange(**new_attrs)
 
 
+# pylint: disable=unused-argument
+def _mx_make_loss(inputs, attrs):
+    return inputs[0]
+
+
 def _mx_repeat(inputs, attrs):
     assert len(inputs) == 1
     new_attrs = {}
@@ -1824,6 +1829,7 @@ _convert_map = {
     "SoftmaxActivation" : _mx_softmax_activation,
     "LinearRegressionOutput" : _mx_linear_regression_output,
     "smooth_l1"     : _mx_smooth_l1,
+    "make_loss"     : _mx_make_loss,
     "_contrib_div_sqrt_dim": _mx_contrib_div_sqrt_dim,
     "one_hot"           : _mx_one_hot,
     # vision

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -649,7 +649,7 @@ def _mx_arange(inputs, attrs):
 # pylint: disable=unused-argument
 def _mx_make_loss(inputs, attrs):
     # while doing inference make_loss does not have any effect
-    # and should be mapped to identity  
+    # and should be mapped to identity
     return inputs[0]
 
 

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -649,7 +649,7 @@ def _mx_arange(inputs, attrs):
 # pylint: disable=unused-argument
 def _mx_make_loss(inputs, attrs):
     # while doing inference make_loss does not have any effect
-    # and should be mapped to identity
+    # and it should be mapped to identity
     return inputs[0]
 
 

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -200,6 +200,12 @@ def test_forward_ones_like():
     mx_sym = mx.sym.ones_like(data, dtype='float32')
     verify_mxnet_frontend_impl(mx_sym, (2, 3, 4), (2, 3, 4))
 
+def test_forward_make_loss():
+    data = mx.sym.var('data')
+    ones = mx.sym.ones(shape=(2, 3, 4), dtype='float32')
+    mx_sym = mx.sym.make_loss((data-ones)**2/2, dtype='float32')
+    verify_mxnet_frontend_impl(mx_sym, (2, 3, 4), (2, 3, 4))
+
 def test_forward_zeros_like():
     data = mx.sym.var('data')
     mx_sym = mx.sym.zeros_like(data, dtype='float32')
@@ -989,3 +995,4 @@ if __name__ == '__main__':
     test_forward_convolution()
     test_forward_deconvolution()
     test_forward_cond()
+    test_forward_make_loss()


### PR DESCRIPTION
MXNet make_loss support.

In forward implementation, the MXNet make_loss function just creates an Identity op hence we have added identity mapping in the mxnet frontend.
https://github.com/apache/incubator-mxnet/blob/992c3c0dd90c0723de6934e826a49bad6569eeac/src/operator/make_loss-inl.h#L88