### PR TITLE
[Runtime] Parameterize constants in MISRA-C runtime

### DIFF
--- a/apps/bundle_deploy/Makefile
+++ b/apps/bundle_deploy/Makefile
@@ -33,6 +33,10 @@ PKG_LDFLAGS = -pthread
 
 build_dir := build
 
+all: demo test
+
+.PHONY: all demo test
+
 demo: $(build_dir)/demo $(build_dir)/bundle.so $(build_dir)/bundle_c.so $(build_dir)/cat.bin
 	TVM_NUM_THREADS=1 $(build_dir)/demo $(build_dir)/bundle.so $(build_dir)/cat.bin
 	TVM_NUM_THREADS=1 $(build_dir)/demo $(build_dir)/bundle_c.so $(build_dir)/cat.bin
@@ -57,19 +61,17 @@ $(build_dir)/graph.json.c: $(build_dir)/graph.json
 $(build_dir)/params.bin.c: $(build_dir)/params.bin
 	xxd -i $^  > $@
 
-# # Serialize our test_graph.json file.
-# $(build_dir)/test_graph.json.c: $(build_dir)/test_graph.json
-# 	xxd -i $^  > $@
-# 
-# # Serialize our test_params.bin file.
-# $(build_dir)/test_params.bin.c: $(build_dir)/test_params.bin
-# 	xxd -i $^  > $@
-
 $(build_dir)/model.o $(build_dir)/graph.json $(build_dir)/params.bin $(build_dir)/cat.bin: build_model.py
 	python3 $< -o $(build_dir)
 
 $(build_dir)/test_model.o $(build_dir)/test_graph.json $(build_dir)/test_params.bin $(build_dir)/test_data.bin $(build_dir)/test_output.bin: build_model.py
 	python3 $< -o $(build_dir) --test
+
+$(build_dir)/crt_config.h: $(build_dir)/graph.json
+	python3 build_crt_config.py --input $< --output $@
+
+$(build_dir)/test_crt_config.h: $(build_dir)/test_graph.json
+	python3 build_crt_config.py --input $< --output $@
 
 # Build our bundle against the serialized bundle.c API, the runtime.cc API, and
 # the serialized graph.json and params.bin
@@ -77,20 +79,21 @@ $(build_dir)/bundle.so: bundle.cc runtime.cc $(build_dir)/model.o
 	@mkdir -p $(@D)
 	g++ -shared $(PKG_CXXFLAGS) -fvisibility=hidden -o $@  $^ $(PKG_LDFLAGS)
 
-$(build_dir)/bundle_c.so: bundle.c runtime.c $(build_dir)/model.o
+$(build_dir)/bundle_c.so: bundle.c runtime.c $(build_dir)/model.o $(build_dir)/crt_config.h
 	@mkdir -p $(@D)
-	gcc -shared $(PKG_CFLAGS) -fvisibility=hidden -o $@  $^ $(PKG_LDFLAGS)
+	gcc -shared $(PKG_CFLAGS) -fvisibility=hidden -o $@  $^ $(PKG_LDFLAGS) -DCRT_CONFIG_H=\"$(build_dir)/crt_config.h\"
 
 $(build_dir)/test_bundle.so: bundle.cc runtime.cc $(build_dir)/test_model.o
 	@mkdir -p $(@D)
 	g++ -shared $(PKG_CXXFLAGS) -fvisibility=hidden -o $@  $^ $(PKG_LDFLAGS)
 
-$(build_dir)/test_bundle_c.so: bundle.c runtime.c $(build_dir)/test_model.o
+$(build_dir)/test_bundle_c.so: bundle.c runtime.c $(build_dir)/test_model.o $(build_dir)/test_crt_config.h
 	@mkdir -p $(@D)
-	gcc -shared $(PKG_CFLAGS) -fvisibility=hidden -o $@  $^ $(PKG_LDFLAGS)
+	gcc -shared $(PKG_CFLAGS) -fvisibility=hidden -o $@  $^ $(PKG_LDFLAGS) -DCRT_CONFIG_H=\"$(build_dir)/test_crt_config.h\"
 
 clean:
-	rm -rf $(build_dir)/bundle.so $(build_dir)/bundle_c.so $(build_dir)/test_bundle.so $(build_dir)/test_bundle_c.so
+	rm -rf $(build_dir)/bundle.so $(build_dir)/bundle_c.so $(build_dir)/crt_config.h \
+		$(build_dir)/test_bundle.so $(build_dir)/test_bundle_c.so $(build_dir)/test_crt_config.h
 
 cleanall:
 	rm -rf $(build_dir)

