### PR TITLE
CI: Install apt-transport-https

### DIFF
--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -23,6 +23,8 @@ set -o pipefail
 # install libraries for building c++ core on ubuntu
 apt-get update && apt-get install -y --no-install-recommends \
         git make libgtest-dev cmake wget unzip libtinfo-dev libz-dev\
-        libcurl4-openssl-dev libopenblas-dev g++ sudo
+        libcurl4-openssl-dev libopenblas-dev g++ sudo \
+        apt-transport-https
+
 
 cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib


### PR DESCRIPTION
The ubuntu_install_llvm.sh script started failing because of a http to
https redirect.  This patch adds the package that allows apt to handle
https transport.

Change-Id: I70bcba32a9fc75d02c54f4f21f288b2f46226689