### PR TITLE
Duplicate likely nodes added when loop axis split unevenly

### DIFF
--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -556,6 +556,15 @@ void PassUpBoundCheck(const Stage& s,
   }
 }
 
+bool IsRangeSame(const Range input_1, const Range input_2) {
+  arith::Analyzer analyzer;
+  if(input_1.same_as(input_2)) return true;
+  if ( !analyzer.CanProve(input_1->min == input_2->min) || !analyzer.CanProve(input_1->extent == input_2->extent)) {
+    return false;
+  }
+  return true;
+}
+
 std::vector<PrimExpr> MakeBoundCheck(
     const Stage& stage,
     const Map<IterVar, Range>& dom_map,
@@ -593,7 +602,7 @@ std::vector<PrimExpr> MakeBoundCheck(
     if (skip_iter.count(iv) || iv->iter_type == kOpaque) continue;
     Range dom = dom_map.at(iv);
     CHECK(iv->dom.defined());
-    if (!skip_ivar_domain && !iv->dom.same_as(dom)) {
+    if (!skip_ivar_domain && !IsRangeSame(iv->dom, dom)) {
       PrimExpr value = value_map.at(iv) - iv->dom->min;
       IntSet s = EvalSet(value, iset_dmap);
       PrimExpr vmin = s.min();

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -558,8 +558,9 @@ void PassUpBoundCheck(const Stage& s,
 
 bool IsRangeSame(const Range input_1, const Range input_2) {
   arith::Analyzer analyzer;
-  if(input_1.same_as(input_2)) return true;
-  if ( !analyzer.CanProve(input_1->min == input_2->min) || !analyzer.CanProve(input_1->extent == input_2->extent)) {
+  if (input_1.same_as(input_2)) return true;
+  if ( !analyzer.CanProve(input_1->min == input_2->min)
+        || !analyzer.CanProve(input_1->extent == input_2->extent)) {
     return false;
   }
   return true;

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -559,7 +559,7 @@ void PassUpBoundCheck(const Stage& s,
 bool IsRangeSame(const Range input_1, const Range input_2) {
   arith::Analyzer analyzer;
   if (input_1.same_as(input_2)) return true;
-  if ( !analyzer.CanProve(input_1->min == input_2->min)
+  if (!analyzer.CanProve(input_1->min == input_2->min)
         || !analyzer.CanProve(input_1->extent == input_2->extent)) {
     return false;
   }

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -559,11 +559,9 @@ void PassUpBoundCheck(const Stage& s,
 bool IsRangeSame(const Range input_1, const Range input_2) {
   arith::Analyzer analyzer;
   if (input_1.same_as(input_2)) return true;
-  if (!analyzer.CanProve(input_1->min == input_2->min)
-        || !analyzer.CanProve(input_1->extent == input_2->extent)) {
-    return false;
-  }
-  return true;
+
+  return (analyzer.CanProve(input_1->min == input_2->min)
+        && analyzer.CanProve(input_1->extent == input_2->extent));
 }
 
 std::vector<PrimExpr> MakeBoundCheck(


### PR DESCRIPTION
1:> This PR handles duplicate likely nodes added when loop axis is split into non-divisible factors.
2:> The scenario is covered in the test case.
