### PR TITLE
[CI] Temporary disable rust test

### DIFF
--- a/tests/scripts/task_rust.sh
+++ b/tests/scripts/task_rust.sh
@@ -19,6 +19,10 @@
 set -e
 set -u
 
+# Temporary disable rust tests
+# remove this line to re-enable.
+exit 0
+
 export TVM_HOME="$(git rev-parse --show-toplevel)"
 
 export LD_LIBRARY_PATH="$TVM_HOME/lib:$TVM_HOME/build:${LD_LIBRARY_PATH:-}"


### PR DESCRIPTION
https://github.com/apache/incubator-tvm/pull/4976 incorporated a major change to the rust codebase and re-enabled the CI. 

But there are some issues(likely due to rust version in the Docker image) before we can re-enable CI. This PR temporarily disable the rust ci so we can unblock other ongoing PRs.

Subsequent PRs to fix the rust CI can uncomment this line.