### PR TITLE
[Draft][BYOC] Annotation Target with Merging

### DIFF
--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -60,7 +60,7 @@ _register_external_op_helper("nn.conv2d")
 _register_external_op_helper("nn.dense")
 _register_external_op_helper("nn.relu")
 _register_external_op_helper("add")
-_register_external_op_helper("subtract")
+#_register_external_op_helper("subtract")
 _register_external_op_helper("multiply")
 
 

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -584,7 +584,7 @@ def AnnotateTargetWithMerge(target):
         The annotated pass that wrapps ops with subgraph_start and
         subgraph_end.
     """
-    return _transform.AnnotateTargetWithMerge(target)
+    return _ffi_api.AnnotateTargetWithMerge(target)
 
 
 def Inline():

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -570,6 +570,23 @@ def AnnotateTarget(target):
     return _ffi_api.AnnotateTarget(target)
 
 
+def AnnotateTargetWithMerge(target):
+    """Annotate ops in an experession with a provied compiler/target and merge them greedy.
+
+    Parameters
+    ----------
+    target : String
+        The target compiler used for codegen.
+
+    Returns
+    -------
+    ret : tvm.relay.Pass
+        The annotated pass that wrapps ops with subgraph_start and
+        subgraph_end.
+    """
+    return _transform.AnnotateTargetWithMerge(target)
+
+
 def Inline():
     """Perform inlining on the given Relay IR module. The global functions that
     are marked as `inline` should be always inlined. A cost model will be

