### PR TITLE
fix ROCm strategy for winograd conv selection

### DIFF
--- a/python/tvm/relay/op/strategy/rocm.py
+++ b/python/tvm/relay/op/strategy/rocm.py
@@ -48,12 +48,13 @@ def conv2d_strategy_rocm(attrs, inputs, out_type, target):
                 wrap_topi_schedule(topi.cuda.schedule_conv2d_nchw),
                 name="conv2d_nchw.cuda")
             _, _, kh, kw = get_const_tuple(kernel.shape)
-            if kh <= 7 and kw <= 7 and kh == kw and stride_h == 1 and stride_w == 1:
+            if 2 < kh < 8 and 2 < kw < 8 and kh == kw and stride_h == 1 and stride_w == 1 and \
+                dilation_h == 1 and dilation_w == 1:
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.cuda.conv2d_nchw_winograd),
                     wrap_topi_schedule(topi.cuda.schedule_conv2d_nchw_winograd),
                     name="conv2d_nchw_winograd.cuda",
-                    plevel=15)
+                    plevel=5)
         elif layout == "HWCN":
             assert kernel_layout == "HWIO"
             strategy.add_implementation(


### PR DESCRIPTION
This adapts the ROCm conv strategy to more closely match the CUDA one.
In particular we don't select winograd when it's not applicable (e.g. 1x1 convs), and replicate the priority fix done for CUDA in #4987 .

@masahi 