### PR TITLE
[SCHEDULE] Improve bound inference for split

### DIFF
--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -82,7 +82,7 @@ void PassDownDomain(const Stage& stage,
                  Range::make_by_min_extent(0, r->factor), actx);
         }
         Update(p_state, r->outer,
-               Range::make_by_min_extent(0,outer_extent) , actx);
+               Range::make_by_min_extent(0, outer_extent) , actx);
       } else {
         Update(p_state, r->outer, Range::make_by_min_extent(0, r->nparts), actx);
         Update(p_state, r->inner,


### PR DESCRIPTION
When we split an axis  `i` with a factor `f` that is larger than the extent of `i`, we should set the extent of the inner axis to be the extent of `i` instead of `f`.

### Test script
```py
import tvm

A = tvm.placeholder((2, 2), name='A')
B = tvm.compute((2, 2), lambda i, j : A[i][j] + 1.0, name='B')

s = tvm.create_schedule([B.op])

i, j = s[B].op.axis
s[B].split(i, 4)

print(tvm.lower(s, [A ,B], simple_mode=True))
```

### Results
Before 
```c++
produce B {
  for (i.inner, 0, 4) {
    for (j, 0, 2) {
      if (likely((i.inner < 2))) {
        if (likely((i.inner < 2))) {
          B[((i.inner*2) + j)] = (A[((i.inner*2) + j)] + 1f)
        }
      }
    }
  }
}
```

After
```c++
produce B {
  for (i.inner, 0, 2) {
    for (j, 0, 2) {
      B[((i.inner*2) + j)] = (A[((i.inner*2) + j)] + 1f)
    }
  }
}
```