### PR TITLE
[Relay][AutoTVM] Bug Fix for ARM CPUs. Lower strict assumption.

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -163,7 +163,7 @@ def conv2d_winograd_without_weight_transfrom_strategy_arm_cpu(attrs, inputs, out
             tile_size = attrs.get_int("tile_size")
             kh = pad_kh - tile_size + 1
             kw = pad_kw - tile_size + 1
-            assert kh == 3 and kw == 3 and stride_h == 1 and stride_w == 1
+            assert kh == 3 and kw == 3
             strategy.add_implementation(
                 wrap_compute_conv2d(topi.arm_cpu.conv2d_nchw_winograd),
                 wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nchw_winograd),


### PR DESCRIPTION
Hello together,
since last changes I had a issue compiling stuff for my ARM CPUs( Rasberry Pi 3b+). I got the error message that stride_h is not known. Seems understandable in the code, so I guess that the required assumption here is to strict. It seems to work well with removed stride assumption. However, the original authors of this code can you take a look and check if I am right. 
Thanks, Bernhard