--- a/apps/bundle_deploy/build_crt_config.py
+++ b/apps/bundle_deploy/build_crt_config.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Creates a config header file for MISRA-C runtime."""
+
+import argparse
+import os
+import logging
+import json
+
+def build_crt_config(fname, graph):
+    with open(fname, 'w') as fp:
+        graph = json.loads(graph)
+        node_max_inputs = max([len(node.get('inputs')) for node in graph['nodes']])
+        max_nodes = len(graph['nodes'])
+        max_input_nodes = len(graph['nodes']) # TODO: get input nodes only
+        max_node_row_ptr = len(graph['node_row_ptr'])
+        max_outputs = len(graph['heads'])
+        fp.write("/* This is an auto-generated header file. Please do NOT modify\n")
+        fp.write(" * the content of this file unless you're aware what you're doing.\n")
+        fp.write(" */\n")
+        fp.write("\n")
+        fp.write("/*! Maximum inputs in a GraphRuntimeNode */\n")
+        fp.write("#define GRAPH_RUNTIME_NODE_MAX_INPUTS {}\n".format(node_max_inputs))
+        fp.write("/*! Maximum supported nodes in a GraphRuntime */\n")
+        fp.write("#define GRAPH_RUNTIME_MAX_NODES {}\n".format(max_nodes))
+        fp.write("/*! Maximum input nodes in a GraphRuntime */\n")
+        fp.write("#define GRAPH_RUNTIME_MAX_INPUT_NODES {}\n".format(max_input_nodes))
+        fp.write("/*! Maximum nodes in a GraphRuntime for quick entry indexing */\n")
+        fp.write("#define GRAPH_RUNTIME_MAX_NODE_ROW_PTR {}\n".format(max_node_row_ptr))
+        fp.write("/*! Maximum output entries in a GraphRuntime */\n")
+        fp.write("#define GRAPH_RUNTIME_MAX_OUTPUTS {}\n".format(max_outputs))
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input', default='')
+    parser.add_argument('-o', '--output', default='')
+    opts = parser.parse_args()
+
+    graph = []
+    with open(opts.input, 'rt') as fp:
+        graph = fp.read()
+    build_crt_config(opts.output, graph)

--- a/apps/bundle_deploy/runtime.c
+++ b/apps/bundle_deploy/runtime.c
@@ -30,19 +30,10 @@
 #define TVM_CRT_MAX_NDIM 6
 /*! Maximum supported arguments in generated functions */
 #define TVM_CRT_MAX_ARGS 10
-
-/*! Maximum inputs in a GraphRuntimeNode */
-#define GRAPH_RUNTIME_NODE_MAX_INPUTS 300
 /*! Maximum supported contexts in a GraphRuntime */
 #define GRAPH_RUNTIME_MAX_CONTEXTS 1
-/*! Maximum supported nodes in a GraphRuntime */
-#define GRAPH_RUNTIME_MAX_NODES 400
-/*! Maximum input nodes in a GraphRuntime */
-#define GRAPH_RUNTIME_MAX_INPUT_NODES 300
-/*! Maximum nodes in a GraphRuntime for quick entry indexing */
-#define GRAPH_RUNTIME_MAX_NODE_ROW_PTR 300
-/*! Maximum output entries in a GraphRuntime */
-#define GRAPH_RUNTIME_MAX_OUTPUTS 300
+
+#include CRT_CONFIG_H
 
 #include "../../src/runtime/crt/crt_runtime_api.c"
 #include "../../src/runtime/crt/crt_backend_api.c"


### PR DESCRIPTION
As part of #5060, this PR parameterize constants in MISRA-C runtime proposed in PR #3934 .

Here is a brief statistics on running the test module:

|    | Code size | Peak Memory Footprint |
| --- | --- | --- |
| Default Runtime |  433 KB  |   94.64 KiB  |
| Proposed Runtime |  **45 KB**  |  **86.01 KiB** |

Here is a brief statistics on running the demo module:

|    | Code size | Peak Memory Footprint |
| --- | --- | --- |
| Default Runtime |  631K  |    **6.686 MB**  |
| Proposed Runtime |  **243K**  |  8.863 MB |

The memory footprint is larger in demo module, because MISRA-C runtime takes max size for all layers.

@ajtulloch @tmoreau89 Please review.