### PR TITLE
Look for TupleType instead of TupleNode in LayoutRewriter

### DIFF
--- a/src/relay/pass/transform_layout.h
+++ b/src/relay/pass/transform_layout.h
@@ -274,10 +274,10 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   }
 
   for (auto arg : ref_call->args) {
-    if (arg->IsInstance<TupleNode>()) {  // flatten tuple
-      Tuple tuple_arg = Downcast<Tuple>(arg);
-      for (auto x : tuple_arg->fields) {
-        input_shapes.push_back(x->type_as<TensorTypeNode>()->shape);
+    if (arg->checked_type().as<TupleTypeNode>()) {  // flatten tuple
+      auto* tuple_type = arg->type_as<TupleTypeNode>();
+      for (auto x : tuple_type->fields) {
+        input_shapes.push_back(x.as<TensorTypeNode>()->shape);
       }
     } else {
       input_shapes.push_back(arg->type_as<TensorTypeNode>()->shape);

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1043,6 +1043,18 @@ def test_alter_op_with_global_var():
 
     assert analysis.alpha_equal(a, b), "Actual = \n" + str(a)
 
+def test_tuple_type_var_node():
+    """Test that input shapes from non-Tuple nodes with TupleType are properly
+    handled."""
+    input_type = relay.TensorType((1, 16, 56, 56), "float32")
+    x = relay.var("x", relay.TupleType([input_type, input_type]))
+    # relay.concatenate only supports list of Expr inputs, so we have to use
+    # _make.concatenate instead.
+    from tvm.relay.op import _make
+    out = _make.concatenate(x, 1)
+    func = relay.Function([x], out)
+    run_opt_pass(func, [transform.InferType(), transform.AlterOpLayout()])
+
 if __name__ == "__main__":
     test_alter_op()
     test_alter_return_none()
@@ -1062,3 +1074,4 @@ if __name__ == "__main__":
     test_alter_layout_sum()
     # test_alter_layout_nhwc_nchw_arm()
     test_alter_op_with_global_var()
+    test_tuple_type_var_node()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -633,24 +633,6 @@ def test_function_lifting_inline():
     ref_mod = expected()
     assert relay.analysis.alpha_equal(partitioned, ref_mod)
 
-def test_partition_concatenate():
-    # A subgraph containing concatenate will have a Var node arg which has
-    # TupleType. LayoutRewriter which is used by AlterOpLayout had a bug and
-    # would crash when running on such a subgraph.
-    x_0 = relay.var("x_0", shape=(1, 2, 6, 6))
-    x_1 = relay.var("x_1", shape=(1, 3, 6, 6))
-    concat_inputs = [x_0, x_1]
-    out = relay.concatenate(concat_inputs, axis=1)
-    func = relay.Function(concat_inputs, out)
-
-    mod = tvm.IRModule()
-    mod["main"] = func
-
-    mod = WhiteListAnnotator(["concatenate"], "test_compiler")(mod)
-    mod = transform.PartitionGraph()(mod)
-    mod = transform.InferType()(mod)
-    mod = transform.Inline()(mod)
-    mod = transform.AlterOpLayout()(mod)
 
 if __name__ == "__main__":
     test_multi_node_compiler()
@@ -661,4 +643,3 @@ if __name__ == "__main__":
     test_extern_dnnl_mobilenet()
     test_function_lifting()
     test_function_lifting_inline()
-    test_partition_concatenate()


### PR DESCRIPTION
When getting the input shapes from the args LayoutRewriter checked for tuples only by seeing if the node is an instance of TupleNode. With that code, the following relay program would encounter an error during LayoutRewriter because the arg to the function is a relay.Var but has a TupleTypeNode instead of a TensorTypeNode as it expected.

```
def @main(%input_0: Tensor[(1, 2, 6, 6), float32], %input_1: Tensor[(1, 3, 6, 6), float32]) -> Tensor[(1, 5, 6, 6), float32] {
  %0 = (%input_0, %input_1);
  %1 = fn (%x: (Tensor[(1, 2, 6, 6), float32], Tensor[(1, 3, 6, 6), float32])) -> Tensor[(1, 5, 6, 6), float32] {
    concatenate(%x, axis=1) /* ty=Tensor[(1, 5, 6, 6), float32] */
  };
  %1(%0) /* ty=Tensor[(1, 5, 6, 6), float32] */
}
```

@zhiics @anijain2305 Could you please review?