### PR TITLE
[Relay][Pass] Sort MergeComposite generated function params alphabetically

### DIFF
--- a/src/relay/pass/merge_composite.cc
+++ b/src/relay/pass/merge_composite.cc
@@ -164,7 +164,7 @@ class MergeCompositeWrapper : public ExprMutator {
     Map<Expr, Expr> call_map;
     auto extract = ExtractPattern(pattern, call, &args_map, &call_map);
     if (extract.defined()) {
-      auto free_vars = GetOrderedFreeVars(extract);
+      auto free_vars = GetFreeVarsAlphabetical(extract);
       // make the composite function
       auto f = FunctionNode::make(free_vars, extract, call->checked_type_, {}, Attrs());
       f = FunctionSetAttr(f, attr::kComposite, tir::StringImmNode::make(pattern_name_));
@@ -187,7 +187,7 @@ class MergeCompositeWrapper : public ExprMutator {
    *         ordering for different patterns that have the same
    *         free vars.
    */
-  Array<Var> GetOrderedFreeVars(const Expr& expr) {
+  Array<Var> GetFreeVarsAlphabetical(const Expr& expr) {
     const auto& free_vars = FreeVars(expr);
 
     // put free_vars into a std::vector since tvm::IterAdapter

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -153,6 +153,12 @@ def make_add_add_free_var_wrong_order_pattern():
 def test_fn_param_order():
     """Test order of composite function params.
        They should be sorted alphabetically.
+
+       Without the sorting, the free vars would be
+       [z, y, x]
+
+       With the sorting, they are
+       [x, y, z]
     """
     pattern_table = [
         ("add_add", make_add_add_free_var_wrong_order_pattern())


### PR DESCRIPTION
This change makes the order of the params to `MergeComposite`'s generated function alphabetical. This is to make for consistent param ordering across multiple patterns which have the same logic, but param ordering may come out different.

As an example of why this is necessary: currently, `MergeComposite` gets free vars using `FreeVisitor().visit()`. This means that the ordering of the free vars is dependent on the order that the visitor visits each node. I have written two different transformer patterns, and their composite functions have come out with arguments in different orders.

For example:

```
(float* input, int* input_mask, float* attn_query_weight, float* attn_query_bias...)
```

and

```
(float* attn_query_weight, float* input, float* attn_query_bias, int* input_mask...)
```

It would be nice to have the ordering be consistent so I only have to write one backend kernel.

cc @comaniac @zhiics @mbaret 