### PR TITLE
[Torch] fix unordered dictionary problem for python version under 3.6

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -918,7 +918,7 @@ def _get_constant(node):
 
 def _get_operator_nodes(nodes):
     """ Returns torch IR nodes that need conversion to Relay """
-    ops = {}
+    ops = []
     # Traverse nodes and add to graph
     for node in nodes:
         if node.outputsSize() > 1:
@@ -927,7 +927,7 @@ def _get_operator_nodes(nodes):
             node_name = _get_output_name(node)
 
         if node.kind() != "prim::GetAttr":
-            ops[node_name] = node
+            ops.append((node_name,node))
 
     return ops
 
@@ -1015,7 +1015,7 @@ def parse_params(graph, state_dict):
 
 def parse_operators(operators, outputs, output_index_map, ret_name):
     """ Convert each Torch IR operators to Relay equivalent """
-    for node_name, op_node in operators.items():
+    for node_name, op_node in operators:
         operator = op_node.kind()
         inputs = _get_op_inputs(op_node, outputs, output_index_map)
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -927,7 +927,7 @@ def _get_operator_nodes(nodes):
             node_name = _get_output_name(node)
 
         if node.kind() != "prim::GetAttr":
-            ops.append((node_name,node))
+            ops.append((node_name, node))
 
     return ops
 


### PR DESCRIPTION
For python version below 3.6, the order of the key in a dictionary is not the insertion order of keys. It will break the dependency order of each ops, causing KeyError. Instead, we can use a list of (node_name, node) instead of a dictionary. 
