### PR TITLE
[Torch] Add initial control flow support 

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1265,7 +1265,14 @@ def convert_operators(operators, outputs, output_index_map, ret_name):
 
 def get_all_op_names(graph):
     """ Return all operator names in the input graph """
-    return set(node.kind() for node in graph.nodes())
+    nodes = list(graph.nodes())
+    prim_with_blocks = ["prim::If", "prim::Loop"]
+    for prim in prim_with_blocks:
+        prim_nodes = graph.findAllNodes(prim, recurse=True)
+        for prim_node in prim_nodes:
+            for block in prim_node.blocks():
+                nodes += block.nodes()
+    return set([node.kind() for node in nodes])
 
 
 def get_graph_input_names(script_module):

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -126,8 +126,10 @@ def _ones():
         else:
             assert "data type {} could not be parsed in ones op" % (type(data))
 
-        dtype = "float32"
-        return _op.full(_expr.const(1), shape, dtype=dtype)
+        dtype_map = {6: "float32", 3: "int32"}
+        dtype_id = inputs[1]
+        assert dtype_id in dtype_map, "Unsupported dtype %d" % dtype_id
+        return _op.full(_expr.const(1), shape, dtype=dtype_map[dtype_id])
     return _impl
 
 def _zeros():
@@ -144,8 +146,10 @@ def _zeros():
         else:
             assert "data type {} could not be parsed in zeros op" % (type(data))
 
-        dtype = "float32"
-        return _op.full(_expr.const(0), shape, dtype=dtype)
+        dtype_map = {6: "float32", 3: "int32"}
+        dtype_id = inputs[1]
+        assert dtype_id in dtype_map, "Unsupported dtype %d" % dtype_id
+        return _op.full(_expr.const(0), shape, dtype=dtype_map[dtype_id])
     return _impl
 
 def _relu():

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -737,30 +737,6 @@ def _tanh():
         return _op.tensor.tanh(data)
     return _impl
 
-def _ge():
-    def _impl(inputs, input_types):
-        assert len(inputs) == 2
-        lhs = _wrap_const(inputs[0])
-        rhs = _wrap_const(inputs[1])
-        return _op.tensor.greater_equal(lhs, rhs)
-    return _impl
-
-def _gt():
-    def _impl(inputs, input_types):
-        assert len(inputs) == 2
-        lhs = _wrap_const(inputs[0])
-        rhs = _wrap_const(inputs[1])
-        return _op.tensor.greater(lhs, rhs)
-    return _impl
-
-def _lt():
-    def _impl(inputs, input_types):
-        assert len(inputs) == 2
-        lhs = _wrap_const(inputs[0])
-        rhs = _wrap_const(inputs[1])
-        return _op.tensor.less(lhs, rhs)
-    return _impl
-
 def _Bool():
     def _impl(inputs, input_types):
         assert len(inputs) == 1
@@ -899,12 +875,15 @@ _convert_map = {
     "aten::upsample_bilinear2d"             : _upsample("bilinear"),
     "aten::upsample_nearest2d"              : _upsample("nearest_neighbor"),
     "aten::expand_as"                       : _expand_as(),
-    'aten::lt'                              : _lt(),
-    'aten::gt'                              : _gt(),
-    'aten::Bool'                            : _Bool(),
-    'aten::Float'                           : _Float(),
-    'aten::neg'                             : _neg(),
-    'aten::tanh'                            : _tanh(),
+    "aten::lt"                              : _elemwise("less"),
+    "aten::gt"                              : _elemwise("greater"),
+    "aten::le"                              : _elemwise("less_equal"),
+    "aten::ge"                              : _elemwise("greater_equal"),
+    "aten::ne"                              : _elemwise("not_equal"),
+    "aten::Bool"                            : _Bool(),
+    "aten::Float"                           : _Float(),
+    "aten::neg"                             : _neg(),
+    "aten::tanh"                            : _tanh(),
 }
 
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1195,6 +1195,7 @@ def convert_loop(loop_node, outputs, output_index_map):
 
     def body(*current_vals):
         # Update loop variables using the prev iteration outputs
