### PR TITLE
[TF][RELAY] Support for AddV2 in Relay Tensorflow frontend converter.

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1522,6 +1522,7 @@ _freezed_graph_pruned_op_list = ['ReadVariableOp', 'ResourceGather', 'Variable',
 _convert_map = {
     'Abs'                               : AttrCvt('abs'),
     'Add'                               : _elemwise('add'),
+    'AddV2'                             : _elemwise('add'),
     'AddN'                              : _add_n(),
     'All'                               : _reduce('all'),
     'Any'                               : _reduce('any'),


### PR DESCRIPTION
The AddV2 op is a stricter version of Add (it doesn't allow strings as inputs), so there should be no issue in mapping it to the `add` op.