--- a/src/relay/pass/annotate_target_with_merge.cc
+++ b/src/relay/pass/annotate_target_with_merge.cc
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/pass/annotate_target_with_merge.cc
+ * \brief Wraps a call with compiler_begin and compiler_end to indicate that
+ * the op of this call node will use external compiler.
+ */
+
+#include <tvm/relay/attrs/annotation.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
+
+namespace tvm {
+namespace relay {
+namespace annotate_target_with_merge {
+
+/*!
+ * \brief The annotation group properties.
+ */
+struct AnnotateGroup {
+  /*! \brief The group ID. */
+  int id;
+
+  /*! \brief Output node of this group. */
+  Expr out;
+
+  /*! \brief Nodes in this group. */
+  std::unordered_set<Expr, ObjectHash, ObjectEqual> nodes;
+
+  /*! \brief The target for this group. */
+  std::string target;
+
+  /*! \brief Restricted gorup IDs. */
+  std::unordered_set<int> restricts;
+};
+
+// A visitor to determine where to insert annotations for which target.
+class AnalyzeAnnotateTargets : public ExprVisitor {
+ public:
+  explicit AnalyzeAnnotateTargets(Array<tvm::PrimExpr> targets) {
+    for (auto target : targets) {
+      auto* str_target = target.as<tir::StringImmNode>();
+      this->targets_.push_back(str_target->value);
+    }
+  }
+
+  std::shared_ptr<AnnotateGroup> CreateAnnotateGroup(const Expr node,
+                                                     std::vector<std::string>& supported_targets) {
+    auto ret = this->groups_.emplace(std::make_shared<AnnotateGroup>());
+    auto group = *ret.first;
+    group->id = this->curr_group_id_++;
+    if (!supported_targets.empty()) {
+      // A heuristic to offload this node to the first offloadable target.
+      group->target = supported_targets.front();
+    }
+    group->nodes.insert(node);
+    group->out = node;
+    return group;
+  }
+
+  std::shared_ptr<AnnotateGroup> GetAnnotateGroup(const Expr node) {
+    for (auto candidate : this->groups_) {
+      if (candidate->nodes.find(node) != candidate->nodes.end()) {
+        return candidate;
+      }
+    }
+    return nullptr;
+  }
+
+  void MergeAnnotateGroup(std::shared_ptr<AnnotateGroup> group1,
+                          std::shared_ptr<AnnotateGroup> group2) {
+    if (group1 == group2) {
+      return;
+    } else if (group1->target != group2->target) {
+      return;
+    }
+
+    // Merge group 2 to group 1 and erase group 2.
+    // FIXME (@comaniac): We do not update the "out" in this function and
+    // let caller deal with it for simplify.
+    group1->nodes.insert(group2->nodes.begin(), group2->nodes.end());
+    group1->restricts.insert(group2->restricts.begin(), group2->restricts.end());
+    this->groups_.erase(group2);
+  }
+
+  void AddToAnnotateGroup(std::shared_ptr<AnnotateGroup> group, const Expr expr) {
+    CHECK(!GetAnnotateGroup(expr)); // The expr cannot be in the other group.
+    group->nodes.insert(expr);
+    group->out = expr;
+  }
+
+  void PrintGroups() {
+    for (auto group : this->groups_) {
+      std::cerr << "Group " << group->id << std::endl;
+      std::cerr << "\tNodes #: " << group->nodes.size() << std::endl;
+      std::cerr << "\tOut: " << AsText(group->out, false) << std::endl;
+    }
+  }
+
+  void VisitExpr_(const CallNode* call) {
+    Op op = Downcast<Op>(call->op);
+    CHECK(op.defined());
+
+    // Supported targets for this node. The order implies the priority.
+    std::vector<std::string> supported_targets;
+
+    // Check which targets this op can be offloaded.
+    for (auto target : this->targets_) {
+      static auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target);
+      if (fannotate.count(op) && fannotate[op](call->attrs, call->args)) {
+        supported_targets.push_back(target);
+      }
+    }
+    if (supported_targets.empty()) {
+      LOG(WARNING) << op->name << " is not registered in any targets. It will be executed on CPU.";
+    }
+    supported_targets.push_back("default"); // Make default as the last option.
+
+    // Traverse arguments.
+    std::unordered_set<std::shared_ptr<AnnotateGroup>> arg_groups;
+    for (const auto& it : call->args) {
+      VisitExpr(it);
+      auto group = GetAnnotateGroup(it);
+      if (group) {
+        arg_groups.insert(group);
+      }
+    }
+
+    // Try to join groups that arguments belong to.
+    std::shared_ptr<AnnotateGroup> joined_group = nullptr;
+    std::unordered_set<int32_t> restricted_ids;
+
+    // Check for blocked groups.
+    for (auto group : arg_groups) {
+      for (auto rid : group->restricts) {
+        restricted_ids.insert(rid);
+      }
+    }
+
+    // Determine the first highest priority target group that does not be blocked.
+    int curr_priority = supported_targets.size();
+    for (auto group : arg_groups) {
+      if (restricted_ids.find(group->id) != restricted_ids.end()) {
+        continue;
+      }
+      auto it = std::find(supported_targets.begin(), supported_targets.end(), group->target);
+      if (it != supported_targets.cend()) {
+        auto priority = std::distance(supported_targets.begin(), it);
+        if (priority < curr_priority) {
+          joined_group = group;
+          curr_priority = priority;
+        }
+      }
+    }
+
+    if (joined_group && (joined_group->target != "default" || supported_targets.size() == 1)) {
+      // Join the group.
+      AddToAnnotateGroup(joined_group, GetRef<Call>(call));
+    } else {
+      // Failed to join any argument groups. Create a new one.
+      joined_group = CreateAnnotateGroup(GetRef<Call>(call), supported_targets);
+    }
+
+    // Merge other non-blocked groups with the same target, or block other groups from re-joining.
+    for (auto group : arg_groups) {
+      if (joined_group == group) {
+        continue;
+      } else if (joined_group->target == group->target &&
+          restricted_ids.find(group->id) == restricted_ids.end()) {
+        MergeAnnotateGroup(joined_group, group);
+      } else {
+        joined_group->restricts.insert(group->id);
+      }
+    }
+  }
+
+ private:
+  int curr_group_id_ = 0; 
+  std::vector<std::string> targets_;
+  std::unordered_set<std::shared_ptr<AnnotateGroup>> groups_;
+};
+
+class AnnotateTargetWithMergeWrapper : public ExprMutator {
+ public:
+  explicit AnnotateTargetWithMergeWrapper() : target_("dnnl") {}
+
+  Expr VisitExpr_(const CallNode* cn) {
+    // TODO(@zhiics, @comaniac) Handle composite functions.
+    auto new_e = ExprMutator::VisitExpr_(cn);
+
+    Call call = Downcast<Call>(new_e);
+    static auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target_);
+    Op op = Downcast<Op>(call->op);
+    CHECK(op.defined());
+
+    if (fannotate.count(op)) {
+      bool external = fannotate[op](call->attrs, call->args);
+      if (external) {
+        tvm::Array<tvm::relay::Expr> compiler_begins;
+        for (const auto& it : call->args) {
+          const auto* begin_op = runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
+          CHECK(begin_op);
+          Expr begin = (*begin_op)(it, target_);
+          compiler_begins.push_back(begin);
+        }
+        Expr update_call = CallNode::make(call->op, compiler_begins, call->attrs);
+        const auto* end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
+        CHECK(end_op);
+        Expr end = (*end_op)(update_call, target_);
+        return end;
+      }
+    } else {
+      LOG(WARNING) << op->name << " in " << target_
+                   << " is not registered. It will be executed on CPU.";
+    }
+    return new_e;
+  }
+
+ private:
+  std::string target_;
+};
+
+Expr AnnotateTargetWithMerge(const Expr& expr, Array<tvm::PrimExpr> targets) {
+  auto analyzer = AnalyzeAnnotateTargets(targets);
+  analyzer.VisitExpr(expr);
+  analyzer.PrintGroups();
+  return AnnotateTargetWithMergeWrapper().Mutate(expr);
+}
+
+}  // namespace annotate_target_with_merge
+
+namespace transform {
+
+Pass AnnotateTargetWithMerge(Array<tvm::PrimExpr> targets) {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        return Downcast<Function>(
+            relay::annotate_target_with_merge::AnnotateTargetWithMerge(f, targets));
+      };
+  auto func_pass = CreateFunctionPass(pass_func, 0, "AnnotateTargetWithMergeFunc",
+                                      {tir::StringImmNode::make("InferType")});
+  return transform::Sequential({func_pass, InferType()}, "AnnotateTargetWithMerge");
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.AnnotateTargetWithMerge")
+.set_body_typed(AnnotateTargetWithMerge);
+
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/transforms/annotate_target_with_merge.cc
+++ b/src/relay/transforms/annotate_target_with_merge.cc
@@ -48,8 +48,8 @@ struct AnnotateGroup {
   /*! \brief The target for this group. */
   std::string target;
 
-  /*! \brief Restricted gorup IDs. */
-  std::unordered_set<int> restricts;
+  /*! \brief Block gorup IDs. */
+  std::unordered_set<int> blocks;
 };
 
 // A visitor to determine where to insert annotations for which target.
@@ -87,7 +87,7 @@ class AnalyzeAnnotateTargets : public ExprVisitor {
 
   void MergeAnnotateGroup(std::shared_ptr<AnnotateGroup> group1,
                           std::shared_ptr<AnnotateGroup> group2) {
-    if (group1 == group2) {
+    if (group1->id == group2->id) {
       return;
     } else if (group1->target != group2->target) {
       return;
@@ -97,7 +97,7 @@ class AnalyzeAnnotateTargets : public ExprVisitor {
     // FIXME (@comaniac): We do not update the "out" in this function and
     // let caller deal with it for simplify.
     group1->nodes.insert(group2->nodes.begin(), group2->nodes.end());
-    group1->restricts.insert(group2->restricts.begin(), group2->restricts.end());
+    group1->blocks.insert(group2->blocks.begin(), group2->blocks.end());
     this->groups_.erase(group2);
   }
 
@@ -112,6 +112,80 @@ class AnalyzeAnnotateTargets : public ExprVisitor {
       std::cerr << "Group " << group->id << std::endl;
       std::cerr << "\tNodes #: " << group->nodes.size() << std::endl;
       std::cerr << "\tOut: " << AsText(group->out, false) << std::endl;
+    }
+  }
+
+  std::unordered_set<std::shared_ptr<AnnotateGroup>> GetGroups() {
+    std::unordered_set<std::shared_ptr<AnnotateGroup>> groups;
+    for (auto group : this->groups_) {
+      if (group->target != "default") {
+        groups.insert(group);
+      }
+    }
+    return groups;
+  }
+
+  void JoinArgAnnotateGroup(const Array<Expr> args,
+                            std::vector<std::string> supported_targets,
+                            Expr node_expr) {
+    // Try to join groups that arguments belong to.
+    std::shared_ptr<AnnotateGroup> joined_group = nullptr;
+    std::unordered_set<int32_t> blocked_ids;
+
+    // Traverse arguments.
+    std::unordered_set<std::shared_ptr<AnnotateGroup>> arg_groups;
+    for (const auto& it : args) {
+      VisitExpr(it);
+      auto group = GetAnnotateGroup(it);
+      if (group) {
+        arg_groups.insert(group);
+      }
+    }
+
+    // Check for blocked groups.
+    for (auto group : arg_groups) {
+      for (auto rid : group->blocks) {
+        blocked_ids.insert(rid);
+      }
+    }
+
+    // Determine the first highest priority target group that does not be blocked.
+    int curr_priority = supported_targets.size();
+    for (auto group : arg_groups) {
+      if (blocked_ids.find(group->id) != blocked_ids.end()) {
+        continue;
+      }
+      auto it = std::find(supported_targets.begin(), supported_targets.end(), group->target);
+      if (it != supported_targets.cend()) {
+        auto priority = std::distance(supported_targets.begin(), it);
+        if (priority < curr_priority) {
+          joined_group = group;
+          curr_priority = priority;
+        }
+      }
+    }
+
+    if (joined_group && (joined_group->target != "default" || supported_targets.size() == 1)) {
+      // Join the group.
+      AddToAnnotateGroup(joined_group, node_expr);
+    } else {
+      // Failed to join any argument groups. Create a new one.
+      joined_group = CreateAnnotateGroup(node_expr, supported_targets);
+
+      // Inherit block IDs from arguments.
+      joined_group->blocks.insert(blocked_ids.begin(), blocked_ids.end());
+    }
+
+    // Merge other non-blocked groups with the same target, or block other groups from re-joining.
+    for (auto group : arg_groups) {
+      if (joined_group->id == group->id) {
+        continue;
+      } else if (joined_group->target == group->target &&
+                 blocked_ids.find(group->id) == blocked_ids.end()) {
+        MergeAnnotateGroup(joined_group, group);
+      } else {
+        joined_group->blocks.insert(group->id);
+      }
     }
   }
 
@@ -133,63 +207,38 @@ class AnalyzeAnnotateTargets : public ExprVisitor {
       LOG(WARNING) << op->name << " is not registered in any targets. It will be executed on CPU.";
     }
     supported_targets.push_back("default"); // Make default as the last option.
+    JoinArgAnnotateGroup(call->args, supported_targets, GetRef<Call>(call));
+  }
 
-    // Traverse arguments.
-    std::unordered_set<std::shared_ptr<AnnotateGroup>> arg_groups;
-    for (const auto& it : call->args) {
-      VisitExpr(it);
-      auto group = GetAnnotateGroup(it);
-      if (group) {
-        arg_groups.insert(group);
-      }
-    }
+  void VisitExpr_(const TupleNode* op) final {
+    JoinArgAnnotateGroup(op->fields, {"default"}, GetRef<Tuple>(op));
+  }
 
-    // Try to join groups that arguments belong to.
-    std::shared_ptr<AnnotateGroup> joined_group = nullptr;
-    std::unordered_set<int32_t> restricted_ids;
+  void VisitExpr_(const TupleGetItemNode* op) final {
+    JoinArgAnnotateGroup(Array<Expr>({op->tuple}), {"default"}, GetRef<TupleGetItem>(op));
+  }
 
-    // Check for blocked groups.
-    for (auto group : arg_groups) {
-      for (auto rid : group->restricts) {
-        restricted_ids.insert(rid);
-      }
-    }
+  void VisitExpr_(const LetNode* op) final {
+    std::vector<Expr> args = {op->var, op->value, op->body};
+    JoinArgAnnotateGroup(Array<Expr>(args), {"default"}, GetRef<Let>(op));
+  }
 
-    // Determine the first highest priority target group that does not be blocked.
-    int curr_priority = supported_targets.size();
-    for (auto group : arg_groups) {
-      if (restricted_ids.find(group->id) != restricted_ids.end()) {
-        continue;
-      }
-      auto it = std::find(supported_targets.begin(), supported_targets.end(), group->target);
-      if (it != supported_targets.cend()) {
-        auto priority = std::distance(supported_targets.begin(), it);
-        if (priority < curr_priority) {
-          joined_group = group;
-          curr_priority = priority;
-        }
-      }
-    }
+  void VisitExpr_(const IfNode* op) final {
+    std::vector<Expr> args = {op->cond, op->true_branch, op->false_branch};
+    JoinArgAnnotateGroup(args, {"default"}, GetRef<If>(op));
+  }
 
-    if (joined_group && (joined_group->target != "default" || supported_targets.size() == 1)) {
-      // Join the group.
-      AddToAnnotateGroup(joined_group, GetRef<Call>(call));
-    } else {
-      // Failed to join any argument groups. Create a new one.
-      joined_group = CreateAnnotateGroup(GetRef<Call>(call), supported_targets);
-    }
+  void VisitExpr_(const RefCreateNode* op) final {
+    JoinArgAnnotateGroup(Array<Expr>({op->value}), {"default"}, GetRef<RefCreate>(op));
+  }
 
-    // Merge other non-blocked groups with the same target, or block other groups from re-joining.
-    for (auto group : arg_groups) {
-      if (joined_group == group) {
-        continue;
-      } else if (joined_group->target == group->target &&
-          restricted_ids.find(group->id) == restricted_ids.end()) {
-        MergeAnnotateGroup(joined_group, group);
-      } else {
-        joined_group->restricts.insert(group->id);
-      }
-    }
+  void VisitExpr_(const RefReadNode* op) final {
+    JoinArgAnnotateGroup(Array<Expr>({op->ref}), {"default"}, GetRef<RefRead>(op));
+  }
+
+  void VisitExpr_(const RefWriteNode* op) final {
+    std::vector<Expr> args = {op->ref, op->value};
+    JoinArgAnnotateGroup(Array<Expr>(args), {"default"}, GetRef<RefWrite>(op));
   }
 
  private:
@@ -200,49 +249,78 @@ class AnalyzeAnnotateTargets : public ExprVisitor {
 
 class AnnotateTargetWithMergeWrapper : public ExprMutator {
  public:
-  explicit AnnotateTargetWithMergeWrapper() : target_("dnnl") {}
+  explicit AnnotateTargetWithMergeWrapper(std::unordered_set<std::shared_ptr<AnnotateGroup>> groups)
+      : groups_(groups) {}
 
-  Expr VisitExpr_(const CallNode* cn) {
+
+  Expr VisitExpr_(const CallNode* call) {
     // TODO(@zhiics, @comaniac) Handle composite functions.
-    auto new_e = ExprMutator::VisitExpr_(cn);
 
-    Call call = Downcast<Call>(new_e);
-    static auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target_);
-    Op op = Downcast<Op>(call->op);
-    CHECK(op.defined());
+    tvm::Array<tvm::relay::Expr> new_args;
+    auto group = GetAnnotateGroup(GetRef<Call>(call));
+    for (const auto& it : call->args) {
+      auto new_arg = VisitExpr(it);
+      auto arg_group = GetAnnotateGroup(it);
 
-    if (fannotate.count(op)) {
-      bool external = fannotate[op](call->attrs, call->args);
-      if (external) {
-        tvm::Array<tvm::relay::Expr> compiler_begins;
-        for (const auto& it : call->args) {
-          const auto* begin_op = runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
-          CHECK(begin_op);
-          Expr begin = (*begin_op)(it, target_);
-          compiler_begins.push_back(begin);
-        }
-        Expr update_call = CallNode::make(call->op, compiler_begins, call->attrs);
+      // Insert compiler_end to close the group that the argument belongs to if
+      // the argument belongs to a different group.
+      if (arg_group && (!group || arg_group->id != group->id)) {
         const auto* end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
         CHECK(end_op);
-        Expr end = (*end_op)(update_call, target_);
-        return end;
+        new_arg = (*end_op)(new_arg, arg_group->target);
       }
-    } else {
-      LOG(WARNING) << op->name << " in " << target_
-                   << " is not registered. It will be executed on CPU.";
+
+      // Insert compiler_begin to start this group if the argument belongs to a different group.
+      if (group) {
+        if (!arg_group || arg_group->id != group->id) {
+          const auto* begin_op = runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
+          CHECK(begin_op);
+          new_arg = (*begin_op)(new_arg, group->target);
+        }
+      }
+      new_args.push_back(new_arg);
     }
-    return new_e;
+    return CallNode::make(call->op, new_args, call->attrs);
+  }
+
+  Expr VisitExpr_(const FunctionNode* op) final {
+    // Insert compiler_end to the last node of this function if it belongs to a group.
+    auto group = GetAnnotateGroup(op->body);
+    if (group) {
+      Array<Var> params;
+      for (auto param : op->params) {
+        Var new_param = Downcast<Var>(VisitExpr(param));
+        params.push_back(new_param);
+      }
+      auto body = VisitExpr(op->body);
+      Call last_call = Downcast<Call>(body);
+      Expr update_call = CallNode::make(last_call->op, last_call->args, last_call->attrs);
+      const auto* end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
+      CHECK(end_op);
+      Expr new_body = (*end_op)(update_call, group->target);
+      return Function(params, new_body, op->ret_type, op->type_params, op->attrs);
+    }
+    return ExprMutator::VisitExpr_(op);
   }
 
  private:
-  std::string target_;
+  // TODO(@comaniac): Move this function to a common place to share with AnalyzeAnnotateTargets.
+  std::shared_ptr<AnnotateGroup> GetAnnotateGroup(const Expr node) {
+    for (auto candidate : this->groups_) {
+      if (candidate->nodes.find(node) != candidate->nodes.end()) {
+        return candidate;
+      }
+    }
+    return nullptr;
+  }
+
+  std::unordered_set<std::shared_ptr<AnnotateGroup>> groups_;
 };
 
 Expr AnnotateTargetWithMerge(const Expr& expr, Array<tvm::PrimExpr> targets) {
   auto analyzer = AnalyzeAnnotateTargets(targets);
   analyzer.VisitExpr(expr);
-  analyzer.PrintGroups();
-  return AnnotateTargetWithMergeWrapper().Mutate(expr);
+  return AnnotateTargetWithMergeWrapper(analyzer.GetGroups()).Mutate(expr);
 }
 
 }  // namespace annotate_target_with_merge

--- a/tests/python/relay/test_annotate_target.py
+++ b/tests/python/relay/test_annotate_target.py
@@ -213,13 +213,58 @@ def test_annotate_with_merge():
         mod = tvm.IRModule.from_expr(f)
         return mod
 
+    def expected():
+        in_1 = relay.var('in_1', shape=(10, 10), dtype='float32')
+        in_2 = relay.var('in_2', shape=(10, 10), dtype='float32')
+        in_3 = relay.var('in_3', shape=(10, 10), dtype='float32')
+        in_4 = relay.var('in_4', shape=(10, 10), dtype='float32')
+        in_5 = relay.var('in_5', shape=(10, 10), dtype='float32')
+        in_6 = relay.var('in_6', shape=(10, 10), dtype='float32')
+        in_7 = relay.var('in_7', shape=(10, 10), dtype='float32')
+        in_8 = relay.var('in_8', shape=(10, 10), dtype='float32')
+        in_9 = relay.var('in_9', shape=(10, 10), dtype='float32')
+        in_10 = relay.var('in_10', shape=(10, 10), dtype='float32')
+
+        begin0 = relay.annotation.compiler_begin(in_1, "dnnl")
+        begin1 = relay.annotation.compiler_begin(in_2, "dnnl")
+        begin2 = relay.annotation.compiler_begin(in_3, "dnnl")
+        begin3 = relay.annotation.compiler_begin(in_4, "dnnl")
+        node0 = relay.add(begin0, begin1)
+        node1 = relay.add(begin2, begin3)
+        node2 = relay.add(node0, node1)
+
+        node3 = relay.subtract(in_5, in_6)
+        node4 = relay.subtract(in_7, node3)
+
+        begin4 = relay.annotation.compiler_begin(node4, "dnnl")
+        begin5 = relay.annotation.compiler_begin(in_9, "dnnl")
+
+        node5 = relay.add(node2, begin4)
+        end0 = relay.annotation.compiler_end(node5, "dnnl")
+
+        node6 = relay.subtract(in_8, end0)
+        node7 = relay.add(begin5, node5)
+        end1 = relay.annotation.compiler_end(node7, "dnnl")
+        begin6 = relay.annotation.compiler_begin(end1, "dnnl")
+        begin7 = relay.annotation.compiler_begin(node6, "dnnl")
+
+        node8 = relay.add(begin7, begin6)
+
+        begin8 = relay.annotation.compiler_begin(in_10, "dnnl")
+        node9 = relay.add(begin8, node8)
+        end2 = relay.annotation.compiler_end(node9, "dnnl")
+
+        f = relay.Function([in_1, in_2, in_3, in_4, in_5, in_6, in_7, in_8, in_9, in_10], end2)
+        mod = tvm.IRModule.from_expr(f)
+        return mod
+
     mod = annotated()
     mod = transform.AnnotateTargetWithMerge(["dnnl"])(mod)
-    #ref_mod = expected(dtype, ishape, w1shape)
-    #assert relay.analysis.alpha_equal(mod, ref_mod)
+    ref_mod = expected()
+    assert relay.analysis.alpha_equal(mod, ref_mod)
 
 
 if __name__ == "__main__":
-    #test_extern_dnnl()
-    #test_extern_dnnl_mobilenet()
+    test_extern_dnnl()
+    test_extern_dnnl_mobilenet()
     test_annotate_with_merge()

--- a/tests/python/relay/test_annotate_target.py
+++ b/tests/python/relay/test_annotate_target.py
@@ -182,7 +182,44 @@ def test_extern_dnnl_mobilenet():
     check_result(mod, {"data": i_data},
                  (1, 1000), ref_res.asnumpy(), tol=1e-5, params=params)
 
+def test_annotate_with_merge():
+    def annotated():
+        in_1 = relay.var('in_1', shape=(10, 10), dtype='float32')
+        in_2 = relay.var('in_2', shape=(10, 10), dtype='float32')
+        in_3 = relay.var('in_3', shape=(10, 10), dtype='float32')
+        in_4 = relay.var('in_4', shape=(10, 10), dtype='float32')
+        in_5 = relay.var('in_5', shape=(10, 10), dtype='float32')
+        in_6 = relay.var('in_6', shape=(10, 10), dtype='float32')
+        in_7 = relay.var('in_7', shape=(10, 10), dtype='float32')
+        in_8 = relay.var('in_8', shape=(10, 10), dtype='float32')
+        in_9 = relay.var('in_9', shape=(10, 10), dtype='float32')
+        in_10 = relay.var('in_10', shape=(10, 10), dtype='float32')
+
+        node0 = relay.add(in_1, in_2)
+        node1 = relay.add(in_3, in_4)
+        node2 = relay.add(node0, node1)
+
+        node3 = relay.subtract(in_5, in_6)
+        node4 = relay.subtract(in_7, node3)
+
+        node5 = relay.add(node2, node4)
+        node6 = relay.subtract(in_8, node5)
+        node7 = relay.add(in_9, node5)
+
+        node8 = relay.add(node6, node7)
+        node9 = relay.add(in_10, node8)
+
+        f = relay.Function([in_1, in_2, in_3, in_4, in_5, in_6, in_7, in_8, in_9, in_10], node9)
+        mod = tvm.IRModule.from_expr(f)
+        return mod
+
+    mod = annotated()
+    mod = transform.AnnotateTargetWithMerge(["dnnl"])(mod)
+    #ref_mod = expected(dtype, ishape, w1shape)
+    #assert relay.analysis.alpha_equal(mod, ref_mod)
+
 
 if __name__ == "__main__":
-    test_extern_dnnl()
-    test_extern_dnnl_mobilenet()
+    #test_extern_dnnl()
+    #test_extern_dnnl_mobilenet()
+    test_annotate_with_merge()


### PR DESCRIPTION
This PR implements a Relay pass that annotates target device. Different from the existing annotation target pass (#4933), this pass implements the algorithm RFC proposed by @mbaret (https://discuss.tvm.ai/t/relay-improved-graph-partitioning-algorithm/5830). In short, it greedy merges supported ops and minimizes the number of generated subgraphs.

Some highlights and lowlights for this PR:
- The pass is general in terms of supporting multiple targets. We can use ["dnnl", "trt"], for example to annotate the graph.
- The pass uses lots of utility functions which are supposed to be removed after https://discuss.tvm.ai/t/discuss-annotation-defined-subgraphs/5934 has been implemented.
- This pass supports multiple outputs, but the subgraph with multiple outputs cannot be partitioned at this moment because we haven't supported multiple outputs in the partition pass.
- The unit test uses exactly the same example used in the RFC. The "add" nodes are blue nodes while "substrate" are red nodes in the RFC figure.
- I marked "substrate" as a non-support op to demonstrate how this pass works, but we need a more suitable way to do so.

Here is the example graph:
```
def @main(%in_1: Tensor[(10, 10), float32], %in_2: Tensor[(10, 10), float32], %in_3: Tensor[(10, 10), float32], %in_4: Tensor[(10, 10), float32], %in_5: Tensor[(10, 10), float32], %in_6: Tensor[(10, 10), float32], %in_7: Tensor[(10, 10), float32], %in_8: Tensor[(10, 10), float32], %in_9: Tensor[(10, 10), float32], %in_10: Tensor[(10, 10), float32]) -> Tensor[(10, 10), float32] {
  %0 = add(%in_1, %in_2) /* ty=Tensor[(10, 10), float32] */;
  %1 = add(%in_3, %in_4) /* ty=Tensor[(10, 10), float32] */;
  %2 = add(%0, %1) /* ty=Tensor[(10, 10), float32] */;
  %3 = subtract(%in_5, %in_6) /* ty=Tensor[(10, 10), float32] */;
  %4 = subtract(%in_7, %3) /* ty=Tensor[(10, 10), float32] */;
  %5 = add(%2, %4) /* ty=Tensor[(10, 10), float32] */;
  %6 = subtract(%in_8, %5) /* ty=Tensor[(10, 10), float32] */;
  %7 = add(%in_9, %5) /* ty=Tensor[(10, 10), float32] */;
  %8 = add(%6, %7) /* ty=Tensor[(10, 10), float32] */;
  add(%in_10, %8) /* ty=Tensor[(10, 10), float32] */
}
```

After annotation with merge:

```
def @main(%in_1: Tensor[(10, 10), float32], %in_2: Tensor[(10, 10), float32], %in_3: Tensor[(10, 10), float32], %in_4: Tensor[(10, 10), float32], %in_5: Tensor[(10, 10), float32], %in_6: Tensor[(10, 10), float32], %in_7: Tensor[(10, 10), float32], %in_8: Tensor[(10, 10), float32], %in_9: Tensor[(10, 10), float32], %in_10: Tensor[(10, 10), float32]) -> Tensor[(10, 10), float32] {
  %0 = annotation.compiler_begin(%in_10, meta[relay.attrs.CompilerAttrs][0]) /* ty=Tensor[(10, 10), float32] */;
  %1 = annotation.compiler_begin(%in_1, meta[relay.attrs.CompilerAttrs][1]) /* ty=Tensor[(10, 10), float32] */;
  %2 = annotation.compiler_begin(%in_2, meta[relay.attrs.CompilerAttrs][2]) /* ty=Tensor[(10, 10), float32] */;
  %3 = add(%1, %2) /* ty=Tensor[(10, 10), float32] */;
  %4 = annotation.compiler_begin(%in_3, meta[relay.attrs.CompilerAttrs][3]) /* ty=Tensor[(10, 10), float32] */;
  %5 = annotation.compiler_begin(%in_4, meta[relay.attrs.CompilerAttrs][4]) /* ty=Tensor[(10, 10), float32] */;
  %6 = add(%4, %5) /* ty=Tensor[(10, 10), float32] */;
  %7 = add(%3, %6) /* ty=Tensor[(10, 10), float32] */;
  %8 = subtract(%in_5, %in_6) /* ty=Tensor[(10, 10), float32] */;
  %9 = subtract(%in_7, %8) /* ty=Tensor[(10, 10), float32] */;
  %10 = annotation.compiler_begin(%9, meta[relay.attrs.CompilerAttrs][5]) /* ty=Tensor[(10, 10), float32] */;
  %11 = add(%7, %10) /* ty=Tensor[(10, 10), float32] */;
  %12 = annotation.compiler_end(%11, meta[relay.attrs.CompilerAttrs][6]) /* ty=Tensor[(10, 10), float32] */;
  %13 = subtract(%in_8, %12) /* ty=Tensor[(10, 10), float32] */;
  %14 = annotation.compiler_begin(%13, meta[relay.attrs.CompilerAttrs][7]) /* ty=Tensor[(10, 10), float32] */;
  %15 = annotation.compiler_begin(%in_9, meta[relay.attrs.CompilerAttrs][8]) /* ty=Tensor[(10, 10), float32] */;
  %16 = add(%15, %11) /* ty=Tensor[(10, 10), float32] */;
  %17 = annotation.compiler_end(%16, meta[relay.attrs.CompilerAttrs][9]) /* ty=Tensor[(10, 10), float32] */;
  %18 = annotation.compiler_begin(%17, meta[relay.attrs.CompilerAttrs][10]) /* ty=Tensor[(10, 10), float32] */;
  %19 = add(%14, %18) /* ty=Tensor[(10, 10), float32] */;
  %20 = add(%0, %19) /* ty=Tensor[(10, 10), float32] */;
  annotation.compiler_end(%20, meta[relay.attrs.CompilerAttrs][11]) /* ty=Tensor[(10, 10), float32] */
}
```

I'll need to clean up the code and refactor the unit test before it can be reviewed and merged. Meanwhile, @mbaret since you are also working on this pass, could you share your thoughts? We don't have to merge this PR if yours is almost done.

cc @zhiics 