### PR TITLE
[Bugfixes] Improved handling of tir instrinsics applied to ints. Fixed div by zero crash

### DIFF
--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -8,7 +8,7 @@
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
+# Unless required by applicable law or agreed to in writing,    
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
@@ -17,7 +17,7 @@
 # pylint: disable=redefined-builtin, invalid-name
 """Operators used in TIR expression."""
 import tvm._ffi
-from tvm.runtime import convert, const
+from tvm.runtime import convert, const, DataType, TypeCode
 from tvm.ir import Array
 
 from .buffer import Buffer
@@ -315,7 +315,7 @@ def max_value(dtype):
 
 
 def exp(x):
-    """Take exponetial of input x.
+    """Take exponential of float input x.
 
     Parameters
     ----------
@@ -327,11 +327,13 @@ def exp(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("exp only applies to float")
     return call_pure_intrin(x.dtype, "exp", x)
 
 
 def erf(x):
-    """Take gauss error function of the input x.
+    """Take gauss error function of the float input x.
 
     Parameters
     ----------
@@ -343,11 +345,13 @@ def erf(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("erf only applies to float")
     return call_pure_intrin(x.dtype, "erf", x)
 
 
 def tanh(x):
-    """Take hyperbolic tanh of input x.
+    """Take hyperbolic tanh of float input x.
 
     Parameters
     ----------
@@ -359,11 +363,13 @@ def tanh(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("tanh only applies to float")
     return call_pure_intrin(x.dtype, "tanh", x)
 
 
 def sigmoid(x):
-    """Quick function to get sigmoid
+    """Quick function to get sigmoid of float input x
 
     Parameters
     ----------
@@ -375,11 +381,13 @@ def sigmoid(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("sigmoid only applies to float")
     return call_pure_intrin(x.dtype, "sigmoid", x)
 
 
 def log(x):
-    """Take log of input x.
+    """Take log of float input x.
 
     Parameters
     ----------
@@ -391,10 +399,12 @@ def log(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("log only applies to float")
     return call_pure_intrin(x.dtype, "log", x)
 
 def tan(x):
-    """Take tan of input x.
+    """Take tan of float input x.
 
     Parameters
     ----------
@@ -406,11 +416,13 @@ def tan(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("tan only applies to float")
     return call_pure_intrin(x.dtype, "tan", x)
 
 
 def cos(x):
-    """Take cos of input x.
+    """Take cos of float input x.
 
     Parameters
     ----------
@@ -422,10 +434,12 @@ def cos(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("cos only applies to float")
     return call_pure_intrin(x.dtype, "cos", x)
 
 def sin(x):
-    """Take sin of input x.
+    """Take sin of float input x.
 
     Parameters
     ----------
@@ -437,10 +451,12 @@ def sin(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("sin only applies to float")
     return call_pure_intrin(x.dtype, "sin", x)
 
 def atan(x):
-    """Take atan of input x.
+    """Take atan of float input x.
 
     Parameters
     ----------
@@ -452,10 +468,12 @@ def atan(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("atan only applies to float")
     return call_pure_intrin(x.dtype, "atan", x)
 
 def sqrt(x):
-    """Take square root of input x.
+    """Take square root of float input x.
 
     Parameters
     ----------
@@ -467,11 +485,13 @@ def sqrt(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("sqrt only applies to float")
     return call_pure_intrin(x.dtype, "sqrt", x)
 
 
 def rsqrt(x):
-    """Take reciprocal of square root of input x.
+    """Take reciprocal of square root of float input x.
 
     Parameters
     ----------
@@ -483,6 +503,8 @@ def rsqrt(x):
     y : PrimExpr
         The result.
     """
+    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+        raise RuntimeError("rsqrt only applies to float")
     return call_pure_intrin(x.dtype, "rsqrt", x)
 
 

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -8,7 +8,7 @@
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,    
+# Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
@@ -327,7 +327,7 @@ def exp(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("exp only applies to float")
     return call_pure_intrin(x.dtype, "exp", x)
 
@@ -345,7 +345,7 @@ def erf(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("erf only applies to float")
     return call_pure_intrin(x.dtype, "erf", x)
 
@@ -363,7 +363,7 @@ def tanh(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("tanh only applies to float")
     return call_pure_intrin(x.dtype, "tanh", x)
 
@@ -381,7 +381,7 @@ def sigmoid(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("sigmoid only applies to float")
     return call_pure_intrin(x.dtype, "sigmoid", x)
 
@@ -399,7 +399,7 @@ def log(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("log only applies to float")
     return call_pure_intrin(x.dtype, "log", x)
 
@@ -416,7 +416,7 @@ def tan(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("tan only applies to float")
     return call_pure_intrin(x.dtype, "tan", x)
 
@@ -434,7 +434,7 @@ def cos(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("cos only applies to float")
     return call_pure_intrin(x.dtype, "cos", x)
 
@@ -451,7 +451,7 @@ def sin(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("sin only applies to float")
     return call_pure_intrin(x.dtype, "sin", x)
 
@@ -468,7 +468,7 @@ def atan(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("atan only applies to float")
     return call_pure_intrin(x.dtype, "atan", x)
 
@@ -485,7 +485,7 @@ def sqrt(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("sqrt only applies to float")
     return call_pure_intrin(x.dtype, "sqrt", x)
 
@@ -503,7 +503,7 @@ def rsqrt(x):
     y : PrimExpr
         The result.
     """
-    if (DataType(x.dtype).type_code != TypeCode.FLOAT):
+    if DataType(x.dtype).type_code != TypeCode.FLOAT:
         raise RuntimeError("rsqrt only applies to float")
     return call_pure_intrin(x.dtype, "rsqrt", x)
 

--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -181,6 +181,7 @@ inline PrimExpr TryConstFold<tir::ModNode>(PrimExpr a, PrimExpr b) {
   TVM_INDEX_CONST_PROPAGATION({
       const DataType& rtype = a.dtype();
       if (pa && pb) {
+        CHECK_NE(pb->value, 0) << "Divide by zero";
         return IntImm(rtype, pa->value % pb->value);
       }
       if (pa) {
@@ -226,6 +227,7 @@ inline PrimExpr TryConstFold<tir::FloorModNode>(PrimExpr a, PrimExpr b) {
   TVM_INDEX_CONST_PROPAGATION({
       const DataType& rtype = a.dtype();
       if (pa && pb) {
+        CHECK_NE(pb->value, 0) << "Divide by zero";
         return IntImm(rtype, floormod(pa->value, pb->value));
       }
       if (pa) {

--- a/src/tir/ir/op.cc
+++ b/src/tir/ir/op.cc
@@ -606,6 +606,9 @@ PrimExpr fmod(PrimExpr x, PrimExpr y) {
 }
 
 PrimExpr floor(PrimExpr x) {
+  if (x.dtype().is_int() || x.dtype().is_uint()) {
+    return x;
+  }
   using tir::FloatImmNode;
   const FloatImmNode* fx = x.as<FloatImmNode>();
   if (fx) return FloatImm(x.dtype(), std::floor(fx->value));
@@ -613,6 +616,9 @@ PrimExpr floor(PrimExpr x) {
 }
 
 PrimExpr ceil(PrimExpr x) {
+  if (x.dtype().is_int() || x.dtype().is_uint()) {
+    return x;
+  }
   using tir::FloatImmNode;
   const FloatImmNode* fx = x.as<FloatImmNode>();
   if (fx) return FloatImm(x.dtype(), std::ceil(fx->value));
@@ -620,6 +626,9 @@ PrimExpr ceil(PrimExpr x) {
 }
 
 PrimExpr round(PrimExpr x) {
+  if (x.dtype().is_int() || x.dtype().is_uint()) {
+    return x;
+  }
   using tir::FloatImmNode;
   const FloatImmNode* fx = x.as<FloatImmNode>();
   if (fx) return FloatImm(x.dtype(), std::nearbyint(fx->value));
@@ -627,6 +636,9 @@ PrimExpr round(PrimExpr x) {
 }
 
 PrimExpr nearbyint(PrimExpr x) {
+  if (x.dtype().is_int() || x.dtype().is_uint()) {
+    return x;
+  }
   using tir::FloatImmNode;
   const FloatImmNode* fx = x.as<FloatImmNode>();
   if (fx) return FloatImm(x.dtype(), std::nearbyint(fx->value));
@@ -634,6 +646,9 @@ PrimExpr nearbyint(PrimExpr x) {
 }
 
 PrimExpr trunc(PrimExpr x) {
+  if (x.dtype().is_int() || x.dtype().is_uint()) {
+    return x;
+  }
   using tir::FloatImmNode;
   const FloatImmNode* fx = x.as<FloatImmNode>();
   if (fx) {

--- a/tests/python/unittest/test_pass_equal.py
+++ b/tests/python/unittest/test_pass_equal.py
@@ -25,7 +25,7 @@ def test_equal_expr():
         return x + y + 1
 
     def func2():
-        return te.exp(tvm.tir.truncdiv((x + y + 1) * y, 4))
+        return te.abs(tvm.tir.truncdiv((x + y + 1) * y, 4))
 
     assert tvm.tir.ir_pass.Equal(func1(), func1())
     assert tvm.tir.ir_pass.Equal(func2(), func2())

--- a/tests/python/unittest/test_tvm_intrin.py
+++ b/tests/python/unittest/test_tvm_intrin.py
@@ -45,5 +45,27 @@ def test_nearbyint():
         a_rounded.asnumpy(), np.rint(a.asnumpy()))
 
 
+def test_intrinsic_argtypes():
+    for intrinsic in [tvm.tir.round, tvm.tir.trunc, tvm.tir.ceil,
+                            tvm.tir.floor, tvm.tir.nearbyint]:
+        assert intrinsic(tvm.tir.const(10,'int32')).value == 10
+        assert intrinsic(tvm.tir.const(True,'bool')).value == True
+
+    assert tvm.tir.isnan(tvm.tir.const(10, 'int32')).value == False
+    assert isinstance(tvm.tir.popcount(tvm.tir.const(10, 'int32')), tvm.tir.expr.Call)
+
+    for intrinsic in [tvm.tir.exp, tvm.tir.erf, tvm.tir.tanh,
+                            tvm.tir.sigmoid, tvm.tir.log,
+                            tvm.tir.tan, tvm.tir.cos,
+                            tvm.tir.sin, tvm.tir.atan,
+                            tvm.tir.sqrt, tvm.tir.rsqrt]:
+        try:
+            intrinsic(tvm.tir.const(10,'int32'))
+            assert False
+        except RuntimeError:
+            pass
+
+
 if __name__ == "__main__":
     test_nearbyint()
+    test_intrinsic_argtypes()


### PR DESCRIPTION
## Intrinsics

This PR improves the behaviour of many tir instrinsics when called with an integer typed argument. Previously TVM's front-end would accept a statement such as `tvm.tir.sqrt(tvm.tir.const(3,'int32'))` and then the llvm backend would fail to verify with the message:
```
TVMError: LLVM module verification failed with the following errors: 
Intrinsic has incorrect return type!
i32 (i32)* @llvm.sqrt.i32
```
This is due to many of the intrinsics being defined only for floating point types. 

The new behaviour is to raise a Python RuntimeError for the intrinsics `sin,cos,atan,tan,tanh,sigmoid,log,erf,exp,sqrt,rsqrt`.

For the intrinsics `round,trunc,ceil,floor,nearbyint` they simply returns the passed argument. For example `tvm.tir.floor(tvm.tir.const(10)) #prints 10`.

## Divide by Zero Core Dump

It appears that a few cases of dividing by zero were missed causing const_fold to trigger a floating point exception in python. For example `tvm.tir.const(2) % 0

I would appreciate a review!

@tqchen 