### PR TITLE
[Torch] Add initial 3D op support and test on Resnet 3D

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -955,6 +955,7 @@ def _report_missing_conversion(op_names):
         msg = "The following operators are not implemented: {}".format(missing)
         raise NotImplementedError(msg)
 
+
 def _check_input_names(script_module, input_shapes):
     """ Check the graph inputs match the inputs """
     ir_inputs = get_graph_input_names(script_module)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1354,7 +1354,6 @@ def from_pytorch(script_module, input_shapes, custom_convert_map=None):
     """
     graph = script_module.graph.copy()
     _run_jit_passes(graph)
-    print(graph)
 
     if custom_convert_map:
         _convert_map.update(custom_convert_map)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -163,7 +163,7 @@ def _relu():
         return _op.nn.relu(data)
     return _impl
 
-def _adaptive_avg_2d():
+def _adaptive_avg_pool_2d():
     def _impl(inputs, input_types):
         data = inputs[0]
         output_size = _infer_shape(inputs[1])
@@ -178,7 +178,7 @@ def _adaptive_avg_2d():
 
     return _impl
 
-def _adaptive_max_2d():
+def _adaptive_max_pool_2d():
     def _impl(inputs, input_types):
         data = inputs[0]
         output_size = _infer_shape(inputs[1])
@@ -189,7 +189,7 @@ def _adaptive_max_2d():
             output_size=output_size), None
     return _impl
 
-def _adaptive_max_3d():
+def _adaptive_max_pool_3d():
     def _impl(inputs, input_types):
         data = inputs[0]
         output_size = _infer_shape(inputs[1])
@@ -198,7 +198,7 @@ def _adaptive_max_3d():
 
     return _impl
 
-def _adaptive_avg_3d():
+def _adaptive_avg_pool_3d():
     def _impl(inputs, input_types):
         data = inputs[0]
         output_size = _infer_shape(inputs[1])
@@ -859,8 +859,8 @@ _convert_map = {
     "aten::select"                          : _select(),
     "aten::relu"                            : _relu(),
     "aten::relu_"                           : _relu(),
-    "aten::adaptive_avg_pool2d"             : _adaptive_avg_2d(),
-    "aten::adaptive_max_pool2d"             : _adaptive_max_2d(),
+    "aten::adaptive_avg_pool2d"             : _adaptive_avg_pool_2d(),
+    "aten::adaptive_max_pool2d"             : _adaptive_max_pool_2d(),
     "aten::max_pool2d"                      : _maxpool_2d(),
     "aten::max_pool2d_with_indices"         : _maxpool_2d(),
     "aten::hardtanh"                        : _hardtanh(),
@@ -910,8 +910,8 @@ _convert_map = {
     "aten::Float"                           : _Float(),
     "aten::neg"                             : _neg(),
     "aten::tanh"                            : _tanh(),
-    "aten::adaptive_avg_pool3d"             : _adaptive_avg_3d(),
-    "aten::adaptive_max_pool3d"             : _adaptive_max_3d()
+    "aten::adaptive_avg_pool3d"             : _adaptive_avg_pool_3d(),
+    "aten::adaptive_max_pool3d"             : _adaptive_max_pool_3d()
 }
 
 

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -358,8 +358,9 @@ def test_quantized_imagenet():
         qmodels += [
             ("resnet18", qresnet.resnet18(pretrained=True), per_channel),
             ("mobilenet_v2", qmobilenet.mobilenet_v2(pretrained=True), per_channel),
-            # disable inception test for now, since loading it takes ~5min on torchvision-0.5
-            #("inception_v3", qinception.inception_v3(pretrained=True), per_channel),
+            # disable inception test for now, since loading it takes ~5min on torchvision-0.5 due to scipy bug
+            # See https://discuss.pytorch.org/t/torchvisions-inception-v3-takes-much-longer-to-load-than-other-models/68756
+            # ("inception_v3", qinception.inception_v3(pretrained=True), per_channel),
             ("googlenet", qgooglenet(pretrained=True), per_channel),
         ]
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -707,6 +707,8 @@ def test_adaptive_pool3d():
     verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
     verify_model(torch.nn.AdaptiveAvgPool3d((1, 1, 1)).eval(), inp)
     verify_model(torch.nn.AdaptiveAvgPool3d((2, 2, 2)).eval(), inp)
+    verify_model(torch.nn.AdaptiveAvgPool3d((4, 8, 8)).eval(), inp)
+    verify_model(torch.nn.AdaptiveMaxPool3d((7, 8, 9)).eval(), inp)
 
 
 def test_conv3d():

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -710,10 +710,11 @@ def test_to():
 
 def test_adaptive_pool3d():
     inp = torch.rand((1, 32, 16, 16, 16))
+
+    verify_model(torch.nn.AdaptiveMaxPool3d((1, 1, 1)).eval(), inp)
+    verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
     verify_model(torch.nn.AdaptiveAvgPool3d((1, 1, 1)).eval(), inp)
     verify_model(torch.nn.AdaptiveAvgPool3d((2, 2, 2)).eval(), inp)
-    # verify_model(torch.nn.AdaptiveMaxPool3d((1, 1, 1)).eval(), inp)
-    # verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
 
 
 def test_conv3d():
@@ -1039,8 +1040,8 @@ if __name__ == "__main__":
     # test_forward_chunk()
     # test_upsample()
     # test_to()
-    # test_adaptive_pool3d()
-    test_conv3d()
+    test_adaptive_pool3d()
+    # test_conv3d()
 
     # # Model tests
     # test_resnet18()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -702,28 +702,34 @@ def test_to():
 
 
 def test_adaptive_pool3d():
-    inp = torch.rand((1, 32, 16, 16, 16))
-    verify_model(torch.nn.AdaptiveMaxPool3d((1, 1, 1)).eval(), inp)
-    verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
-    verify_model(torch.nn.AdaptiveAvgPool3d((1, 1, 1)).eval(), inp)
-    verify_model(torch.nn.AdaptiveAvgPool3d((2, 2, 2)).eval(), inp)
-    verify_model(torch.nn.AdaptiveAvgPool3d((4, 8, 8)).eval(), inp)
-    verify_model(torch.nn.AdaptiveMaxPool3d((7, 8, 9)).eval(), inp)
+    for ishape in [(1, 32, 16, 16, 16),
+                   (1, 32, 9, 15, 15),
+                   (1, 32, 13, 7, 7)]:
+        inp = torch.rand(ishape)
+        verify_model(torch.nn.AdaptiveMaxPool3d((1, 1, 1)).eval(), inp)
+        verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
+        verify_model(torch.nn.AdaptiveAvgPool3d((1, 1, 1)).eval(), inp)
+        verify_model(torch.nn.AdaptiveAvgPool3d((2, 2, 2)).eval(), inp)
+        verify_model(torch.nn.AdaptiveAvgPool3d((4, 8, 8)).eval(), inp)
+        verify_model(torch.nn.AdaptiveMaxPool3d((7, 8, 9)).eval(), inp)
 
 
 def test_conv3d():
-    inp = torch.rand((1, 32, 16, 16, 16))
-    verify_model(torch.nn.Conv3d(32, 16, (3, 3, 3),
-                                 padding=(1, 1, 1)).eval(),
-                 inp),
-    verify_model(torch.nn.Conv3d(32, 16, (5, 5, 5),
-                                 padding=(2, 2, 2)).eval(),
-                 inp),
-    verify_model(torch.nn.Conv3d(32, 16, kernel_size=1).eval(),
-                 inp)
-    # downsample
-    verify_model(torch.nn.Conv3d(32, 16, kernel_size=1, stride=2).eval(),
-                 inp)
+    for ishape in [(1, 32, 16, 16, 16),
+                   (1, 32, 9, 15, 15),
+                   (1, 32, 13, 7, 7)]:
+        inp = torch.rand(ishape)
+        verify_model(torch.nn.Conv3d(32, 16, (3, 3, 3),
+                                     padding=(1, 1, 1)).eval(),
+                     inp),
+        verify_model(torch.nn.Conv3d(32, 16, (5, 5, 5),
+                                     padding=(2, 2, 2)).eval(),
+                     inp),
+        verify_model(torch.nn.Conv3d(32, 16, kernel_size=1).eval(),
+                     inp)
+        # downsample
+        verify_model(torch.nn.Conv3d(32, 16, kernel_size=1, stride=2).eval(),
+                     inp)
 
 
 # Model tests

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -471,8 +471,18 @@ def test_forward_batchnorm():
             return self.batch_norm(args[0])
 
     input_data = torch.rand(input_shape).float()
-    verify_model(BatchNorm1().float().eval(), input_data=input_data)
-    verify_model(BatchNorm2().float().eval(), input_data=input_data)
+    # verify_model(BatchNorm1().float().eval(), input_data=input_data)
+    # verify_model(BatchNorm2().float().eval(), input_data=input_data)
+    bn3d = torch.nn.BatchNorm3d(16).eval()
+    torch.nn.init.normal(bn3d.weight)
+    torch.nn.init.normal_(bn3d.bias)
+
+    for i in range(10):
+        bn3d(torch.rand((1, 16, 32, 32, 32)))
+
+    print(bn3d.state_dict())
+    verify_model(bn3d,
+                 input_data=torch.rand((1, 16, 32, 32, 32)))
 
 def test_forward_transpose():
     torch.set_grad_enabled(False)
@@ -1022,7 +1032,7 @@ if __name__ == "__main__":
     # test_forward_conv()
     # test_forward_threshold()
     # test_forward_contiguous()
-    # test_forward_batchnorm()
+    test_forward_batchnorm()
     # test_forward_transpose()
     # test_forward_size()
     # test_forward_view()
@@ -1040,7 +1050,7 @@ if __name__ == "__main__":
     # test_forward_chunk()
     # test_upsample()
     # test_to()
-    test_adaptive_pool3d()
+    # test_adaptive_pool3d()
     # test_conv3d()
 
     # # Model tests

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -729,9 +729,14 @@ def test_conv3d():
     verify_model(torch.nn.Conv3d(32, 16, (3, 3, 3),
                                  padding=(1, 1, 1)).eval(),
                  inp),
-    # verify_model(torch.nn.Conv3d(32, 16, (3, 3, 3),
-    #                              padding=(1, 1, 1)).eval(),
-    #              inp)
+    verify_model(torch.nn.Conv3d(32, 16, (5, 5, 5),
+                                 padding=(2, 2, 2)).eval(),
+                 inp),
+    verify_model(torch.nn.Conv3d(32, 16, kernel_size=1).eval(),
+                 inp)
+    # downsample
+    verify_model(torch.nn.Conv3d(32, 16, kernel_size=1, stride=2).eval(),
+                 inp)
 
 
 # Model tests

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -708,6 +708,24 @@ def test_to():
     verify_model(ToInt().eval(), torch.tensor(2.0))
 
 
+def test_adaptive_pool3d():
+    inp = torch.rand((1, 32, 16, 16, 16))
+    verify_model(torch.nn.AdaptiveAvgPool3d((1, 1, 1)).eval(), inp)
+    verify_model(torch.nn.AdaptiveAvgPool3d((2, 2, 2)).eval(), inp)
+    # verify_model(torch.nn.AdaptiveMaxPool3d((1, 1, 1)).eval(), inp)
+    # verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
+
+
+def test_conv3d():
+    inp = torch.rand((1, 32, 16, 16, 16))
+    verify_model(torch.nn.Conv3d(32, 16, (3, 3, 3),
+                                 padding=(1, 1, 1)).eval(),
+                 inp),
+    # verify_model(torch.nn.Conv3d(32, 16, (3, 3, 3),
+    #                              padding=(1, 1, 1)).eval(),
+    #              inp)
+
+
 # Model tests
 def test_resnet18():
     torch.set_grad_enabled(False)
@@ -991,57 +1009,59 @@ def test_simple_rnn():
 
 if __name__ == "__main__":
     # Single operator tests
-    test_forward_add()
-    test_forward_subtract()
-    test_forward_multiply()
-    test_forward_unsqueeze()
-    test_forward_concatenate()
-    test_forward_relu()
-    test_forward_adaptiveavgpool()
-    test_forward_maxpool()
-    test_forward_hardtanh()
-    test_forward_conv()
-    test_forward_threshold()
-    test_forward_contiguous()
-    test_forward_batchnorm()
-    test_forward_transpose()
-    test_forward_size()
-    test_forward_view()
-    test_forward_select()
-    test_forward_clone()
-    test_forward_logsoftmax()
-    test_forward_sigmoid()
-    test_forward_dense()
-    test_forward_avgpool()
-    test_forward_dropout()
-    test_forward_slice()
-    test_forward_mean()
-    test_forward_expand()
-    test_forward_pow()
-    test_forward_chunk()
-    test_upsample()
-    test_to()
+    # test_forward_add()
+    # test_forward_subtract()
+    # test_forward_multiply()
+    # test_forward_unsqueeze()
+    # test_forward_concatenate()
+    # test_forward_relu()
+    # test_forward_adaptiveavgpool()
+    # test_forward_maxpool()
+    # test_forward_hardtanh()
+    # test_forward_conv()
+    # test_forward_threshold()
+    # test_forward_contiguous()
+    # test_forward_batchnorm()
+    # test_forward_transpose()
+    # test_forward_size()
+    # test_forward_view()
+    # test_forward_select()
+    # test_forward_clone()
+    # test_forward_logsoftmax()
+    # test_forward_sigmoid()
+    # test_forward_dense()
+    # test_forward_avgpool()
+    # test_forward_dropout()
+    # test_forward_slice()
+    # test_forward_mean()
+    # test_forward_expand()
+    # test_forward_pow()
+    # test_forward_chunk()
+    # test_upsample()
+    # test_to()
+    # test_adaptive_pool3d()
+    test_conv3d()
 
-    # Model tests
-    test_resnet18()
-    test_squeezenet1_0()
-    test_squeezenet1_1()
-    test_densenet121()
-    test_inception_v3()
-    test_googlenet()
-    test_mnasnet0_5()
-    test_mobilenet_v2()
+    # # Model tests
+    # test_resnet18()
+    # test_squeezenet1_0()
+    # test_squeezenet1_1()
+    # test_densenet121()
+    # test_inception_v3()
+    # test_googlenet()
+    # test_mnasnet0_5()
+    # test_mobilenet_v2()
 
-    test_custom_conversion_map()
+    # test_custom_conversion_map()
 
-    test_segmentaton_models()
+    # test_segmentaton_models()
 
-    # Quantization test
-    from qnn_test import test_quantized_imagenet, test_quantized_modules
+    # # Quantization test
+    # from qnn_test import test_quantized_imagenet, test_quantized_modules
 
-    test_quantized_modules()
-    test_quantized_imagenet()
+    # test_quantized_modules()
+    # test_quantized_imagenet()
 
-    # Test simple conditionals and loop
-    test_control_flow()
-    test_simple_rnn()
+    # # Test simple conditionals and loop
+    # test_control_flow()
+    # test_simple_rnn()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -452,34 +452,20 @@ def test_forward_contiguous():
     input_data = torch.rand(input_shape).float()
     verify_model(Contiguous1().float().eval(), input_data=input_data)
 
+
 def test_forward_batchnorm():
-    torch.set_grad_enabled(False)
-    input_shape = [1, 3, 10, 10]
+    def init_weight(m):
+        torch.nn.init.normal_(m.weight, 0, 0.01)
+        torch.nn.init.normal_(m.bias)
 
-    class BatchNorm1(Module):
-        def __init__(self):
-            super(BatchNorm1, self).__init__()
-            self.batch_norm = torch.nn.BatchNorm2d(3, affine=True)
-        def forward(self, *args):
-            return self.batch_norm(args[0])
+    inp_2d = torch.rand((1, 16, 10, 10))
+    inp_3d = torch.rand((1, 16, 10, 10, 10))
 
-    class BatchNorm2(Module):
-        def __init__(self):
-            super(BatchNorm2, self).__init__()
-            self.batch_norm = torch.nn.BatchNorm2d(3, affine=False)
-        def forward(self, *args):
-            return self.batch_norm(args[0])
+    for bn, inp in [(torch.nn.BatchNorm2d(16), inp_2d),
+                    (torch.nn.BatchNorm3d(16), inp_3d)]:
+        init_weight(bn.eval())
+        verify_model(bn.eval(), input_data=inp)
 
-    input_data = torch.rand(input_shape).float()
-    verify_model(BatchNorm1().float().eval(), input_data=input_data)
-    verify_model(BatchNorm2().float().eval(), input_data=input_data)
-
-    bn3d = torch.nn.BatchNorm3d(16).eval()
-    torch.nn.init.normal(bn3d.weight)
-    torch.nn.init.normal_(bn3d.bias)
-
-    verify_model(bn3d,
-                 input_data=torch.rand((1, 16, 32, 32, 32)))
 
 def test_forward_transpose():
     torch.set_grad_enabled(False)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -703,7 +703,6 @@ def test_to():
 
 def test_adaptive_pool3d():
     inp = torch.rand((1, 32, 16, 16, 16))
-
     verify_model(torch.nn.AdaptiveMaxPool3d((1, 1, 1)).eval(), inp)
     verify_model(torch.nn.AdaptiveMaxPool3d((2, 2, 2)).eval(), inp)
     verify_model(torch.nn.AdaptiveAvgPool3d((1, 1, 1)).eval(), inp)
@@ -1052,7 +1051,9 @@ if __name__ == "__main__":
     test_squeezenet1_0()
     test_squeezenet1_1()
     test_densenet121()
-    test_inception_v3()
+    # disable inception test for now, since loading it takes ~5min on torchvision-0.5 due to scipy bug
+    # See https://discuss.pytorch.org/t/torchvisions-inception-v3-takes-much-longer-to-load-than-other-models/68756
+    # test_inception_v3()
     test_googlenet()
     test_mnasnet0_5()
     test_mobilenet_v2()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -471,16 +471,13 @@ def test_forward_batchnorm():
             return self.batch_norm(args[0])
 
     input_data = torch.rand(input_shape).float()
-    # verify_model(BatchNorm1().float().eval(), input_data=input_data)
-    # verify_model(BatchNorm2().float().eval(), input_data=input_data)
+    verify_model(BatchNorm1().float().eval(), input_data=input_data)
+    verify_model(BatchNorm2().float().eval(), input_data=input_data)
+
     bn3d = torch.nn.BatchNorm3d(16).eval()
     torch.nn.init.normal(bn3d.weight)
     torch.nn.init.normal_(bn3d.bias)
 
-    for i in range(10):
-        bn3d(torch.rand((1, 16, 32, 32, 32)))
-
-    print(bn3d.state_dict())
     verify_model(bn3d,
                  input_data=torch.rand((1, 16, 32, 32, 32)))
 
@@ -838,6 +835,12 @@ def test_segmentaton_models():
         verify_model(SegmentationModelWrapper(deeplab.eval()), inp, [cuda_ctx])
 
 
+def test_3d_models():
+    input_shape = (1, 3, 4, 56, 56)
+    resnet3d = torchvision.models.video.r3d_18(pretrained=True).eval()
+    verify_model(resnet3d, [torch.rand(input_shape)])
+
+
 def verify_script_model(pt_model, ishapes):
     script_module = torch.jit.script(pt_model)
     input_names = get_graph_input_names(script_module)
@@ -1020,59 +1023,60 @@ def test_simple_rnn():
 
 if __name__ == "__main__":
     # Single operator tests
-    # test_forward_add()
-    # test_forward_subtract()
-    # test_forward_multiply()
-    # test_forward_unsqueeze()
-    # test_forward_concatenate()
-    # test_forward_relu()
-    # test_forward_adaptiveavgpool()
-    # test_forward_maxpool()
-    # test_forward_hardtanh()
-    # test_forward_conv()
-    # test_forward_threshold()
-    # test_forward_contiguous()
+    test_forward_add()
+    test_forward_subtract()
+    test_forward_multiply()
+    test_forward_unsqueeze()
+    test_forward_concatenate()
+    test_forward_relu()
+    test_forward_adaptiveavgpool()
+    test_forward_maxpool()
+    test_forward_hardtanh()
+    test_forward_conv()
+    test_forward_threshold()
+    test_forward_contiguous()
     test_forward_batchnorm()
-    # test_forward_transpose()
-    # test_forward_size()
-    # test_forward_view()
-    # test_forward_select()
-    # test_forward_clone()
-    # test_forward_logsoftmax()
-    # test_forward_sigmoid()
-    # test_forward_dense()
-    # test_forward_avgpool()
-    # test_forward_dropout()
-    # test_forward_slice()
-    # test_forward_mean()
-    # test_forward_expand()
-    # test_forward_pow()
-    # test_forward_chunk()
-    # test_upsample()
-    # test_to()
-    # test_adaptive_pool3d()
-    # test_conv3d()
+    test_forward_transpose()
+    test_forward_size()
+    test_forward_view()
+    test_forward_select()
+    test_forward_clone()
+    test_forward_logsoftmax()
+    test_forward_sigmoid()
+    test_forward_dense()
+    test_forward_avgpool()
+    test_forward_dropout()
+    test_forward_slice()
+    test_forward_mean()
+    test_forward_expand()
+    test_forward_pow()
+    test_forward_chunk()
+    test_upsample()
+    test_to()
+    test_adaptive_pool3d()
+    test_conv3d()
 
-    # # Model tests
-    # test_resnet18()
-    # test_squeezenet1_0()
-    # test_squeezenet1_1()
-    # test_densenet121()
-    # test_inception_v3()
-    # test_googlenet()
-    # test_mnasnet0_5()
-    # test_mobilenet_v2()
+    # Model tests
+    test_resnet18()
+    test_squeezenet1_0()
+    test_squeezenet1_1()
+    test_densenet121()
+    test_inception_v3()
+    test_googlenet()
+    test_mnasnet0_5()
+    test_mobilenet_v2()
 
-    # test_custom_conversion_map()
+    test_custom_conversion_map()
 
-    # test_segmentaton_models()
+    test_segmentaton_models()
+    test_3d_models()
 
-    # # Quantization test
-    # from qnn_test import test_quantized_imagenet, test_quantized_modules
+    # Quantization test
+    from qnn_test import test_quantized_imagenet, test_quantized_modules
 
-    # test_quantized_modules()
-    # test_quantized_imagenet()
+    test_quantized_modules()
+    test_quantized_imagenet()
 
-    # # Test simple conditionals and loop
-    # test_control_flow()
-    # test_simple_rnn()
+    # Test simple conditionals and loop
+    test_control_flow()
+    test_simple_rnn()


### PR DESCRIPTION
* Add support for conv3d and adaptive pool 3D in the torch frontend.
* This enables loading [Resnet 3D](https://github.com/pytorch/vision/blob/master/torchvision/models/video/resnet.py#L286) from torchvision. Added to the test.

please review @kevinthesun @anijain2305 @icemelon9 @jwfromm @alexwong @optima2005 