### PR TITLE
[CODEGEN] Add support for extern prologue/epilogue functions

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -659,6 +659,10 @@ constexpr const char* reduce_scope = "reduce_scope";
 constexpr const char* pragma_scope_prefix = "pragma_";
 /*! \brief Import llvm source or file into the final code gen module */
 constexpr const char* pragma_import_llvm = "pragma_import_llvm";
+/*! \brief Mark prologue function to execute for scope */
+constexpr const char* pragma_prologue = "pragma_prologue";
+/*! \brief Mark epilogue function to execute for scope */
+constexpr const char* pragma_epilogue = "pragma_epilogue";
 /*! \brief Try to modify the AST to support Tensor Core */
 constexpr const char* pragma_tensor_core = "pragma_tensor_core";
 /*!

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -73,6 +73,7 @@ class CodeGenCPU : public CodeGenLLVM {
   // Lazy entry for function call.
   llvm::FunctionType* ftype_tvm_static_init_callback_{nullptr};
   llvm::FunctionType* ftype_tvm_static_init_{nullptr};
+  llvm::FunctionType* ftype_tvm_prologue_epilogue_{nullptr};
 
  private:
   // the parallel group information
@@ -93,6 +94,7 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* RuntimeTVMAPISetLastError();
   llvm::Value* RuntimeTVMParallelLaunch();
   llvm::Value* RuntimeTVMParallelBarrier();
+  llvm::Function* GetExternFunc(const std::string &func_name);
   llvm::Value* CreateStaticHandle();
   llvm::Value* GetPackedFuncHandle(const std::string& str);
   llvm::Value* PackClosureData(const Array<Var>& fields, uint64_t *num_bytes);
@@ -109,6 +111,9 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* CreateCallPacked(const CallNode* op);
   // Create trace call into tvm packed function.
   llvm::Value* CreateCallTracePacked(const CallNode *op);
+  // Create prologue and epilogue function call
+  void CreatePrologue(const std::string& func_name, const Stmt& body);
+  void CreateEpilogue(const std::string& func_name, const Stmt& body);
   // Create static initialization
   void CreateStaticInit(const std::string& init_fname, const Stmt& body);
   // Create parallel launch


### PR DESCRIPTION
This commmit adds support for adding prologue and/or epilogue function calls for a code block via the pragma schedule.  A dummy use can be found here: https://gist.github.com/KireinaHoro/c959170557d75d81c52c116c3750d78a

The addition is proposed to support better control in the generated code when using the tensorize and inline asm flows to do codegen for something like [Gemmini](https://github.com/ucb-bar/gemmini), which requires explicit `fence` instructions to block the execution flow until data has been fully flushed back to DRAM.  With this change an external function that does the `fence` can be placed in the epilogue of a computation.  The prologue pragma may be useful in similar situations when a device needs some sort of initialization, and is added for symmetry.