+        assert len(current_vals) == len(block_input_names)
         for (i, iname) in enumerate(block_input_names):
             outputs[output_index_map[iname]] = current_vals[i]
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -898,7 +898,7 @@ _convert_map = {
     "aten::detach"                          : _identity(),
     "aten::upsample_bilinear2d"             : _upsample("bilinear"),
     "aten::upsample_nearest2d"              : _upsample("nearest_neighbor"),
-    "aten::expand_as"                       : _expand_as()
+    "aten::expand_as"                       : _expand_as(),
     'aten::lt'                              : _lt(),
     'aten::gt'                              : _gt(),
     'aten::Bool'                            : _Bool(),
@@ -1350,8 +1350,8 @@ def from_pytorch(script_module, input_shapes, custom_convert_map=None):
         qnn_torch.add_quant_params(tvm_params, weight_quant_params)
         _convert_map.update(qnn_torch.convert_map)
 
-    body = convert_operators(_get_operator_nodes(graph.nodes()), outputs,
-                             output_index_map, ret_name)
-    func = tvm.relay.Function(_analysis.free_vars(body), body)
+    ret = convert_operators(_get_operator_nodes(graph.nodes()), outputs,
+                            output_index_map, ret_name)
+    func = tvm.relay.Function(_analysis.free_vars(ret[0]), ret[0])
 
     return _module.IRModule.from_expr(func), tvm_params

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -347,7 +347,8 @@ def test_quantized_imagenet():
         qmodels += [
             ("resnet18", qresnet.resnet18(pretrained=True), per_channel),
             ("mobilenet_v2", qmobilenet.mobilenet_v2(pretrained=True), per_channel),
-            ("inception_v3", qinception.inception_v3(pretrained=True), per_channel),
+            # disable inception test for now, since loading it takes ~5min on torchvision-0.5
+            #("inception_v3", qinception.inception_v3(pretrained=True), per_channel),
             ("googlenet", qgooglenet(pretrained=True), per_channel),
         ]
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -910,6 +910,11 @@ def test_control_flow():
             while i < inp.size(0):
                 a += i
                 i += 2
+            i = 0
+            # also test constant init cond
+            while i < 10:
+                a += i
+                i += 3
             return a
 
     class SimpleWhileLoop(torch.nn.Module):

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -751,7 +751,6 @@ def test_vgg11_bn():
     verify_model("vgg11_bn")
 """
 
-
 def test_custom_conversion_map():
     def get_roi_align():
         pool_size = 5
@@ -801,6 +800,189 @@ def test_segmentaton_models():
         # see https://github.com/apache/incubator-tvm/issues/4962
         verify_model(SegmentationModelWrapper(model.eval()), inp,
                      ctx_list=[("cuda", tvm.gpu(0))])
+
+
+def run_and_compare_vm(mod, params, pt_result):
+    executor = relay.create_executor("vm", mod=mod, ctx=tvm.cpu(0),
+                                     target="llvm")
+    evaluator = executor.evaluate()
+
+    op_res = evaluator(**params)
+
+    if not isinstance(pt_result, torch.Tensor):
+        tvm_res = op_res.asnumpy().item()
+        assert pt_result == tvm_res
+    else:
+        tvm.testing.assert_allclose(op_res.asnumpy(), pt_result.numpy(),
+                                    rtol=1e-5, atol=1e-5)
+
+
+def test_control_flow():
+    class SimpleIf(torch.nn.Module):
+        def __init__(self, N, M):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.rand(N, M))
+
+        def forward(self, inp):
+            if inp.sum() > 0.:
+                output = self.weight + inp
+            else:
+                output = self.weight - inp
+            return output
+
+    class NestedIf(torch.nn.Module):
+        def __init__(self, N, M):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.rand(N, M))
+
+        def forward(self, inp):
+            if inp.sum() > 0.:
+                if inp.mean() > 0.:
+                    output = self.weight + inp
+                else:
+                    output = self.weight - inp
+            else:
+                if inp.mean() > 0.:
+                    output = self.weight * inp
+                else:
+                    output = self.weight / inp
+
+            return output
+
+    class ScalarLoop(torch.nn.Module):
+        def forward(self, inp):
+            a = 0
+            for i in range(inp.size(0)):
+                b = i * i
+                b = b + 1
+                a += b
+            return a
+
+    class SimpleLoop(torch.nn.Module):
+        def forward(self, inp):
+            a = inp
+            for i in range(inp.size(0)):
+                b = a * 2.
+                c = a + b
+                a += c
+            return a
+
+    class LoopWithIf(torch.nn.Module):
+        def forward(self, inp):
+            a = inp
+            for i in range(inp.size(0)):
+                b = a * 2.
+                b = a + b
+                if b.sum() > 0.0:
+                    a += b
+                else:
+                    a -= b
+            return a
+
+    class NestedLoop(torch.nn.Module):
+        def forward(self, inp):
+            a = inp
+            for i in range(inp.size(0)):
+                b = a * float(i)
+                for j in range(inp.size(1)):
+                    a += b * float(j)
+            return a
+
+    class SimpleScalarWhileLoop(torch.nn.Module):
+        def forward(self, inp):
+            a = 1
+            i = 0
+            while i < inp.size(0):
+                a += i
+                i += 2
+            return a
+
+    class SimpleWhileLoop(torch.nn.Module):
+        def forward(self, inp):
+            a = inp
+            i = 0
+            while i < inp.size(0):
+                a += a * float(i) * 2.0
+                i += 1
+            return a
+
+    models = [
+        SimpleIf(10, 20),
+        NestedIf(10, 20),
+        ScalarLoop(),
+        SimpleLoop(),
+        LoopWithIf(),
+        SimpleScalarWhileLoop(),
+        SimpleWhileLoop(),
+        NestedLoop(),
+    ]
+
+    for raw_model in models:
+        raw_model.eval()
+        script_module = torch.jit.script(raw_model)
+        input_name = get_graph_input_names(script_module)[0]
+        input_shapes = {input_name: (10, 20)}
+        mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
+
+        for i in range(5):
+            inp = torch.randn(input_shapes[input_name], dtype=torch.float)
+            with torch.no_grad():
+                pt_result = raw_model(inp.clone())
+
+            params[input_name] = inp.numpy()
+
+            run_and_compare_vm(mod, params, pt_result)
+
+
+def test_simple_rnn():
+    class DecisionGate(torch.nn.Module):
+        def forward(self, x):
+            if x.sum() > 0:
+                return x
+            else:
+                return -x
+
+    class Cell(torch.nn.Module):
+        def __init__(self, dg):
+            super(Cell, self).__init__()
+            self.dg = dg
+            self.linear = torch.nn.Linear(4, 4)
+
+        def forward(self, x, h):
+            new_h = torch.tanh(self.dg(self.linear(x)) + h)
+            return new_h, new_h
+
+    # The mixed tracing and scripting example from
+    # https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html#mixing-scripting-and-tracing
+    class RNNLoop(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            x = torch.rand(10, 4, dtype=torch.float)
+            h = torch.rand(10, 4, dtype=torch.float)
+            self.cell = torch.jit.trace(Cell(DecisionGate()), (x, h))
+
+        def forward(self, xs):
+            h = torch.zeros(10, 4, dtype=torch.float)
+            y = torch.zeros(10, 4, dtype=torch.float)
+            for i in range(xs.size(0)):
+                y, h = self.cell(xs[i], h)
+            return y
+
+    raw_model = RNNLoop().eval()
+    script_module = torch.jit.script(raw_model)
+    input_name = get_graph_input_names(script_module)[0]
+    input_shapes = {input_name: (10, 10, 4)}
+
+    mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
+
+    for i in range(5):
+        inp = torch.randn(input_shapes[input_name], dtype=torch.float)
+        with torch.no_grad():
+            pt_result = raw_model(inp.clone())
+
+        params[input_name] = inp.numpy()
+
+        run_and_compare_vm(mod, params, pt_result)
 
 
 if __name__ == "__main__":
@@ -855,3 +1037,7 @@ if __name__ == "__main__":
 
     test_quantized_modules()
     test_quantized_imagenet()
+
+    # Test simple conditionals and loop
+    test_control_flow()
+    test_simple_rnn()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -859,7 +859,7 @@ def test_control_flow():
                 else:
                     output = self.weight - inp
             else:
-                if inp.mean() > 0.:
+                if inp.mean() >= 0.:
                     output = self.weight * inp
                 else:
                     output = self.weight / inp
@@ -873,6 +873,10 @@ def test_control_flow():
                 b = i * i
                 b = b + 1
                 a += b
+            if a != 0:
+                a += 1
+            else:
+                a += 2
             return a
 
     class SimpleLoop(torch.nn.Module):
@@ -909,7 +913,7 @@ def test_control_flow():
         def forward(self, inp):
             a = 1
             i = 0
-            while i < inp.size(0):
+            while i <= inp.size(0):
                 a += i
                 i += 2
             i = 0

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -795,11 +795,13 @@ def test_segmentaton_models():
 
     inp = [torch.rand((1, 3, 300, 300), dtype=torch.float)]
 
-    for model in [fcn, deeplab]:
-        # depthwise + dilated covolution not supported on x86
-        # see https://github.com/apache/incubator-tvm/issues/4962
-        verify_model(SegmentationModelWrapper(model.eval()), inp,
-                     ctx_list=[("cuda", tvm.gpu(0))])
+    verify_model(SegmentationModelWrapper(fcn.eval()), inp)
+
+    # depthwise + dilated covolution not supported on x86
+    # see https://github.com/apache/incubator-tvm/issues/4962
+    cuda_ctx = ("cuda", tvm.gpu(0))
+    if cuda_ctx[1].exist:
+        verify_model(SegmentationModelWrapper(deeplab.eval()), inp, [cuda_ctx])
 
 
 def verify_script_model(pt_model, ishapes):


### PR DESCRIPTION
This adds support for parsing Torchscript `prim::If` and `prim::Loop` nodes. This is also the first attempt at translating from the output of `torch.jit.script(...)`. See the test cases for currently supported Python construct.

* `prim::If` can be easily translated by recursively parsing true and else branches. The spec https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/OVERVIEW.md#if
* `prim::Loop` requires more mork, but using Relay conditional and tail recursion it is not too hard. https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/OVERVIEW.md#loops

The related discussion (with an example IR dump): https://discuss.tvm.ai/t/discuss-adding-a-pytorch-frontend/5026/24

The CI is blocked by unrelated sphinx issue, but it is ready for review. 

cc @zhiics @icemelon9 @wweic  @jroesch @MarisaKirisame @alexwong @tqchen @junrushao1994 @ajtulloch @yinghai 