### PR TITLE
Fix stride default value None in torch.nn.functional.avg_pool

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -921,7 +921,7 @@ def _get_constant(node):
 
 def _get_operator_nodes(nodes):
     """ Returns torch IR nodes that need conversion to Relay """
-    ops = []
+    ops = {}
     # Traverse nodes and add to graph
     for node in nodes:
         if node.outputsSize() > 1:
@@ -930,7 +930,7 @@ def _get_operator_nodes(nodes):
             node_name = _get_output_name(node)
 
         if node.kind() != "prim::GetAttr":
-            ops.append((node_name, node))
+            ops[node_name] = node
 
     return ops
 
@@ -1018,7 +1018,7 @@ def parse_params(graph, state_dict):
 
 def parse_operators(operators, outputs, output_index_map, ret_name):
     """ Convert each Torch IR operators to Relay equivalent """
-    for node_name, op_node in operators:
+    for node_name, op_node in operators.items():
         operator = op_node.kind()
         inputs = _get_op_inputs(op_node, outputs, output_index_map)
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -918,7 +918,7 @@ def _get_constant(node):
 
 def _get_operator_nodes(nodes):
     """ Returns torch IR nodes that need conversion to Relay """
-    ops = {}
+    ops = []
     # Traverse nodes and add to graph
     for node in nodes:
         if node.outputsSize() > 1:
@@ -927,7 +927,7 @@ def _get_operator_nodes(nodes):
             node_name = _get_output_name(node)
 
         if node.kind() != "prim::GetAttr":
-            ops[node_name] = node
+            ops.append((node_name,node))
 
     return ops
 
@@ -1015,7 +1015,7 @@ def parse_params(graph, state_dict):
 
 def parse_operators(operators, outputs, output_index_map, ret_name):
     """ Convert each Torch IR operators to Relay equivalent """
-    for node_name, op_node in operators.items():
+    for node_name, op_node in operators:
         operator = op_node.kind()
         inputs = _get_op_inputs(op_node, outputs, output_index_map)
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -458,7 +458,10 @@ def _avg_pool2d():
         data = inputs[0]
 
         pool_size = _infer_shape(inputs[1])
-        strides = _infer_shape(inputs[2])
+        if inputs[2]:
+            strides = _infer_shape(inputs[2])
+        else:
+            strides = pool_size
         padding = _infer_shape(inputs[3])
 
         ceil_mode = int(inputs[4])

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -927,7 +927,7 @@ def _get_operator_nodes(nodes):
             node_name = _get_output_name(node)
 
         if node.kind() != "prim::GetAttr":
-            ops.append((node_name,node))
+            ops.append((node_name, node))
 
     return ops
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -375,8 +375,13 @@ def test_forward_avgpool():
         def forward(self, *args):
             return torch.nn.AvgPool2d(kernel_size=[10, 10])(args[0])
 
+    class AvgPool2D2(Module):
+        def forward(self, *args):
+            return torch.nn.functional.avg_pool2d(args[0], kernel_size=[10, 10])
+
     input_data = torch.rand(input_shape).float()
     verify_model(AvgPool2D1().float().eval(), input_data=input_data)
+    verify_model(AvgPool2D2().float().eval(), input_data=input_data)
 
 def test_forward_hardtanh():
     torch.set_grad_enabled(False)


### PR DESCRIPTION
The default value of stride in nn.functional.avg_pool is set as None,
https://github.com/apache/incubator-tvm/blob/5a0f39b5481a30a2eec49e27cbc17a722bd6ee6a/python/tvm/relay/frontend/pytorch.py#L461
It will cause `TVMError: Check failed: ObjectTypeChecker<TObjectRef>: :Check(ptr): Expect relay.Expr but get Array` since `inputs[2]` is empty.
Fix it by detecting None type of stride in tvm frontend pytorch.
