### PR TITLE
Tighten split's extent

### DIFF
--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -116,22 +116,22 @@ void PassDownDomain(const Stage& stage,
       CHECK(!state.count(r->inner));
       const Range& range_parent = state.at(r->parent);
       if (r->factor.defined()) {
-        Update(
-            p_state, r->inner,
-            Range::make_by_min_extent(0, dominating_thread[r->inner] || allow_missing
-                                             ? r->factor
-                                             : minimum_or_later(range_parent->extent, r->factor)),
-            actx);
+        Update(p_state, r->inner,
+               Range::make_by_min_extent(
+                   0, dominating_thread[r->inner] || allow_missing || is_zero(range_parent->extent)
+                          ? r->factor
+                          : minimum_or_later(range_parent->extent, r->factor)),
+               actx);
         Update(p_state, r->outer,
                Range::make_by_min_extent(
                    0, ceil_div(range_parent->extent, r->factor)), actx);
       } else {
-        Update(
-            p_state, r->outer,
-            Range::make_by_min_extent(0, dominating_thread[r->outer] || allow_missing
-                                             ? r->nparts
-                                             : minimum_or_later(range_parent->extent, r->nparts)),
-            actx);
+        Update(p_state, r->outer,
+               Range::make_by_min_extent(
+                   0, dominating_thread[r->outer] || allow_missing || is_zero(range_parent->extent)
+                          ? r->nparts
+                          : minimum_or_later(range_parent->extent, r->nparts)),
+               actx);
         Update(p_state, r->inner,
                Range::make_by_min_extent(
                    0, ceil_div(range_parent->extent, r->nparts)), actx);

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -123,7 +123,7 @@ void PassDownDomain(const Stage& stage,
       const Range& range_parent = state.at(r->parent);
       // Tighten iv's extent to min(parent_extent, factor_or_nparts), only if all of the
       // following conditions are met:
-      // 1. No leaf IterVar is derived from iv binds to any thread.  People may use split
+      // 1. No leaf IterVar derived from iv binds to any thread.  People may use split
       // to force an IterVar extent to match the number of allocated threads to fuse stages
       // that require different number of threads.  We don't want to change these extents.
       // 2. allow_missing is false, i.e. that PassDownDomain is called by the final InferBound,

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -123,7 +123,7 @@ void PassDownDomain(const Stage& stage,
       const Range& range_parent = state.at(r->parent);
       // Tighten iv's extent to min(parent_extent, factor_or_nparts), only if all of the
       // following conditions are met:
-      // 1. no leaf IterVar derived from iv binds to any thread.  People may use split
+      // 1. No leaf IterVar is derived from iv binds to any thread.  People may use split
       // to force an IterVar extent to match the number of allocated threads to fuse stages
       // that require different number of threads.  We don't want to change these extents.
       // 2. allow_missing is false, i.e. that PassDownDomain is called by the final InferBound,

--- a/src/tir/pass/vectorize_loop.cc
+++ b/src/tir/pass/vectorize_loop.cc
@@ -524,12 +524,8 @@ class LoopVectorizer : public StmtMutator {
       CHECK(is_zero(op->min));
       int lanes = 0;
       bool succ = arith::GetConstInt(op->extent, &lanes);
-      if (!succ || lanes < 0) {
+      if (!succ || lanes < 1) {
         LOG(FATAL) << "Failed to vectorize loop with extent " << op->extent;
-      }
-      if (lanes == 0) {
-        // Nothing to run.  This may happen when a tensor has 0-sized dimension.
-        return Stmt();
       }
       return Vectorizer(op->loop_var, lanes)(op->body);
     } else {

--- a/src/tir/pass/vectorize_loop.cc
+++ b/src/tir/pass/vectorize_loop.cc
@@ -524,8 +524,12 @@ class LoopVectorizer : public StmtMutator {
       CHECK(is_zero(op->min));
       int lanes = 0;
       bool succ = arith::GetConstInt(op->extent, &lanes);
-      if (!succ || lanes < 1) {
+      if (!succ || lanes < 0) {
         LOG(FATAL) << "Failed to vectorize loop with extent " << op->extent;
+      }
+      if (lanes == 0) {
+        // Nothing to run.  This may happen when a tensor has 0-sized dimension.
+        return Stmt();
       }
       return Vectorizer(op->loop_var, lanes)(op->body);
     } else {

--- a/tests/python/unittest/test_schedule_bound_inference.py
+++ b/tests/python/unittest/test_schedule_bound_inference.py
@@ -70,6 +70,32 @@ def test_bound3():
     assert(bounds[A1.op.axis[0]].extent.value==32)
     assert(bounds[A1.op.axis[1]].extent.value==16)
 
+def test_bound_split_ext_less_than_factor():
+    m = 8
+    I = tvm.placeholder((m,), name='I')
+    EF = tvm.compute((m,), lambda i: I[i] * 2, name = "EF")
+    E = tvm.compute((m,), lambda i: EF[i] * 2, name = "E")
+    s = tvm.create_schedule([E.op])
+    xo, xi = s[E].split(s[E].op.axis[0], factor = 32)
+    s[EF].compute_at(s[E], xo)
+
+    bounds = tvm.schedule.InferBound(s)
+    assert isinstance(bounds, tvm.container.Map)
+    assert bounds[xi].extent.value == m
+
+def test_bound_split_ext_less_than_naprts():
+    m = 8
+    I = tvm.placeholder((m,), name='I')
+    EF = tvm.compute((m,), lambda i: I[i] * 2, name = "EF")
+    E = tvm.compute((m,), lambda i: EF[i] * 2, name = "E")
+    s = tvm.create_schedule([E.op])
+    xo, xi = s[E].split(s[E].op.axis[0], nparts = 32)
+    s[EF].compute_at(s[E], xo)
+
+    bounds = tvm.schedule.InferBound(s)
+    assert isinstance(bounds, tvm.container.Map)
+    assert bounds[xo].extent.value == m
+
 def test_bound_split_divisible():
     m = te.var('m')
     l = te.var('l')

--- a/tests/python/unittest/test_schedule_bound_inference.py
+++ b/tests/python/unittest/test_schedule_bound_inference.py
@@ -72,27 +72,27 @@ def test_bound3():
 
 def test_bound_split_ext_less_than_factor():
     m = 8
-    I = tvm.placeholder((m,), name='I')
-    EF = tvm.compute((m,), lambda i: I[i] * 2, name = "EF")
-    E = tvm.compute((m,), lambda i: EF[i] * 2, name = "E")
-    s = tvm.create_schedule([E.op])
+    I = te.placeholder((m,), name='I')
+    EF = te.compute((m,), lambda i: I[i] * 2, name = "EF")
+    E = te.compute((m,), lambda i: EF[i] * 2, name = "E")
+    s = te.create_schedule([E.op])
     xo, xi = s[E].split(s[E].op.axis[0], factor = 32)
     s[EF].compute_at(s[E], xo)
 
-    bounds = tvm.schedule.InferBound(s)
+    bounds = tvm.te.schedule.InferBound(s)
     assert isinstance(bounds, tvm.container.Map)
     assert bounds[xi].extent.value == m
 
 def test_bound_split_ext_less_than_naprts():
     m = 8
-    I = tvm.placeholder((m,), name='I')
-    EF = tvm.compute((m,), lambda i: I[i] * 2, name = "EF")
-    E = tvm.compute((m,), lambda i: EF[i] * 2, name = "E")
-    s = tvm.create_schedule([E.op])
+    I = te.placeholder((m,), name='I')
+    EF = te.compute((m,), lambda i: I[i] * 2, name = "EF")
+    E = te.compute((m,), lambda i: EF[i] * 2, name = "E")
+    s = te.create_schedule([E.op])
     xo, xi = s[E].split(s[E].op.axis[0], nparts = 32)
     s[EF].compute_at(s[E], xo)
 
-    bounds = tvm.schedule.InferBound(s)
+    bounds = tvm.te.schedule.InferBound(s)
     assert isinstance(bounds, tvm.container.Map)
     assert bounds[xo].extent.value == m
 


### PR DESCRIPTION
PassDownDomain always sets inner IterVar's extent to the split factor, even if the parent extent is less than the factor (usually happens when the parent has been reduced to a single point).  Although predicates are added to guard bounds, unnecessary likely statements are inserted. They are road blocks for tensorization/intrinsic.

Here is an example from the new test:
Before:
```
// attr [EF] storage_scope = "global"
allocate EF[float32 * 8]
produce E {
  produce EF {
    for (i, 0, 8) {
      EF[i] = (I[i]*2f)
    }
  }
  for (i.inner, 0, 32) {
    if (likely((i.inner < 8))) {
      if (likely((i.inner < 8))) {
        EF[i.inner] = (EF[i.inner]*2f)
      }
    }
  }
}
```
After:
```
// attr [EF] storage_scope = "global"
allocate EF[float32 * 8]
produce E {
  produce EF {
    for (i, 0, 8) {
      EF[i] = (I[i]*2f)
    }
  }
  for (i.inner, 0, 8) {
    EF[i.inner] = (EF[i.inner]*2f)
  }
}
```

**Solution:**
Tighten iv's extent to min(parent_extent, factor_or_nparts), only if all of the
following three conditions are met:
1. No leaf IterVar is derived from iv binds to any thread.  People may use split
to force an IterVar extent to match the number of allocated threads to fuse stages
that require different number of threads.  We don't want to change these extents.
2. allow_missing is false, i.e. that PassDownDomain is called by the final InferBound,
rather than by an early compiler phase, such as rfactor().  We don't want to tighten an
IterVar in an early phase allowing missing IterVars, because it may bind to a thread later.
3. range_parent's extent is not 0.  At lest one Topi test has a case where a tensor has one
zero-sized dimension.  Split creates iv with a positive extent to avoid zero-extent
IterVar.  We don't touch it.

An earlier attempt to this issue is in this PR (https://github.com/apache/incubator-tvm/pull/4885).    This PR also reports it (https://github.com/apache/incubator-tvm/pull/4932).

Follow-up to the discussion in https://github.com/apache/incubator-tvm/pull/4885:
1. Comparing with https://github.com/apache/incubator-tvm/pull/4885, this one doesn't have to change existing tests/schedules and keeps allowing the following use case:
```
for (int i = 0; i < 31; ++i) {
   B[i] = C[i] + 1
}
for (int j = 0; j < 32; ++j) {
   C[i] = A[i] * 2
}
```
2. The running time for tests/python/unittest/test_schedule_tensor_core.py:test_tensor_core_batch_conv reduces further (Original: 0.060 ms, https://github.com/apache/incubator-tvm/pull/4885: 0.035 ms, this one: 0.026ms).





