### PR TITLE
[AutoTVM] Avoid using RPC for LocalRunner

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -23,30 +23,31 @@ remote devices, recording the running time costs, and checking the correctness o
 """
 
 import logging
-import shutil
 import os
+import shutil
+import tempfile
 import threading
 import time
-from random import getrandbits
 from collections import namedtuple
-import tempfile
+from random import getrandbits
 
 import numpy as np
 
 import tvm._ffi
-from tvm import nd, rpc as _rpc, target as _target
-from tvm.tir import ir_pass
-from tvm.error import TVMError
-from tvm.target import build_config
+from tvm import nd
+from tvm import rpc as _rpc
+from tvm.contrib import ndk, nvcc, tar
 from tvm.driver import build
-from tvm.contrib import nvcc, ndk, tar
+from tvm.error import TVMError
+from tvm.runtime import module as _module
+from tvm.target import build_config
+from tvm.tir import ir_pass
 
-from ..util import get_const_tuple
 from ..env import AutotvmGlobalScope
 from ..task.space import InstantiationError
-
-from .measure import MeasureResult, MeasureErrorNo, Builder, Runner
+from ..util import get_const_tuple
 from .local_executor import LocalExecutor
+from .measure import Builder, MeasureErrorNo, MeasureResult, Runner
 
 logger = logging.getLogger('autotvm')
 
@@ -187,24 +188,12 @@ class RPCRunner(Runner):
                  timeout=10, n_parallel=None,
                  number=4, repeat=3, min_repeat_ms=0, cooldown_interval=0.1,
                  check_correctness=False):
-        super(RPCRunner, self).__init__(timeout, n_parallel)
-
+        super(RPCRunner, self).__init__(timeout, n_parallel, number, repeat, min_repeat_ms,
+                                        cooldown_interval, check_correctness)
         self.key = key
         self.host = host
         self.port = port
         self.priority = priority
-        self.timeout = timeout
-
-        self.number = number
-        self.repeat = repeat
-        self.min_repeat_ms = min_repeat_ms
-
-        self.ref_input = None
-        self.ref_output = None
-        self.check_correctness = check_correctness
-        self.cooldown_interval = cooldown_interval
-
-        self.executor = LocalExecutor()
 
     def set_task(self, task):
         self.task = task
@@ -217,69 +206,21 @@ class RPCRunner(Runner):
                                "'python -m tvm.exec.query_rpc_tracker --port [THE PORT YOU USE]' "
                                "and make sure you have free devices on the queue status.")
 
-        if self.check_correctness:
-            # use llvm cpu to generate a reference input/output
-            # this option works for tuning topi, but might not work for you custom op
-            with _target.create("llvm"):
-                s, arg_bufs = task.instantiate(task.config_space.get(0))
-            self.ref_input = [np.random.uniform(size=get_const_tuple(x.shape)).astype(x.dtype)
-                              for x in arg_bufs]
-            func = build(s, arg_bufs, "llvm")
-            tvm_buf = [nd.array(x) for x in self.ref_input]
-            func(*tvm_buf)
-            self.ref_output = [x.asnumpy() for x in tvm_buf]
+    def get_device_context(self):
+        remote = request_remote(self.key, self.host, self.port)
+        return remote.context(str(self.task.target), 0)
 
-    def get_build_kwargs(self):
-        kwargs = {}
-        if 'cuda' in self.task.target.keys or 'opencl' in self.task.target.keys or \
-           'rocm' in self.task.target.keys:
-            remote = request_remote(self.key, self.host, self.port)
-            ctx = remote.context(str(self.task.target), 0)
-            max_dims = ctx.max_thread_dimensions
-            kwargs['check_gpu'] = {
-                'max_shared_memory_per_block': ctx.max_shared_memory_per_block,
-                'max_threads_per_block': ctx.max_threads_per_block,
-                'max_thread_x': max_dims[0],
-                'max_thread_y': max_dims[1],
-                'max_thread_z': max_dims[2],
-            }
 
-            if 'cuda' in self.task.target.keys:
-                kwargs["cuda_arch"] = "sm_" + "".join(ctx.compute_version.split('.'))
-
-        return kwargs
-
-    def run(self, measure_inputs, build_results):
-        results = []
+    def get_run_args(self, measure_inputs, build_results):
         remote_args = (self.key, self.host, self.port, self.priority, self.timeout)
+        args = [
+            run_through_rpc, measure_inputs, build_results, self.number, self.repeat,
+            self.min_repeat_ms, self.cooldown_interval, remote_args, self.ref_input,
+            self.ref_output
+        ]
+        return args
 
-        for i in range(0, len(measure_inputs), self.n_parallel):
-            futures = []
-            for measure_inp, build_res in zip(measure_inputs[i:i+self.n_parallel],
-                                              build_results[i:i+self.n_parallel]):
-                ret = self.executor.submit(run_through_rpc,
-                                           measure_inp,
-                                           build_res,
-                                           self.number,
-                                           self.repeat,
-                                           self.min_repeat_ms,
-                                           self.cooldown_interval,
-                                           remote_args,
-                                           self.ref_input,
-                                           self.ref_output)
-                futures.append(ret)
-
-            for future in futures:
-                res = future.get()
-                if isinstance(res, Exception):   # executor error or timeout
-                    results.append(MeasureResult((str(res),), MeasureErrorNo.RUN_TIMEOUT,
-                                                 self.timeout, time.time()))
-                else:
-                    results.append(res)
-
-        return results
-
-class LocalRunner(RPCRunner):
+class LocalRunner(Runner):
     """Run generated code on local devices.
 
     Parameters
