### PR TITLE
[RELAY] Remove kCompiler attr from ext mod

### DIFF
--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -627,6 +627,7 @@ class CompileEngineImpl : public CompileEngineNode {
         const tvm::tir::StringImmNode* symbol_name = ext_symbol.as<tvm::tir::StringImmNode>();
         CHECK(symbol_name) << "No external symbol is set for:\n" << AsText(src_func, false);
         auto gv = GlobalVar(symbol_name->value);
+        src_func = FunctionSetAttr(src_func, attr::kCompiler, tir::StringImmNode::make("default"));
         ext_mods[code_gen->value]->Add(gv, src_func);
         cached_ext_funcs.push_back(it.first);
       }

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -627,7 +627,7 @@ class CompileEngineImpl : public CompileEngineNode {
         const tvm::tir::StringImmNode* symbol_name = ext_symbol.as<tvm::tir::StringImmNode>();
         CHECK(symbol_name) << "No external symbol is set for:\n" << AsText(src_func, false);
         auto gv = GlobalVar(symbol_name->value);
-        src_func = FunctionSetAttr(src_func, attr::kCompiler, tir::StringImmNode::make("default"));
+        src_func = WithAttr(src_func, attr::kCompiler, tir::StringImmNode::make("default"));
         ext_mods[code_gen->value]->Add(gv, src_func);
         cached_ext_funcs.push_back(it.first);
       }


### PR DESCRIPTION
Functions in external modules kept their kCompiler attribute which means UseDefaultCompiler returns false. This prevents you from being able to run any passes on these external modules. By setting this attribute to 'default' when we add the function to the external module, we allow for passes to be run external modules.