### PR TITLE
Added CopyFromBytes and CopyToBytes convenience methods to NDArray.  Fixed typos.

### DIFF
--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -324,12 +324,6 @@ inline void NDArray::CopyFrom(const NDArray& other) {
   CopyFromTo(&(other.get_mutable()->dl_tensor), &(get_mutable()->dl_tensor));
 }
 
-inline void NDArray::CopyFromBytes(const void* data, size_t nbytes) {
-  CHECK(data != nullptr);
-  CHECK(data_ != nullptr);
-  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, const_cast<void*>(data), nbytes), 0);
-}
-
 inline void NDArray::CopyTo(DLTensor* other) const {
   CHECK(data_ != nullptr);
   CopyFromTo(&(get_mutable()->dl_tensor), other);
@@ -339,12 +333,6 @@ inline void NDArray::CopyTo(const NDArray& other) const {
   CHECK(data_ != nullptr);
   CHECK(other.data_ != nullptr);
   CopyFromTo(&(get_mutable()->dl_tensor), &(other.get_mutable()->dl_tensor));
-}
-
-inline void NDArray::CopyToBytes(void* data, size_t nbytes) const {
-  CHECK(data != nullptr);
-  CHECK(data_ != nullptr);
-  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, data, nbytes), 0);
 }
 
 inline NDArray NDArray::CopyTo(const DLContext& ctx) const {

--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -327,7 +327,6 @@ inline void NDArray::CopyFrom(const NDArray& other) {
 inline void NDArray::CopyFromBytes(const void* data, size_t nbytes) {
   CHECK(data != nullptr);
   CHECK(data_ != nullptr);
-  CHECK(nbytes > 0);
 
   // Make a temporary copy of the dltensor
   DLTensor input = get_mutable()->dl_tensor;

--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -91,7 +91,7 @@ class NDArray : public ObjectRef {
   inline void CopyTo(DLTensor* other) const;
   inline void CopyTo(const NDArray& other) const;
   /*!
-   * \brief Copy data content into a byte buffer
+   * \brief Copy data content into another array.
    * \param data The source bytes to be copied from.
    * \param nbytes The size of the data buffer.
    *        Must be equal to the size of the NDArray.
@@ -327,21 +327,7 @@ inline void NDArray::CopyFrom(const NDArray& other) {
 inline void NDArray::CopyFromBytes(const void* data, size_t nbytes) {
   CHECK(data != nullptr);
   CHECK(data_ != nullptr);
-
-  // Make a temporary copy of the dltensor
-  DLTensor input = get_mutable()->dl_tensor;
-
-  CHECK_EQ(nbytes, GetDataSize(input))
-      << "CopyFromBytes: The size must exactly match";
-
-  TVMContext cpu_ctx;
-  cpu_ctx.device_type = kDLCPU;
-  cpu_ctx.device_id = 0;
-  // Overwrite our temporary dltensor with a CPU context
-  input.ctx = cpu_ctx;
-  input.data = const_cast<void*>(data);
-  
-  CopyFrom(&input);
+  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, const_cast<void*>(data), nbytes), 0);
 }
 
 inline void NDArray::CopyTo(DLTensor* other) const {
@@ -358,21 +344,7 @@ inline void NDArray::CopyTo(const NDArray& other) const {
 inline void NDArray::CopyToBytes(void* data, size_t nbytes) const {
   CHECK(data != nullptr);
   CHECK(data_ != nullptr);
-
-  // Make a temporary copy of the dltensor
-  DLTensor output = get_mutable()->dl_tensor;
-  
-  CHECK_EQ(nbytes, GetDataSize(output))
-    << "CopyToBytes: The size must exactly match";
-  
-  TVMContext cpu_ctx;
-  cpu_ctx.device_type = kDLCPU;
-  cpu_ctx.device_id = 0;
-  // Overwrite our temporary dltensor with a CPU context
-  output.ctx = cpu_ctx;
-  output.data = data;
-  
-  CopyTo(&output);
+  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, data, nbytes), 0);
 }
 
 inline NDArray NDArray::CopyTo(const DLContext& ctx) const {

--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -81,7 +81,7 @@ class NDArray : public ObjectRef {
  * \note The copy may happen asynchronously if it involves a GPU context.
  *       TVMSynchronize is necessary.
  */
-  inline void CopyFromBytes(const void* data, size_t nbytes);
+  TVM_DLL void CopyFromBytes(const void* data, size_t nbytes);
   /*!
    * \brief Copy data content into another array.
    * \param other The source array to be copied from.
@@ -98,7 +98,7 @@ class NDArray : public ObjectRef {
    * \note The copy may happen asynchronously if it involves a GPU context.
    *       TVMSynchronize is necessary.
    */
-  inline void CopyToBytes(void* data, size_t nbytes) const;
+  TVM_DLL void CopyToBytes(void* data, size_t nbytes) const;
   /*!
    * \brief Copy the data to another context.
    * \param ctx The target context.

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -185,6 +185,18 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
   return NDArray(GetObjectPtr<Object>(data));
 }
 
+void NDArray::CopyToBytes(void* data, size_t nbytes) const {
+  CHECK(data != nullptr);
+  CHECK(data_ != nullptr);
+  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, data, nbytes), 0);
+}
+
+void NDArray::CopyFromBytes(const void* data, size_t nbytes) {
+  CHECK(data != nullptr);
+  CHECK(data_ != nullptr);
+  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, const_cast<void*>(data), nbytes), 0);
+}
+
 void NDArray::CopyFromTo(const DLTensor* from,
                          DLTensor* to,
                          TVMStreamHandle stream) {

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -73,7 +73,7 @@ void ArrayCopyFromBytes(DLTensor* handle, const void* data, size_t nbytes) {
       nbytes, cpu_ctx, handle->ctx, handle->dtype, nullptr);
 }
 
-void ArrayCopyToBytes(DLTensor* handle, void* data, size_t nbytes) {
+void ArrayCopyToBytes(const DLTensor* handle, void* data, size_t nbytes) {
   TVMContext cpu_ctx;
   cpu_ctx.device_type = kDLCPU;
   cpu_ctx.device_id = 0;

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -214,15 +214,13 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
 void NDArray::CopyToBytes(void* data, size_t nbytes) const {
   CHECK(data != nullptr);
   CHECK(data_ != nullptr);
-  DLTensor* handle = &get_mutable()->dl_tensor;
-  ArrayCopyToBytes(handle, data, nbytes);
+  ArrayCopyToBytes(&get_mutable()->dl_tensor, data, nbytes);
 }
 
 void NDArray::CopyFromBytes(const void* data, size_t nbytes) {
   CHECK(data != nullptr);
   CHECK(data_ != nullptr);
-  DLTensor* handle = &get_mutable()->dl_tensor;
-  ArrayCopyFromBytes(handle, data, nbytes);
+  ArrayCopyFromBytes(&get_mutable()->dl_tensor, data, nbytes);
 }
 
 void NDArray::CopyFromTo(const DLTensor* from,

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -188,7 +188,7 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
 void NDArray::CopyToBytes(void* data, size_t nbytes) const {
   CHECK(data != nullptr);
   CHECK(data_ != nullptr);
-  CHECK_EQ(TVMArrayCopyFromBytes(&get_mutable()->dl_tensor, data, nbytes), 0);
+  CHECK_EQ(TVMArrayCopyToBytes(&get_mutable()->dl_tensor, data, nbytes), 0);
 }
 
 void NDArray::CopyFromBytes(const void* data, size_t nbytes) {


### PR DESCRIPTION
It is not very intuitive (specially as a beginner) on how to copy a `void*` to an `NDArray`.  Currently one may have to configure a `DLTensor `and run an `NDArray::CopyTo(...)`.

This PR adds two member functions to NDArray to copy to and from a `void*`.

`NDArray::CopyFromBytes(const void* data, size_t nbytes)`
and
`NDArray::CopyToBytes(void* data, size_t nbytes)`

Included in this PR are also a few typo fixes.
