### PR TITLE
[CODEGEN][OPENCL] Explicitly cast min/max operands

### DIFF
--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -55,9 +55,10 @@ class CodeGenOpenCL final : public CodeGenC {
 
   // overload visitor
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final; // NOLINT(*)
-  void VisitExpr_(const CallNode* op, std::ostream& os) final; // NOLINT(*)
-  void VisitExpr_(const SelectNode* op, std::ostream& os) final; // NOLINT(*)
   void VisitExpr_(const FloatImmNode *op, std::ostream& os) final; // NOLINT(*)
+  // overload min and max to avoid ambiguous call errors
+  void VisitExpr_(const MinNode *op, std::ostream& os) final;
+  void VisitExpr_(const MaxNode *op, std::ostream& os) final;
 
  private:
   // whether enable fp16 and fp64 extension


### PR DESCRIPTION
OpenCL codegen needs explicit casts to min/max operands to avoid ambiguous call errors.
This will fix the reported bug in https://discuss.tvm.ai/t/relay-opencl-quantization-error/5963

#2821 looks no longer necessary, so this PR also reverts it.

@lixiaoquan @tqchen please help to review.