### PR TITLE
[TOPI][CUDA] Teak CUDA injective scheduler

### DIFF
--- a/topi/python/topi/cuda/injective.py
+++ b/topi/python/topi/cuda/injective.py
@@ -39,9 +39,13 @@ def schedule_injective_from_existing(sch, out):
     num_thread = tvm.target.Target.current(allow_none=False).max_num_threads
     max_block = 256
 
-    # vectorize on fp16 data type. This allows to better utilize the memory
-    # bandwidth.
-    vector_width = 4 if out.dtype == "float16" else 1
+    # vectorize on fp16 and fp32 data types. This allows to better utilize
+    # the memory bandwidth.
+    vector_width = 1
+    if out.dtype == "float16":
+        vector_width = 8
+    elif out.dtype == "float32" or out.dtype == "int32":
+        vector_width = 4
 
     try:
         const_size = util.get_const_int(util.prod(out.shape))

--- a/topi/tests/python/test_topi_tensor.py
+++ b/topi/tests/python/test_topi_tensor.py
@@ -114,6 +114,8 @@ def verify_vectorization(n, m, dtype):
 
 def test_vectorization():
     verify_vectorization(128, 64, "float16")
+    verify_vectorization(128, 64, "float32")
+    verify_vectorization(128, 64, "int32")
 
 def test_elemwise_sum():
     verify_elemwise_sum(1, "float32")


### PR DESCRIPTION
- vectorizing fp32/int32 types is also beneficial.

Signed-off-by: Wei Pan <weip@nvidia.com>

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
