### PR TITLE
Fix gpu not found when running TVM docker

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -79,7 +79,7 @@ if [ "$#" -lt 1 ] || [ ! -e "${SCRIPT_DIR}/Dockerfile.${CONTAINER_TYPE}" ]; then
 fi
 
 # Use nvidia-docker if the container is GPU.
-if [[ "${DOCKER_IMAGE_NAME}" == *"gpu"* ]]; then
+if [[ "${CONTAINER_TYPE}" == *"gpu"* ]]; then
     if ! type "nvidia-docker" 1> /dev/null 2> /dev/null
     then
         DOCKER_BINARY="docker"


### PR DESCRIPTION
When running dockerfile.demo_gpu, `nvidia-smi` command always not found.
Because we didn't declare `DOCKER_IMAGE_NAME`, so we always use docker instead of nvidia-docker
change `DOCKER_IMAGE_NAME` to `CONTAINER_TYPE`.