### PR TITLE
[Runtime] Fix TVM_DLL_EXPORT_TYPED_FUNC to work on Windows

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -921,10 +921,10 @@ class TVMRetValue : public TVMPODValue_ {
                          TVMValue* out_value,                           \
                          int* out_type_code);                           \
   int ExportName(TVMValue* args,                                        \
-                         int* type_code,                                \
-                         int num_args,                                  \
-                         TVMValue* out_value,                           \
-                         int* out_type_code) {                          \
+                 int* type_code,                                        \
+                 int num_args,                                          \
+                 TVMValue* out_value,                                   \
+                 int* out_type_code) {                                  \
     try {                                                               \
       ::tvm::runtime::TVMRetValue rv;                                   \
       Function(::tvm::runtime::TVMArgs(                                 \

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -919,6 +919,11 @@ class TVMRetValue : public TVMPODValue_ {
                          int* type_code,                                \
                          int num_args,                                  \
                          TVMValue* out_value,                           \
+                         int* out_type_code);                           \
+  int ExportName(TVMValue* args,                                        \
+                         int* type_code,                                \
+                         int num_args,                                  \
+                         TVMValue* out_value,                           \
                          int* out_type_code) {                          \
     try {                                                               \
       ::tvm::runtime::TVMRetValue rv;                                   \


### PR DESCRIPTION
On Windows, it is not valid to define a function in the same statement as declaring it `dllexport`. This change splits `TVM_DLL_EXPORT_PACKED_FUNC` into declaration and definition. Only declaration uses `TVM_DLL`.

I have also verified that this change works on Linux.

@zhiics @comaniac would you be able to take a quick look?