### PR TITLE
[Torch, QNN] Add missing upcast to uint8 avg_pool conversion 

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -172,7 +172,7 @@ def _adaptive_avg_2d():
             return _op.nn.adaptive_avg_pool2d(x, output_size=output_size)
 
         if input_types[0] == "quint8":
-            return qnn_torch.quantized_adaptive_avg_2d(data, func)
+            return qnn_torch.apply_with_upcast(data, func)
 
         return func(data)
 
@@ -484,13 +484,21 @@ def _avg_pool2d():
         ceil_mode = int(inputs[4])
         count_include_pad = int(inputs[5])
 
-        return _op.nn.avg_pool2d(data,
-                                 pool_size=pool_size,
-                                 strides=strides,
-                                 padding=padding,
-                                 ceil_mode=ceil_mode,
-                                 count_include_pad=count_include_pad)
+        def func(x):
+            return _op.nn.avg_pool2d(x,
+                                     pool_size=pool_size,
+                                     strides=strides,
+                                     padding=padding,
+                                     ceil_mode=ceil_mode,
+                                     count_include_pad=count_include_pad)
+
+        if input_types[0] == "quint8":
+            return qnn_torch.apply_with_upcast(data, func)
+
+        return func(data)
+
     return _impl
+
 
 def _dropout():
     def _impl(inputs, input_types):

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -359,10 +359,9 @@ def add_quant_params(params, quant_params):
             params[qparam.bias_var.name_hint] = tvm.nd.array(qparam.bias)
 
 
-def quantized_adaptive_avg_2d(data, func_fp32):
-    # this follows tflite impl
+def apply_with_upcast(data, func):
     inp = _op.cast(data, dtype="int32")
-    out = func_fp32(inp)
+    out = func(inp)
     return _op.cast(out, "uint8")
 
 


### PR DESCRIPTION
Previously we were missing an upcast to int32 for avg_pool2d, fixed now. It seems avg_pool is used in inception v3, but I don't know why our accuracy is not affected by the missing upcast.

 Beside the accuracy issue, without upcast it also causes a mysterious typing problem for inception v3 when compiling for AVX512. For AVX2 and other, there have been no issue. 

Even with the upcast, the raw output from the new test case, quantize -> avgpool -> dequantize, has some gap with torch output. This depends on how Torch implements uint8 avg pool (probably with fp32 piggy back).

```
max abs diff: 0.003921509
mean abs diff: 0.0014691062 
The ratio of identical output: 0.6253720238095238
```
 
cc @anijain2305 
