### PR TITLE
[Bugfix][IR][ATTRS] Fix AttrEqual for Array and StrMap, double

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -143,8 +143,13 @@ class AttrsEqualHandler;
 class AttrsEqual {
  public:
   bool operator()(const double& lhs, const double& rhs) const {
-    return lhs == rhs;
+    // fuzzy float pt comparison
+    constexpr double atol = 1e-9;
+    if (lhs == rhs) return true;
+    double diff = lhs - rhs;
+    return diff > -atol && diff < atol;
   }
+
   bool operator()(const int64_t& lhs, const int64_t& rhs) const {
     return lhs == rhs;
   }

--- a/src/printer/doc.cc
+++ b/src/printer/doc.cc
@@ -40,9 +40,6 @@ class DocTextNode : public DocAtomNode {
 
   explicit DocTextNode(std::string str_val)
       : str(str_val) {
-    if (str.find_first_of("\t\n") != str.npos) {
-      LOG(WARNING) << "text node: '" << str << "' should not has tab or newline.";
-    }
   }
 
   static constexpr const char* _type_key = "printer.DocText";
@@ -54,6 +51,9 @@ TVM_REGISTER_OBJECT_TYPE(DocTextNode);
 class DocText : public DocAtom {
  public:
   explicit DocText(std::string str) {
+    if (str.find_first_of("\t\n") != str.npos) {
+      LOG(WARNING) << "text node: '" << str << "' should not has tab or newline.";
+    }
     data_ = runtime::make_object<DocTextNode>(str);
   }
 
@@ -123,6 +123,10 @@ Doc Doc::NewLine(int indent) {
 
 Doc Doc::Text(std::string text) {
   return Doc() << DocText(text);
+}
+
+Doc Doc::RawText(std::string text) {
+  return Doc() << DocAtom(runtime::make_object<DocTextNode>(text));
 }
 
 Doc Doc::Indent(int indent, Doc doc) {

--- a/src/printer/doc.h
+++ b/src/printer/doc.h
@@ -111,6 +111,11 @@ class Doc {
    */
   static Doc Text(std::string value);
   /*!
+   * \brief Create a doc that represents raw text(can have new lines)
+   * \return The created doc.
+   */
+  static Doc RawText(std::string value);
+  /*!
    * \brief Create a doc that represents a new line.
    * \return The created doc.
    */

--- a/src/printer/meta_data.h
+++ b/src/printer/meta_data.h
@@ -121,7 +121,7 @@ class TextMetaDataContext {
    */
   Doc GetMetaSection() const {
     if (meta_data_.size() == 0) return Doc();
-    return Doc::Text(
+    return Doc::RawText(
         SaveJSON(Map<std::string, ObjectRef>(meta_data_.begin(), meta_data_.end())));
   }
 

--- a/tests/python/unittest/test_ir_attrs.py
+++ b/tests/python/unittest/test_ir_attrs.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te
+import tvm.ir._ffi_api
 
 def test_make_attrs():
     try:
@@ -50,6 +50,19 @@ def test_dict_attrs():
     assert len(dattr.items()) == 4
 
 
+def test_attrs_equal():
+    attr_equal = tvm.ir._ffi_api.AttrsEqual
+    dattr0 = tvm.ir.make_node("DictAttrs", x=1, y=[10, 20])
+    dattr1 = tvm.ir.make_node("DictAttrs", y=[10, 20], x=1)
+    dattr2 = tvm.ir.make_node("DictAttrs", x=1, y=None)
+    assert attr_equal(dattr0, dattr1)
+    assert not attr_equal(dattr0, dattr2)
+    assert not attr_equal({"x": 1}, tvm.runtime.convert(1))
+    assert not attr_equal([1, 2], tvm.runtime.convert(1))
+
+
+
 if __name__ == "__main__":
     test_make_attrs()
     test_dict_attrs()
+    test_attrs_equal()


### PR DESCRIPTION
- Use fuzzy comparison for double.
- Removed the hack for BatchNormAttrs and DictAttr.

Also removed a warning from text printer printing.

cc @MarisaKirisame @zhiics @merrymercy @jroesch @spectrometerHBH 