@@ -308,43 +249,17 @@ class LocalRunner(RPCRunner):
         Whether check correctness after measurement. This will use llvm cpu target to
         call your template and get the reference output.
         This can work for TOPI templates, but may not work for your custom template.
-
-    Note
-    ----
-    This is a "fake" local mode. We start a silent rpc tracker and rpc server
-    for the user. In this way we reuse timeout/isolation mechanism in RPC infrastructure.
     """
-    def __init__(self,
-                 timeout=10,
-                 number=4, repeat=3, min_repeat_ms=0, cooldown_interval=0.1,
-                 check_correctness=False):
-        super(LocalRunner, self).__init__('', None, None, 0,
-                                          timeout=timeout, n_parallel=1,
-                                          number=number, repeat=repeat,
-                                          min_repeat_ms=min_repeat_ms,
-                                          cooldown_interval=cooldown_interval,
-                                          check_correctness=check_correctness)
-        self.tracker = None
-        self.server = None
 
-    def set_task(self, task):
-        # pylint: disable=import-outside-toplevel
-        from ...rpc.tracker import Tracker
-        from ...rpc.server import Server
+    def get_device_context(self):
+        return nd.context(str(self.task.target), 0)
 
-        self.task = task
-        tracker = Tracker('0.0.0.0', port=9000, port_end=10000, silent=True)
-        device_key = '$local$device$%d' % tracker.port
-        server = Server('0.0.0.0', port=9000, port_end=10000,
-                        key=device_key,
-                        use_popen=True, silent=True,
-                        tracker_addr=(tracker.host, tracker.port))
-        self.key = device_key
-        self.host = tracker.host
-        self.port = tracker.port
-
-        super(LocalRunner, self).set_task(task)
-        return server, tracker
+    def get_run_args(self, measure_inputs, build_results):
+        args = [
+            run_local, measure_inputs, build_results, self.number, self.repeat, self.min_repeat_ms,
+            self.cooldown_interval, self.ref_input, self.ref_output
+        ]
+        return args
 
 
 def _build_func_common(measure_input, check_gpu=None, cuda_arch=None, build_option=None):
@@ -583,6 +498,103 @@ def check_remote(target, device_key, host=None, port=None, priority=100, timeout
     t.start()
     t.join(timeout)
     return not t.is_alive()
+
+
+def run_local(measure_input,
+              build_result,
+              number,
+              repeat,
+              min_repeat_ms,
+              cooldown_interval,
+              ref_input=None,
+              ref_output=None):
+    """Run a generated library locally.
+
+    Parameters
+    ----------
+    measure_input: MeasureInput
+        The raw measure input
+    build_result: BuildResult
+        The result returned from Builder. This contains the path to the generated library.
+    number: int
+        The number of times to run the generated code for taking average.
+        We call these runs as one `repeat` of measurement.
+    repeat : int, optional
+        The number of times to repeat the measurement.
+        In total, the generated code will be run (1 + number x repeat) times,
+        where the first one is warm up and will be discarded.
+        The returned result contains `repeat` costs,
+        each of which is an average of `number` costs.
+    min_repeat_ms: int, optional
+        The minimum duration of one `repeat` in milliseconds.
+        By default, one `repeat` contains `number` runs. If this parameter is set,
+        the parameters `number` will be dynamically adjusted to meet the
+        minimum duration requirement of one `repeat`.
+        i.e., When the run time of one `repeat` falls below this time, the `number` parameter
+        will be automatically increased.
+    cooldown_interval: float
+        The cool down interval between two measurements
+    ref_input: List of np.ndarray
+        The reference input used for checking correctness
+    ref_output: List of np.ndarray
+        The reference output used for checking correctness
+    """
+    if isinstance(build_result, MeasureResult):
+        return build_result
+
+    tic = time.time()
+    errno = MeasureErrorNo.NO_ERROR
+    try:
+        # Program the FPGA every single time when targeting VTA
+        # FIXME(comaniac): Do we need this step for local run?
+        # if (hasattr(measure_input.target, 'device_name')
+        #         and measure_input.target.device_name == 'vta'):
+        #     # pylint: disable=import-outside-toplevel
+        #     from vta import program_fpga, reconfig_runtime
+        #     program_fpga(remote, None)
+        #     reconfig_runtime(remote)
+        func = _module.load_module(build_result.filename)
+        ctx = nd.context(str(measure_input.target), 0)
+        time_f = func.time_evaluator(func.entry_name,
+                                     ctx,
+                                     number=number,
+                                     repeat=repeat,
+                                     min_repeat_ms=min_repeat_ms)
+
+        # set input
+        if ref_input:
+            args = [nd.array(x, ctx=ctx) for x in ref_input]
+        else:
+            # create empty arrays on the remote device and copy them once.
+            # This can avoid some memory issues that make the measurement results unreliable.
+            args = [nd.empty(x[0], dtype=x[1], ctx=ctx) for x in build_result.arg_info]
+            args = [nd.array(x, ctx=ctx) for x in args]
+            ctx.sync()
+
+        costs = time_f(*args).results
+
+        if len(costs) > 2:  # remove largest and smallest value to reduce variance
+            costs = list(costs)
+            costs.sort()
+            costs = tuple(costs[1:-1])
+
+        # check correctness of output
+        if ref_output:
+            for expected, real in zip(ref_output, args):
+                if not np.allclose(expected, real.asnumpy(), rtol=1e-4):
+                    logger.warning("Wrong Answer!")
+                    errno = MeasureErrorNo.WRONG_ANSWER
+    except TVMError as exc:
+        msg = str(exc)
+        if "Stack trace returned" in msg:
+            msg = msg[:msg.index("Stack trace returned")]
+        if "CUDA Source" in msg:
+            msg = msg[:msg.index("CUDA Source")]
+        costs = (RuntimeError(msg[:1024]), )
+        errno = MeasureErrorNo.RUNTIME_DEVICE
+    tstamp = time.time()
+    time.sleep(cooldown_interval)
+    return MeasureResult(costs, errno, tstamp - tic + build_result.time_cost, tstamp)
 
 
 @tvm._ffi.register_func


### PR DESCRIPTION
### Motivation and Summary

`LocalRunner`, which measures the runtime of an op with a certain schedule config on the host machine directly, is one of the two runners in AutoTVM. However, `LocalRunner` was derived from `RPCRunner` and launched a local RPC server. The reason for this implementation was to have a unified interface and logic for both runners, but it introduces two problems:

1. Overhead.
Although local RPC session doesn't really have to send the built binary via network, it still has 1) the RPC connection overhead, and 2) an additional binary copy overhead (`RPCRunner` will upload the locally built binary to remote RPC server. In the local RPC case, it means a copy from `/tmp`to `pwd`). 

2. Reliability.
As many people have reported in the discuss, the local RPC connection may be dropped or unstable. One possible reason may come from the tornado package but it's hard to be identified and fixed. Anyway, when we are using `LocalRunner`, it doesn't make any sense to see an error or warning regrad to RPC connection.

This PR refactors AutoTVM `Runner` and fully decouples `LocalRunner` and `RPCRunner`. In summary:
* Now both `LocalRunner` and `RPCRunner` are derived from `Runner`.
* Common logic and interfaces such as "prepare golden reference for correctness checking" and "run N configs in parallel" are lifted to base `Runner` class.
* Each derived runner only needs to specify how to acquire TVM context (local or remote) and how to run oneconfig.
* No change on the user interfaces and APIs.

### Evaluation

Since user interface and underlying measurement remain the same, I just tested the first task extracted from ResNet-18 on CPU for evaluation. Both tests use `LocalRunner`.

Without this PR:

```
[Task  1/12]  Current/Best:   20.81/ 169.89 GFLOPS | Progress: (252/252) | 556.76 s Done
```

With this PR:

```
[Task  1/12]  Current/Best:   17.89/ 150.35 GFLOPS | Progress: (252/252) | 192.78 s Done
```

While I think the performance difference should be due to the measurement error, we can clearly see that this PR is capable of reducing the tuning time.

### Issue

For VTA using `RPCRunner`, it will reprogram FPGA every time before a measurement, but I am not sure if we still need this step for the real local runner. Please help review and provide your suggestions (cc @tmoreau89).

@merrymercy @eqy @kevinthesun please help to review. Thanks.