### PR TITLE
[External Codegen] Fix annotate pass static variable

### DIFF
--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -43,7 +43,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto new_e = ExprMutator::VisitExpr_(cn);
 
     Call call = Downcast<Call>(new_e);
-    static auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target_);
+    auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target_);
     Op op = Downcast<Op>(call->op);
     CHECK(op.defined());
 


### PR DESCRIPTION
'fannotate' in the annotate_target pass was designated as static. This meant that if you use the pass to annotate more than one codegen, its value is not updated when the target changes resulting in incorrect annotation.