### PR TITLE
fix bug for slice and tile of relay's frontend for tensorflow

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -790,7 +790,7 @@ def _slice():
             size = _infer_value(inputs[2], params).asnumpy().tolist()[0]
         
         # handle situations when return empty constant
-        input0_np = _infer_value(inputs[0], params).asnumpy()  
+        input0_np = _infer_value_simulated(inputs[0], params).asnumpy()  
         input0_shape = input0_np.shape
         for input_dim_i, begin_i, size_i in zip(input0_shape, begin, size):
             # when one size_i == 0, return empty constant

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -2411,6 +2411,8 @@ def test_forward_slice():
     _test_forward_slice_operation_input([0, 1, 2, 3], [3], [-1])
     _test_forward_slice_operation_input([[0, 1, 2, 3], [4, 5, 6, 7]],
                                         begin_value=[0, 1], size_value=[-1, -1])
+    _test_forward_slice_operation_input([19], [0], [0])
+    _test_forward_slice_operation_input([19], [1], [-1])                                    
 
 def test_forward_ceil():
     ishape = (1, 3, 10, 10)


### PR DESCRIPTION
Fix bugs of `def _slice` and `def _tile` in `relay.frontend.tensorflow.py` file.

1. For `def _slice`, the codes added is used to handle situations when the `slice` operation returns an empty result, which will cause a failure when `_transform.InferType()` is called.

2. For `def _tile`, the codes added is used to fix bugs when the `rep` is a `expr.Call`.