### PR TITLE
[DRAFT][BYOC] Add support for multiple outputs to the graph partitioning flow

### DIFF
--- a/python/tvm/relay/analysis/__init__.py
+++ b/python/tvm/relay/analysis/__init__.py
@@ -19,6 +19,9 @@
 # Analysis passes
 from .analysis import *
 
+# Subgraphs
+from . import subgraph_set
+
 # Call graph
 from . import call_graph
 
@@ -26,3 +29,4 @@ from . import call_graph
 from . import feature
 
 CallGraph = call_graph.CallGraph
+SubgraphSet = subgraph_set.SubgraphSet

--- a/python/tvm/relay/analysis/subgraph_set.py
+++ b/python/tvm/relay/analysis/subgraph_set.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=no-else-return, unidiomatic-typecheck, invalid-name, unused-import
+"""Subgraphs used in Relay."""
+
+from tvm.runtime import Object
+from . import _ffi_api
+
+
+class SubgraphSet(Object):
+    """Class to represent a relay expression split into subgraphs."""
+
+    def __init__(self, expr, subgraph_begin_op, subgraph_end_op):
+        """Construct subgraphs from an expression.
+
+        Parameters
+        ----------
+        expr : tvm.relay.Expr
+            The expression from which to construct the subgraphs.
+        subgraph_begin_op : tvm.relay.Op
+            The subgraph begin annotation.
+        subgraph_end_op : tvm.relay.Op
+            The subgraph end annotation.
+
+        """
+        self.__init_handle_by_constructor__(_ffi_api.SubgraphSet,
+                                            expr,
+                                            subgraph_begin_op,
+                                            subgraph_end_op)
+
+    def __len__(self):
+        return len(self.subgraphs)
+
+    def get_subgraph(self, expr):
+        """Get the subgraph an expression belongs to.
+
+        Parameters
+        ----------
+        expr : tvm.relay.Expr
+            The expression.
+
+        Returns
+        -------
+        subgraph : Subgraph
+            The subgraph containing the expression.
+            None if not found.
+        """
+        return _ffi_api.GetSubgraph(self, expr)

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -384,6 +384,18 @@ def MergeComposite(pattern_table):
     return _ffi_api.MergeComposite(pattern_names, patterns)
 
 
+def MergeSupported():
+    """Merge supported operators into target subgraphs.
+
+    Returns
+    -------
+    ret : tvm.relay.Pass
+        The registered pass that annotates supported target
+        subgraphs.
+    """
+    return _ffi_api.MergeSupported()
+
+
 def RewriteAnnotatedOps(fallback_device):
     """Rewrite the annotated program where annotation operators, e.g.
     `on_deivce`, mark which device an expression should be scheduled to.

--- a/src/relay/analysis/subgraph_set.cc
+++ b/src/relay/analysis/subgraph_set.cc
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "subgraph_set.h"
+
+#include <tvm/relay/expr.h>
+#include <tvm/ir/error.h>
+
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
+
+namespace tvm {
+namespace relay {
+
+Subgraph SubgraphSetNode::GetSubgraph(const Expr& expr) const {
+  for (auto candidate : subgraphs_) {
+    if (candidate->nodes.find(expr) != candidate->nodes.end()) {
+      return candidate;
+    }
+  }
+  return Subgraph(nullptr);
+}
+
+void SubgraphSetNode::MergeSubgraph(Subgraph subgraph1,
+                                    Subgraph subgraph2) {
+  if (subgraph1 == subgraph2) {
+    return;
+  }
+
+  // Merge subgraph 2 to subgraph 1 and erase subgraph 2.
+  subgraph1->nodes.insert(subgraph2->nodes.begin(), subgraph2->nodes.end());
+  for (auto arg : subgraph2->args) {
+    subgraph1->args.push_back(arg);
+  }
+  for (auto out : subgraph2->rets) {
+    subgraph1->rets.push_back(out);
+  }
+  // if any of the outputs of 2 are inputs of 1, they become internal nodes
+  // so remove them from outs/args
+  std::vector<Expr> args_to_remove;
+  for (const auto& arg : subgraph1->args) {
+    auto call = Downcast<Call>(arg);
+    auto it = std::find(subgraph2->rets.begin(), subgraph2->rets.end(), call->args[0]);
+    if (it != subgraph2->rets.end()) {
+      args_to_remove.push_back(arg);
+      subgraph1->rets.remove(*it);
+    }
+  }
+  for (const auto& arg : args_to_remove) {
+    subgraph1->args.remove(arg);
+  }
+  subgraphs_.erase(subgraph2);
+}
+
+void SubgraphSetNode::AddToSubgraph(Subgraph subgraph, const Expr& expr) {
+  auto subgraph2 = GetSubgraph(expr);
+  if (subgraph2.defined()) {
+    MergeSubgraph(subgraph, subgraph2);
+  } else {
+    subgraph->nodes.insert(expr);
+  }
+}
+
+Subgraph SubgraphSetNode::MakeSubgraph() {
+  auto ret = subgraphs_.emplace(Subgraph());
+  return *ret.first;
+}
+
+class SubgraphSet::Creator : public ExprVisitor {
+ public:
+  Creator(const Op &subgraph_begin_op, const Op &subgraph_end_op) :
+    begin_op_(subgraph_begin_op), end_op_(subgraph_end_op) {}
+
+  SubgraphSet Create(const Expr &expr) {
+    VisitExpr(expr);
+    return std::move(subgraph_set_);
+  }
+
+  void VisitExpr_(const CallNode *call) {
+    auto op_node = call->op.as<OpNode>();
+
+    if (op_node == nullptr || call->attrs.as<CompilerAttrs>() == nullptr) {
+      // Propagate subgraph to arguments
+      auto subgraph = subgraph_set_->GetSubgraph(GetRef<Call>(call));
+      if (subgraph.defined()) {
+        for (auto arg : call->args) {
+          subgraph_set_->AddToSubgraph(subgraph, arg);
+        }
+      }
+    } else if (call->op == begin_op_) {
+      // The annotation node is inserted on edge so it must have only one argument.
+      CHECK_EQ(call->args.size(), 1U);
+
+      auto subgraph = subgraph_set_->GetSubgraph(GetRef<Call>(call));
+      if (!subgraph.defined()) {
+        throw Error(ErrorBuilder()
+                      << "Cannot find the corresponding subgraph for start annotation:\n"
+                      << AsText(GetRef<Call>(call), false));
+      }
+      subgraph->args.push_back(GetRef<Call>(call));
+    } else {
+      CHECK_EQ(call->op, end_op_);
+      // The annotation node is inserted on edge so it must have only one argument.
+      CHECK_EQ(call->args.size(), 1U);
+
+      // Check if the argument already belongs to a subgraph
+      auto subgraph = subgraph_set_->GetSubgraph(call->args[0]);
+      if (!subgraph.defined()) {
+        subgraph = subgraph_set_->MakeSubgraph();
+        subgraph->nodes.insert(call->args[0]);
+        subgraph->id = subgraph_id_++;
+      }
+      subgraph->nodes.insert(GetRef<Call>(call));
+      subgraph->rets.push_back(GetRef<Call>(call));
+    }
+    ExprVisitor::VisitExpr_(call);
+  }
+
+  void VisitExpr_(const TupleNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<Tuple>(op));
+    if (subgraph.defined()) {
+      for (auto field : op->fields) {
+        subgraph_set_->AddToSubgraph(subgraph, field);
+      }
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const TupleGetItemNode *g) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<TupleGetItem>(g));
+    if (subgraph.defined()) {
+      subgraph_set_->AddToSubgraph(subgraph, g->tuple);
+    }
+    ExprVisitor::VisitExpr_(g);
+  }
+
+  void VisitExpr_(const FunctionNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<Function>(op));
+    if (subgraph.defined()) {
+      for (auto param : op->params) {
+        subgraph_set_->AddToSubgraph(subgraph, param);
+      }
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const LetNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<Let>(op));
+    if (subgraph.defined()) {
+      subgraph_set_->AddToSubgraph(subgraph, op->var);
+      subgraph_set_->AddToSubgraph(subgraph, op->value);
+      subgraph_set_->AddToSubgraph(subgraph, op->body);
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const IfNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<If>(op));
+    if (subgraph.defined()) {
+      subgraph_set_->AddToSubgraph(subgraph, op->cond);
+      subgraph_set_->AddToSubgraph(subgraph, op->true_branch);
+      subgraph_set_->AddToSubgraph(subgraph, op->false_branch);
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const RefCreateNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<RefCreate>(op));
+    if (subgraph.defined()) {
+      subgraph_set_->AddToSubgraph(subgraph, op->value);
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const RefReadNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<RefRead>(op));
+    if (subgraph.defined()) {
+      subgraph_set_->AddToSubgraph(subgraph, op->ref);
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const RefWriteNode *op) {
+    auto subgraph = subgraph_set_->GetSubgraph(GetRef<RefWrite>(op));
+    if (subgraph.defined()) {
+      subgraph_set_->AddToSubgraph(subgraph, op->ref);
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+ private:
+  /*! \brief The subgraph set being constructed.*/
+  SubgraphSet subgraph_set_;
+  /*! \brief The next subgraph ID to assign. */
+  int subgraph_id_{0};
+  /*! \brief Subgraph 'begin' annotation operator. */
+  const Op begin_op_;
+  /*! \brief Subgraph 'end' annotation operator. */
+  const Op end_op_;
+};
+
+SubgraphSet SubgraphSet::Create(const Expr& expr, const Op& begin, const Op& end) {
+  return Creator(begin, end).Create(expr);
+}
+
+TVM_REGISTER_NODE_TYPE(SubgraphNode);
+TVM_REGISTER_NODE_TYPE(SubgraphSetNode);
+
+TVM_REGISTER_GLOBAL("relay.analysis.SubgraphSet")
+.set_body_typed([](Expr expr, Op begin, Op end) {
+  return SubgraphSet::Create(expr, begin, end);
+});
+
+TVM_REGISTER_GLOBAL("relay.analysis.GetSubgraph")
+.set_body_typed([](SubgraphSet subgraph_set, Expr expr) {
+  return subgraph_set->GetSubgraph(expr);
+});
+
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/analysis/subgraph_set.h
+++ b/src/relay/analysis/subgraph_set.h
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relay/pass/subgraph_set.h
+ * \brief Define data structures to extract and manipulate subgraphs from
+ * a relay function. Subgraphs are denoted by subgraph_begin and subgraph_end
+ * annotations that exist on all the input and output edges of the subgraph.
+ */
+
+#ifndef TVM_RELAY_ANALYSIS_SUBGRAPH_SET_H_
+#define TVM_RELAY_ANALYSIS_SUBGRAPH_SET_H_
+
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/attrs/annotation.h>
+#include <tvm/relay/expr.h>
+#include <tvm/ir/error.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/transform.h>
+
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include <list>
+
+namespace tvm {
+namespace relay {
+
+struct Subgraph;
+class SubgraphSet;
+
+struct SubgraphNode : public Object {
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("id", &id);
+    Array<Expr> nodes_array(nodes.begin(), nodes.end());
+    v->Visit("nodes", &nodes_array);
+    Array<Expr> args_array(args.begin(), args.end());
+    v->Visit("args", &args_array);
+    Array<Expr> rets_array(rets.begin(), rets.end());
+    v->Visit("rets", &rets_array);
+  }
+
+  /*! \brief The subgraph ID. */
+  int id{-1};
+
+  /*! \brief The input arguments to this subgraph. */
+  std::list<Expr> args;
+
+  /*! \brief The return values of this subgraph */
+  std::list<Expr> rets;
+
+  /*! \brief Nodes in this subgraph. */
+  std::unordered_set<Expr, ObjectHash, ObjectEqual> nodes;
+
+  static constexpr const char* _type_key = "relay.Subgraph";
+  TVM_DECLARE_FINAL_OBJECT_INFO(SubgraphNode, Object);
+};
+
+/*!
+ * \brief An object to hold the properties of a subgraph as used by the
+ * SubgraphSet class.
+*/
+struct Subgraph : public ObjectRef {
+  Subgraph() {
+    auto n = make_object<SubgraphNode>();
+    data_ = std::move(n);
+  }
+
+  /*!
+ * \brief Construct from an object pointer.
+ * \param n The object pointer.
+ */
+  explicit Subgraph(ObjectPtr<Object> n) : ObjectRef(n) {}
+
+  /*! \return Mutable pointers to the node. */
+  SubgraphNode* operator->() const {
+    auto* ptr = get_mutable();
+    CHECK(ptr != nullptr);
+    return static_cast<SubgraphNode*>(ptr);
+  }
+};
+
+class SubgraphSetNode : public Object {
+  using UnorderedSubgraphSet =
+  std::unordered_set<Subgraph, ObjectHash, ObjectEqual>;
+  // Create iterator alias for a CallGraph object.
+  using iterator = UnorderedSubgraphSet::iterator;
+  using const_iterator = UnorderedSubgraphSet::const_iterator;
+
+ public:
+  /*! \brief Default constructor. */
+  SubgraphSetNode() = default;
+
+  /*! \return The begin iterator */
+  iterator begin() {
+    return subgraphs_.begin();
+  }
+  /*! \return The end iterator */
+  iterator end() {
+    return subgraphs_.end();
+  }
+  /*! \return The const begin iterator */
+  const_iterator begin() const {
+    return subgraphs_.begin();
+  }
+  /*! \return The const end iterator */
+  const_iterator end() const {
+    return subgraphs_.end();
+  }
+
+  /*!
+   * \brief Get the subgraph that an expression belongs to.
+   *
+   * \param expr Which expr to get the subgraph for.
+   *
+   * \return A pointer to the subgraph, nullptr if the expression
+   * doesn't belong to a subgraph.
+   */
+  Subgraph GetSubgraph(const Expr& expr) const;
+
+  /*!
+   * \brief Merge subgraph 1 into subgraph 2.
+   *
+   * \param subgraph1 A subgraph to merge.
+   * \param subgraph2 A subgraph to merge.
+   */
+  void MergeSubgraph(Subgraph subgraph1, Subgraph subgraph2);
+
+  /*!
+   * \brief Add an expression to a subgraph.
+   *
+   * \param subgraph The subgraph to add the expression to.
+   * \param expr The expression.
+   */
+  void AddToSubgraph(Subgraph subgraph, const Expr& expr);
+
+  /*!
+   * \brief Make a new subgraph.
+   *
+   * \return The new subgraph.
+   */
+  Subgraph MakeSubgraph();
+
+  void VisitAttrs(AttrVisitor* v) {
+    Array<Subgraph> subgraphs_array(subgraphs_.begin(), subgraphs_.end());
+    v->Visit("subgraphs", &subgraphs_array);
+  }
+
+  static constexpr const char* _type_key = "relay.SubgraphSet";
+  TVM_DECLARE_FINAL_OBJECT_INFO(SubgraphSetNode, Object);
+
+ private:
+  std::unordered_set<Subgraph, ObjectHash, ObjectEqual> subgraphs_;
+};
+
+/*!
+ * \brief A class to hold a set of subgraphs produced from a relay expression
+ * that contains 'subgraph_begin' and 'subgraph_end' style annotations. The
+ * subgraphs should be disjoint. The class provides both a method to construct
+ * the subgraph set of a given relay expression as well as additional methods
+ * to update and query subgraphs.
+ */
+class SubgraphSet : public ObjectRef {
+  using UnorderedSubgraphSet =
+    std::unordered_set<Subgraph, ObjectHash, ObjectEqual>;
+  // Create iterator alias for a CallGraph object.
+  using iterator = UnorderedSubgraphSet::iterator;
+  using const_iterator = UnorderedSubgraphSet::const_iterator;
+
+ public:
+  SubgraphSet() {
+    auto n = make_object<SubgraphSetNode>();
+    data_ = std::move(n);
+  }
+
+  /*!
+ * \brief Construct from an object pointer.
+ *
+ * \param n The object pointer.
+ */
+  explicit SubgraphSet(ObjectPtr<Object> n) : ObjectRef(n) {}
+
+  /*! \return The begin iterator. */
+  iterator begin() {
+    auto* n = operator->();
+    CHECK(n);
+    return n->begin();
+  }
+  /*! \return The end iterator. */
+  iterator end() {
+    auto* n = operator->();
+    CHECK(n);
+    return n->end();
+  }
+  /*! \return The begin iterator. */
+  const_iterator begin() const {
+    const auto* n = operator->();
+    CHECK(n);
+    return n->begin();
+  }
+  /*! \return The end iterator. */
+  const_iterator end() const {
+    const auto *n = operator->();
+    CHECK(n);
+    return n->end();
+  }
+
+    /*! \return mutable pointers to the node. */
+  SubgraphSetNode* operator->() const {
+    auto* ptr = get_mutable();
+    CHECK(ptr != nullptr);
+    return static_cast<SubgraphSetNode*>(ptr);
+  }
+
+  /*! \brief Create a SubgraphSet from a relay expression.
+   *
+   * \param expr The relay expr from which to construct the set.
+   * \param begin Subgraph begin annotation operator.
+   * \param end Subgraph end annotation operator.
+   *
+   * \return The created SubgraphSet for the expression.
+   */
+  static SubgraphSet Create(const Expr& expr,
+                            const Op& begin,
+                            const Op& end);
+
+ private:
+  /*! \brief Helper class to construct a SubgraphSet from an expr.*/
+  class Creator;
+};
+
+}  // namespace relay
+}  // namespace tvm
+
+#endif  // TVM_RELAY_ANALYSIS_SUBGRAPH_SET_H_

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -38,38 +38,136 @@ class AnnotateTargetWrapper : public ExprMutator {
  public:
   explicit AnnotateTargetWrapper(const std::string& target) : target_(target) {}
 
+  Expr Annotate(const Expr& expr) {
+    return InsertEnd(Mutate(expr));
+  }
+
+  bool IsSupported(const Expr& expr) {
+    if (expr->IsInstance<CallNode>()) {
+      Call call = Downcast<Call>(expr);
+      auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target_);
+      Op op = Downcast<Op>(call->op);
+      CHECK(op.defined());
+      if (fannotate.count(op)) {
+        return fannotate[op](call->attrs, call->args);
+      }
+    }
+    return false;
+  }
+
+  Expr InsertEnd(const Expr& arg) {
+    if (IsSupported(arg)) {
+      const auto *end_op =
+        runtime::Registry::Get("relay.op.annotation._make.compiler_end");
+      CHECK(end_op);
+      Expr end = (*end_op)(arg, target_);
+      return end;
+    }
+    return arg;
+  }
+
   Expr VisitExpr_(const CallNode* cn) {
     // TODO(@zhiics, @comaniac) Handle composite functions.
     auto new_e = ExprMutator::VisitExpr_(cn);
 
     Call call = Downcast<Call>(new_e);
-    static auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + target_);
-    Op op = Downcast<Op>(call->op);
-    CHECK(op.defined());
 
-    if (fannotate.count(op)) {
-      bool external = fannotate[op](call->attrs, call->args);
-      if (external) {
-        tvm::Array<tvm::relay::Expr> compiler_begins;
-        for (const auto& it : call->args) {
-          const auto* begin_op =
-            runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
-          CHECK(begin_op);
-          Expr begin = (*begin_op)(it, target_);
-          compiler_begins.push_back(begin);
-        }
-        Expr update_call = CallNode::make(call->op, compiler_begins, call->attrs);
-        const auto* end_op =
-          runtime::Registry::Get("relay.op.annotation._make.compiler_end");
-        CHECK(end_op);
-        Expr end = (*end_op)(update_call, target_);
-        return end;
-      }
-    } else {
-      LOG(WARNING) << op->name << " in " << target_
-                   << " is not registered. It will be executed on CPU.";
+    // add end annotations if the args are supported
+    Array<Expr> compiler_ends;
+    for (const auto& it : call->args) {
+      compiler_ends.push_back(InsertEnd(it));
     }
-    return new_e;
+    call = CallNode::make(call->op, compiler_ends, call->attrs);
+
+    // add begin annotations if the call node is supported
+    if (IsSupported(call)) {
+      tvm::Array<tvm::relay::Expr> compiler_begins;
+      for (const auto& it : call->args) {
+        const auto* begin_op =
+          runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
+        CHECK(begin_op);
+        Expr begin = (*begin_op)(it, target_);
+        compiler_begins.push_back(begin);
+      }
+      call = CallNode::make(call->op, compiler_begins, call->attrs);
+    }
+
+    return std::move(call);
+  }
+
+  Expr VisitExpr_(const TupleNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto tup = Downcast<Tuple>(new_e);
+    Array<Expr> new_fields;
+    for (auto field : tup->fields) {
+      new_fields.push_back(InsertEnd(field));
+    }
+    return TupleNode::make(new_fields);
+  }
+
+  Expr VisitExpr_(const TupleGetItemNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto get = Downcast<TupleGetItem>(new_e);
+    return TupleGetItemNode::make(
+      InsertEnd(get->tuple),
+      get->index);
+  }
+
+  Expr VisitExpr_(const FunctionNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto func = Downcast<Function>(new_e);
+    return Function(
+      func->params,
+      InsertEnd(func->body),
+      func->ret_type,
+      func->type_params,
+      func->attrs);
+  }
+
+  Expr VisitExpr_(const LetNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto let = Downcast<Let>(new_e);
+    return LetNode::make(
+      let->var,
+      InsertEnd(let->value),
+      InsertEnd(let->body));
+  }
+
+  Expr VisitExpr_(const IfNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto iff = Downcast<If>(new_e);
+    return IfNode::make(
+      InsertEnd(iff->cond),
+      InsertEnd(iff->true_branch),
+      InsertEnd(iff->false_branch));
+  }
+
+  Expr VisitExpr_(const RefCreateNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto create = Downcast<RefCreate>(new_e);
+    return RefCreateNode::make(InsertEnd(create->value));
+  }
+
+  Expr VisitExpr_(const RefReadNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto read = Downcast<RefRead>(new_e);
+    return RefReadNode::make(InsertEnd(read->ref));
+  }
+
+  Expr VisitExpr_(const RefWriteNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+
+    auto write = Downcast<RefWrite>(new_e);
+    return RefWriteNode::make(
+      InsertEnd(write->ref),
+      InsertEnd(write->value));
   }
 
  private:
@@ -77,7 +175,7 @@ class AnnotateTargetWrapper : public ExprMutator {
 };
 
 Expr AnnotateTarget(const Expr& expr, const std::string& target) {
-  return AnnotateTargetWrapper(target).Mutate(expr);
+  return AnnotateTargetWrapper(target).Annotate(expr);
 }
 
 }  // namespace annotate_target

--- a/src/relay/transforms/merge_supported.cc
+++ b/src/relay/transforms/merge_supported.cc
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * \file src/relay/pass/merge_supported.cc
+ *
+ * \brief After operators have been annotated with the targets that support
+ * them, this pass creates subgraphs of the operators for each target. It
+ * is guaranteed that the subgraphs will have a topological ordering so that
+ * no data dependency issues exist.
+ *
+ * This pass only introduces annotations to indicate the subgraphs.
+ * partition_graph must subsequently be called to lift these subgraphs out
+ * as external functions.
+ */
+
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/attrs/annotation.h>
+#include <tvm/relay/expr.h>
+#include <tvm/ir/error.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/transform.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "../analysis/subgraph_set.h"
+
+
+namespace tvm {
+namespace relay {
+namespace partitioning {
+
+// Cache compiler_begin and compiler_end annotation ops for equivalence check to
+// reduce registry lookup overhead.
+static const Op& compiler_begin_op = Op::Get("annotation.compiler_begin");
+static const Op& compiler_end_op = Op::Get("annotation.compiler_end");
+
+/*! \brief This is a pre-requisite pass to merge-supported pass.
+ *  The AnnotateRestDefault pass will put "default" Compiler Annotations to
+ *  nodes that are not annotated already. This is there to ensure that the
+ *  user will not leave un-annotated nodes MergeSupported pass is run.
+ *  Why? Because, MergeSupported pass assumes every node to be annotated.
+ */
+class AnnotateRestDefault : public ExprMutator {
+ public:
+  explicit AnnotateRestDefault(const Expr& expr) {
+      subgraphs_ = SubgraphSet::Create(expr, compiler_begin_op, compiler_end_op);
+  }
+
+  Expr Annotate(const Expr& expr) {
+    // Its a function that is being passed on to annotate
+    func_ = Downcast<Function>(expr);
+
+    // Corner Case CC1 : If the last node does not belong
+    // to a subgraph nede to add a compiler_end
+    auto subgraph = subgraphs_->GetSubgraph(func_->body);
+    auto mutated_expr = this->VisitExpr(expr);
+    if (!subgraph.defined()) {
+      func_ = Downcast<Function>(mutated_expr);
+      // CC1 : add that compiler end after mutation
+      auto body = AddCompilerEnd_(func_->body);
+      func_ = Function(func_->params, body,
+                       body->checked_type_, {}, DictAttrs());
+      return Downcast<Expr>(func_);
+    } else {
+      return mutated_expr;
+    }
+  }
+
+    /*! \brief This function adds compiler ends to nodes nodes that
+     * does have a subgraph AND they should not be arguments of the
+     * original function
+     * @param expr
+     * @return expr
+     */
+  Expr AddCompilerEnd(const Expr& expr) {
+    auto subgraph = subgraphs_->GetSubgraph(expr);
+    auto visited_expr = VisitExpr(expr);
+
+    // The compiler ends are added to nodes that does have a subgraph
+    // AND they should not be arguments of the original function
+    if (!subgraph.defined() &&
+       std::find(func_->params.begin(),
+                 func_->params.end(), visited_expr)
+                   == func_->params.end()) {
+      return AddCompilerEnd_(visited_expr);
+    } else {
+      return visited_expr;
+    }
+  }
+
+  Expr AddCompilerEnd_(const Expr& expr) {
+    const auto* end_op =
+      runtime::Registry::Get("relay.op.annotation._make.compiler_end");
+    CHECK(end_op);
+    Expr end = (*end_op)(expr, target_);
+    return end;
+  }
+
+  Expr VisitExpr_(const CallNode* call) final {
+    auto op_node = call->op.as<OpNode>();
+    auto ret = GetRef<Call>(call);
+
+    Array<Expr> args;
+
+    // Add compiler ends if the parent is supported
+    for (auto arg : call->args) {
+      args.push_back(AddCompilerEnd(arg));
+    }
+
+    if (op_node == nullptr || call->attrs.as<CompilerAttrs>() == nullptr) {
+      // Skip annotatation ops, only add default compiler to actual compute nodes
+
+      auto subgraph = subgraphs_->GetSubgraph(ret);
+      if (!subgraph.defined()) {
+        // if the current node does not belong to annotated subgraph
+        // annotate the all incoming edges (args)
+        // with "default" compile_begin and compiler_end annotations.
+        tvm::Array<tvm::relay::Expr> compiler_begins;
+        for (auto arg : args) {
+          const auto* begin_op =
+            runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
+          CHECK(begin_op);
+          Expr begin = (*begin_op)(arg, target_);
+          compiler_begins.push_back(begin);
+        }
+        Expr update_call = CallNode::make(call->op, compiler_begins, call->attrs);
+        return update_call;
+      } else {
+        return CallNode::make(call->op, args, call->attrs);
+      }
+    } else {
+      return CallNode::make(call->op, args, call->attrs);
+    }
+  };
+
+  Expr VisitExpr_(const TupleNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto tup = Downcast<Tuple>(new_e);
+    Array<Expr> new_fields;
+    for (auto field : tup->fields) {
+      new_fields.push_back(AddCompilerEnd(field));
+    }
+    return TupleNode::make(new_fields);
+  }
+
+  Expr VisitExpr_(const TupleGetItemNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto get = Downcast<TupleGetItem>(new_e);
+    return TupleGetItemNode::make(
+      AddCompilerEnd(get->tuple),
+      get->index);
+  }
+
+  Expr VisitExpr_(const LetNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto let = Downcast<Let>(new_e);
+    return LetNode::make(
+      let->var,
+      AddCompilerEnd(let->value),
+      AddCompilerEnd(let->body));
+  }
+
+  Expr VisitExpr_(const IfNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto iff = Downcast<If>(new_e);
+    return IfNode::make(
+      AddCompilerEnd(iff->cond),
+      AddCompilerEnd(iff->true_branch),
+      AddCompilerEnd(iff->false_branch));
+  }
+
+  Expr VisitExpr_(const RefCreateNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto create = Downcast<RefCreate>(new_e);
+    return RefCreateNode::make(AddCompilerEnd(create->value));
+  }
+
+  Expr VisitExpr_(const RefReadNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto read = Downcast<RefRead>(new_e);
+    return RefReadNode::make(AddCompilerEnd(read->ref));
+  }
+
+  Expr VisitExpr_(const RefWriteNode *op) {
+    auto new_e = ExprMutator::VisitExpr_(op);
+    auto write = Downcast<RefWrite>(new_e);
+    return RefWriteNode::make(
+      AddCompilerEnd(write->ref),
+      AddCompilerEnd(write->value));
+  }
+
+ private:
+    SubgraphSet subgraphs_;
+    const std::string target_ = "default";
+    Function func_;
+};
+
+class MergeAnnotations : public ExprMutator {
+ public:
+  explicit MergeAnnotations(SubgraphSet subgraphs) : subgraphs_(subgraphs) {}
+
+  Expr VisitExpr_(const CallNode* call) final {
+    if (call->op == compiler_begin_op) {
+      if (call->args[0]->IsInstance<CallNode>()) {
+        auto arg = Downcast<Call>(call->args[0]);
+        if (arg->op == compiler_end_op) {
+          auto subgraph1 = subgraphs_->GetSubgraph(GetRef<Call>(call));
+          auto subgraph2 = subgraphs_->GetSubgraph(arg);
+          if (subgraph1 == subgraph2) {
+            return ExprMutator::VisitExpr(arg->args[0]);
+          }
+        }
+      }
+    }
+    return ExprMutator::VisitExpr_(call);
+  }
+
+ private:
+  SubgraphSet subgraphs_;
+};
+
+class SubgraphMerger : public ExprVisitor {
+ public:
+  explicit SubgraphMerger(SubgraphSet subgraphs) : subgraphs_(subgraphs) {}
+
+  void VisitExpr_(const CallNode* call) final {
+    if (call->op == compiler_end_op) {
+      auto subgraph = subgraphs_->GetSubgraph(GetRef<Call>(call));
+      // set the subgraph target
+      auto compiler_attrs = call->attrs.as<CompilerAttrs>();
+      subgraph_targets_[subgraph->id] = compiler_attrs->compiler;
+      std::vector<Subgraph> mergeable_subgraphs;
+      // first look at the subgraph args to determine the parent subgraphs
+      for (const auto& arg : subgraph->args) {
+        // all args should be begin annotations
+        auto begin = Downcast<Call>(arg);
+        // the arguments of the begin annotations will be in the parent subgraphs
+        auto parent_subgraph = subgraphs_->GetSubgraph(begin->args[0]);
+        // if there is no parent subgraph, move on
+        if (!parent_subgraph.defined()) continue;
+        // merge the parent subgraph if it hasn't been done already
+        if (merged_subgraphs_.find(parent_subgraph->id) == merged_subgraphs_.end()) {
+          VisitExpr(begin->args[0]);
+        }
+        mergeable_subgraphs.push_back(parent_subgraph);
+      }
+      // subgraph_restrictions_[subgraph->id] = std::unordered_set<int>();
+      auto& subgraph_restrictions = subgraph_restrictions_[subgraph->id];
+      for (const auto& parent_subgraph : mergeable_subgraphs) {
+        auto parent_restrictions = subgraph_restrictions_[parent_subgraph->id];
+        // add all the parent restrictions to the current subgraph
+        subgraph_restrictions.insert(parent_restrictions.begin(),
+                                     parent_restrictions.end());
+      }
+      for (const auto& parent_subgraph : mergeable_subgraphs) {
+        bool merged = false;
+        // check the parent subgraph has the same target
+        if (subgraph_targets_[parent_subgraph->id] == compiler_attrs->compiler) {
+          // check the parent subgraph isn't in the restrictions
+          if (subgraph_restrictions.find(parent_subgraph->id) == subgraph_restrictions.end()) {
+            // merge the parent subgraph into the current subgraph
+            subgraphs_->MergeSubgraph(subgraph, parent_subgraph);
+            // update the restrictions of all other subgraphs to reflect the change in id
+            for (const auto& s : subgraphs_) {
+              auto& restrictions = subgraph_restrictions_[s->id];
+              if (restrictions.find(parent_subgraph->id) != restrictions.end()) {
+                restrictions.erase(parent_subgraph->id);
+                restrictions.insert(subgraph->id);
+              }
+            }
+            merged = true;
+          }
+        }
+        // if the parent wasn't merged, add it as a restriction to the current subgraph
+        if (!merged)
+          subgraph_restrictions.insert(parent_subgraph->id);
+      }
+      merged_subgraphs_.insert(subgraph->id);
+    }
+    ExprVisitor::VisitExpr_(call);
+  }
+
+ private:
+  SubgraphSet subgraphs_;
+  std::unordered_set<int> merged_subgraphs_;
+  std::map<int, std::unordered_set<int>> subgraph_restrictions_;
+  std::map<int, std::string> subgraph_targets_;
+};
+
+
+Expr MergeSupported(const Expr& expr) {
+  // Annotate the nodes that are not annotated, if any.
+  AnnotateRestDefault anno_default(expr);
+  auto expr_all_annotated = anno_default.Annotate(expr);
+
+  // Create subgraphs using the annotations.
+  SubgraphSet subgraphs = SubgraphSet::Create(expr_all_annotated,
+                                              compiler_begin_op, compiler_end_op);
+
+  // By now, all the nodes have some sort of annotation.
+  // Subgraph merger is ExprVisitor that will update the
+  // SubgraphSet.
+  SubgraphMerger merger(subgraphs);
+  merger.VisitExpr(expr_all_annotated);
+
+  // This will use updated (merged)
+  // SubgraphSet : subgraphs_withdefault to remove annotations
+  // within each subgraph
+  MergeAnnotations merge_anno(subgraphs);
+  return merge_anno.Mutate(expr_all_annotated);
+}
+
+}  // namespace partitioning
+
+namespace transform {
+
+Pass MergeSupported() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> part_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        return Downcast<Function>(partitioning::MergeSupported(f));
+      };
+  auto partitioned = CreateFunctionPass(part_func, 0, "MergeSupported", {});
+  return Sequential({partitioned, InferType()});
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.MergeSupported")
+.set_body_typed(transform::MergeSupported);
+
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/tests/python/relay/test_pass_merge_supported.py
+++ b/tests/python/relay/test_pass_merge_supported.py
@@ -1,0 +1,190 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for merge supported."""
+import os
+import sys
+import numpy as np
+import pytest
+
+import tvm
+from tvm import te
+import tvm.relay.testing
+import tvm.relay.transform as transform
+from tvm import relay
+from tvm import runtime
+from tvm.contrib import util
+from tvm.relay.op.annotation import compiler_begin, compiler_end
+from tvm.relay.expr_functor import ExprMutator
+from tvm.relay.testing import run_opt_pass
+
+
+def test_diamond_graph():
+    """
+    This tests that the data dependencies present in a diamond-shaped
+    graph are correctly resolved by the merging pass.
+
+    O = supported by target
+    X = not supported by target
+
+       O         O
+      / \       /               \
+     O   X --> O    +       +    X
+      \ /              \ /
+       O                O
+
+    Note that we can't just merge the three supported operators together,
+    otherwise both subgraphs would depend on the other.
+    """
+
+    def diamond_graph_default_anno():
+        data = relay.var('data', shape=(10, 10))
+        cb_1 = compiler_begin(data, 'test_target')
+        O_1 = relay.abs(cb_1)
+        ce_1 = compiler_end(O_1, 'test_target')
+        ce_2 = compiler_end(O_1, 'test_target')
+        cb_2 = compiler_begin(ce_1, 'test_target')
+        O_2 = relay.nn.relu(cb_2)
+        ce_3 = compiler_end(O_2, 'test_target')
+
+        cb_x = compiler_begin(ce_2, 'default')
+        X = relay.tanh(cb_x)
+        ce_x = compiler_end(X, 'default')
+
+        cb_3 = compiler_begin(ce_3, 'test_target')
+        cb_4 = compiler_begin(ce_x, 'test_target')
+        O_3 = relay.add(cb_3, cb_4)
+        ce_4 = compiler_end(O_3, 'test_target')
+        diamond = relay.Function([data], ce_4)
+        return diamond
+
+    def diamond_graph():
+        data = relay.var('data', shape=(10, 10))
+        cb_1 = compiler_begin(data, 'test_target')
+        O_1 = relay.abs(cb_1)
+        ce_1 = compiler_end(O_1, 'test_target')
+        ce_2 = compiler_end(O_1, 'test_target')
+        cb_2 = compiler_begin(ce_1, 'test_target')
+        O_2 = relay.nn.relu(cb_2)
+        ce_3 = compiler_end(O_2, 'test_target')
+
+        X = relay.tanh(ce_2)
+
+        cb_3 = compiler_begin(ce_3, 'test_target')
+        cb_4 = compiler_begin(X, 'test_target')
+        O_3 = relay.add(cb_3, cb_4)
+        ce_4 = compiler_end(O_3, 'test_target')
+        diamond = relay.Function([data], ce_4)
+        return diamond
+
+    def expected():
+        data = relay.var('data', shape=(10, 10))
+        cb_1 = compiler_begin(data, 'test_target')
+        O_1 = relay.abs(cb_1)
+        ce_2 = compiler_end(O_1, 'test_target')
+        O_2 = relay.nn.relu(O_1)
+        ce_3 = compiler_end(O_2, 'test_target')
+
+        cb_x = compiler_begin(ce_2, 'default')
+        X = relay.tanh(cb_x)
+        ce_x = compiler_end(X, 'default')
+
+        cb_3 = compiler_begin(ce_3, 'test_target')
+        cb_4 = compiler_begin(ce_x, 'test_target')
+        O_3 = relay.add(cb_3, cb_4)
+        ce_4 = compiler_end(O_3, 'test_target')
+        func = relay.Function([data], ce_4)
+        return func
+
+    golden = expected()
+    print(golden)
+    result = run_opt_pass(diamond_graph(), relay.transform.MergeSupported())
+    print(result)
+
+
+def test_diamond_graph_fanouts():
+    def diamond_graph_fanouts():
+        data = relay.var('data', shape=(10, 10))
+        cb_1 = compiler_begin(data, 'test_target')
+        O_1 = relay.abs(cb_1)
+        ce_1 = compiler_end(O_1, 'test_target')
+        ce_2 = compiler_end(O_1, 'test_target')
+        cb_2 = compiler_begin(ce_1, 'test_target')
+        O_2 = relay.nn.relu(cb_2)
+        ce_3 = compiler_end(O_2, 'test_target')
+
+        X = relay.tanh(ce_2)
+
+        cb_3 = compiler_begin(ce_3, 'test_target')
+        cb_4 = compiler_begin(X, 'test_target')
+        O_3 = relay.add(cb_3, cb_4)
+        ce_4 = compiler_end(O_3, 'test_target')
+
+        O_4 = relay.add(ce_4, X)
+
+        diamond = relay.Function([data], O_4)
+        return diamond
+
+    def expected():
+        data = relay.var('data', shape=(10, 10))
+        cb_1 = compiler_begin(data, 'test_target')
+        O_1 = relay.abs(cb_1)
+        ce_2 = compiler_end(O_1, 'test_target')
+        O_2 = relay.nn.relu(O_1)
+        ce_3 = compiler_end(O_2, 'test_target')
+
+        cb_x = compiler_begin(ce_2, 'default')
+        X = relay.tanh(cb_x)
+        ce_x1 = compiler_end(X, 'default')
+        ce_x2 = compiler_end(X, 'default')
+
+        cb_3 = compiler_begin(ce_3, 'test_target')
+        cb_4 = compiler_begin(ce_x1, 'test_target')
+        O_3 = relay.add(cb_3, cb_4)
+        ce_4 = compiler_end(O_3, 'test_target')
+
+        cb_o4_i1 = compiler_begin(ce_4, 'default')
+        cb_o4_i2 = compiler_begin(ce_x2, 'default')
+        O_4 = relay.add(cb_o4_i1, cb_o4_i2)
+        ce_o4 = compiler_end(O_4, 'default')
+
+        func = relay.Function([data], ce_o4)
+        return func
+
+    golden = expected()
+    print("input :")
+    print(diamond_graph_fanouts())
+    print("golden :")
+    print(golden)
+    result = run_opt_pass(diamond_graph_fanouts(), relay.transform.MergeSupported())
+    print("result :")
+    print(result)
+
+
+
+def test_split():
+    data = relay.var('data', shape=(10, 10))
+    out = relay.split(data, 2, axis=1)
+    func = relay.Function([data], out)
+    mod = tvm.IRModule()
+    mod["main"] = func
+    print(mod)
+
+
+if __name__ == "__main__":
+    #test_diamond_graph()
+    # test_split()
+    test_diamond_graph_fanouts()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -634,6 +634,83 @@ def test_function_lifting_inline():
     assert relay.analysis.alpha_equal(partitioned, ref_mod)
 
 
+def test_multiple_outputs():
+    def create_merged_graph():
+        data = relay.var('data', shape=(10, 10))
+
+        cb_1 = compiler_begin(data, 'test_target')
+        O_1 = relay.abs(cb_1)
+        ce_2 = compiler_end(O_1, 'test_target')
+        O_2 = relay.nn.relu(O_1)
+        ce_3 = compiler_end(O_2, 'test_target')
+
+        X = relay.tanh(ce_2)
+
+        cb_3 = compiler_begin(ce_3, 'test_target')
+        cb_4 = compiler_begin(X, 'test_target')
+        O_3 = relay.add(cb_3, cb_4)
+        ce_4 = compiler_end(O_3, 'test_target')
+
+        func = relay.Function([data], ce_4)
+        return func
+
+    def expected():
+        mod = tvm.IRModule()
+
+        # function 1
+        f1_cb1 = relay.var('test_target_1_i0', shape=(10, 10))
+        f1_O_1 = relay.abs(f1_cb1)
+        f1_O_2 = relay.nn.relu(f1_O_1)
+        f1_out = relay.Tuple((f1_O_2,f1_O_1))
+        func1 = relay.Function([f1_cb1], f1_out)
+
+        func1 = func1.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
+        func1 = func1.with_attr("Inline", tvm.tir.IntImm("int32", 1))
+        func1 = func1.with_attr("Compiler",
+                                tvm.tir.StringImm("test_target"))
+        func1 = func1.with_attr("ExternalSymbol",
+                                tvm.tir.StringImm("test_target_1"))
+        gv1 = relay.GlobalVar("test_target_1")
+        mod[gv1] = func1
+
+        # function 0
+        f2_cb3 = relay.var('test_target_0_i0', shape=(10, 10))
+        f2_cb4 = relay.var('test_target_0_i1', shape=(10, 10))
+        f2_O_3 = relay.add(f2_cb3, f2_cb4)
+        func0 = relay.Function([f2_cb3, f2_cb4], f2_O_3)
+
+        func0 = func0.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
+        func0 = func0.with_attr("Inline", tvm.tir.IntImm("int32", 1))
+        func0 = func0.with_attr("Compiler",
+                                tvm.tir.StringImm("test_target"))
+        func0 = func0.with_attr("ExternalSymbol",
+                                tvm.tir.StringImm("test_target_0"))
+        gv0 = relay.GlobalVar("test_target_0")
+        mod[gv0] = func0
+
+        # body
+        data = relay.var('data', shape=(10, 10))
+        tuple_out = gv1(data)
+        ce_2 = relay.TupleGetItem(tuple_out, 1)
+        ce_3 = relay.TupleGetItem(tuple_out, 0)
+
+        X = relay.tanh(ce_2)
+        ce_4 = gv0(ce_3, X)
+        func = relay.Function([data], ce_4)
+        mod["main"] = func
+
+        return mod
+
+    # print(create_merged_graph())
+    mod = tvm.IRModule()
+    mod["main"] = create_merged_graph()
+
+    ref_mod = expected();
+    partitioned = transform.PartitionGraph()(mod)
+
+    assert relay.analysis.alpha_equal(partitioned, ref_mod)
+
+
 if __name__ == "__main__":
     test_multi_node_compiler()
     test_extern_ccompiler_single_op()
@@ -643,3 +720,4 @@ if __name__ == "__main__":
     test_extern_dnnl_mobilenet()
     test_function_lifting()
     test_function_lifting_inline()
+    test_multiple_outputs()

--- a/tests/python/relay/test_subgraph_set.py
+++ b/tests/python/relay/test_subgraph_set.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=no-else-return, unidiomatic-typecheck, invalid-name
+from tvm import relay
+from tvm.relay.op.annotation import compiler_begin, compiler_end
+
+
+def check_subgraph(subgraph_set, args, nodes, rets):
+    subgraph = subgraph_set.get_subgraph(args[0])
+    assert subgraph
+    assert set(args) == set(subgraph.args)
+    assert set(nodes) == set(subgraph.nodes)
+    assert set(rets) == set(subgraph.rets)
+
+
+def test_subgraph_set_creator_diamond():
+    data = relay.var('data', shape=(10, 10))
+    cb_1 = compiler_begin(data, 'test_target')
+    O_1 = relay.abs(cb_1)
+    ce_1 = compiler_end(O_1, 'test_target')
+    ce_2 = compiler_end(O_1, 'test_target')
+    cb_2 = compiler_begin(ce_1, 'test_target')
+    O_2 = relay.nn.relu(cb_2)
+    ce_3 = compiler_end(O_2, 'test_target')
+    cb_d = compiler_begin(ce_2, "default")
+    X = relay.tanh(cb_d)
+    ce_d = compiler_end(X, 'default')
+    cb_3 = compiler_begin(ce_3, 'test_target')
+    cb_4 = compiler_begin(ce_d, 'test_target')
+    O_3 = relay.add(cb_3, cb_4)
+    ce_4 = compiler_end(O_3, 'test_target')
+    diamond = relay.Function([data], ce_4)
+
+    subgraph_set = relay.analysis.SubgraphSet(diamond,
+                                              relay.op.get("annotation.compiler_begin"),
+                                              relay.op.get("annotation.compiler_end"))
+    assert len(subgraph_set) == 4
+    check_subgraph(
+        subgraph_set,
+        [cb_1],
+        [cb_1, O_1, ce_1, ce_2],
+        [ce_1, ce_2],
+    )
+    check_subgraph(
+        subgraph_set,
+        [cb_2],
+        [cb_2, O_2, ce_3],
+        [ce_3],
+    )
+    check_subgraph(
+        subgraph_set,
+        [cb_d],
+        [cb_d, X, ce_d],
+        [ce_d],
+    )
+    check_subgraph(
+        subgraph_set,
+        [cb_3, cb_4],
+        [cb_3, cb_4, O_3, ce_4],
+        [ce_4],
+    )
+
+
+def test_subgraph_set_creator_merged():
+    data = relay.var('data', shape=(10, 10))
+    cb_1 = compiler_begin(data, 'test_target')
+    O_1 = relay.abs(cb_1)
+    ce_2 = compiler_end(O_1, 'test_target')
+    O_2 = relay.nn.relu(O_1)
+    ce_3 = compiler_end(O_2, 'test_target')
+    cb_d = compiler_begin(ce_2, "default")
+    X = relay.tanh(cb_d)
+    ce_d = compiler_end(X, 'default')
+    cb_3 = compiler_begin(ce_3, 'test_target')
+    cb_4 = compiler_begin(ce_d, 'test_target')
+    O_3 = relay.add(cb_3, cb_4)
+    ce_4 = compiler_end(O_3, 'test_target')
+    merged = relay.Function([data], ce_4)
+
+    subgraph_set = relay.analysis.SubgraphSet(merged,
+                                              relay.op.get("annotation.compiler_begin"),
+                                              relay.op.get("annotation.compiler_end"))
+    assert len(subgraph_set) == 3
+    check_subgraph(
+        subgraph_set,
+        [cb_1],
+        [cb_1, O_1, O_2, ce_2, ce_3],
+        [ce_2, ce_3],
+    )
+    check_subgraph(
+        subgraph_set,
+        [cb_d],
+        [cb_d, X, ce_d],
+        [ce_d],
+    )
+    check_subgraph(
+        subgraph_set,
+        [cb_3, cb_4],
+        [cb_3, cb_4, O_3, ce_4],
+        [ce_4],
+    )
+
+
+if __name__ == "__main__":
+    test_subgraph_set_creator_diamond()
+    test_subgraph_set_creator_merged()
+

--- a/tests/python/relay/test_target_partitioner.py
+++ b/tests/python/relay/test_target_partitioner.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example end-to-end graph partitioning flow test."""
+import tvm
+import tvm.relay.testing
+from tvm import relay
+import tvm.relay.op as reg
+
+
+def test_graph_partitioning_flow():
+    def before():
+        in_1 = relay.var('in_1', shape=(10, 10), dtype='float32')
+        in_2 = relay.var('in_2', shape=(10, 10), dtype='float32')
+        in_3 = relay.var('in_3', shape=(10, 10), dtype='float32')
+        in_4 = relay.var('in_4', shape=(10, 10), dtype='float32')
+        in_5 = relay.var('in_5', shape=(10, 10), dtype='float32')
+        in_6 = relay.var('in_6', shape=(10, 10), dtype='float32')
+        in_7 = relay.var('in_7', shape=(10, 10), dtype='float32')
+        in_8 = relay.var('in_8', shape=(10, 10), dtype='float32')
+        in_9 = relay.var('in_9', shape=(10, 10), dtype='float32')
+        in_10 = relay.var('in_10', shape=(10, 10), dtype='float32')
+
+        node0 = relay.add(in_1, in_2)
+        node1 = relay.add(in_3, in_4)
+        node2 = relay.add(node0, node1)
+
+        node3 = relay.subtract(in_5, in_6)
+        node4 = relay.subtract(in_7, node3)
+
+        node5 = relay.add(node2, node4)
+        node6 = relay.subtract(in_8, node5)
+        node7 = relay.add(in_9, node5)
+
+        node8 = relay.add(node6, node7)
+        node9 = relay.add(in_10, node8)
+
+        f = relay.Function([in_1, in_2, in_3, in_4, in_5, in_6, in_7, in_8, in_9, in_10], node9)
+        mod = tvm.IRModule.from_expr(f)
+        return mod
+
+    annotated = relay.transform.AnnotateTarget('test')(before())
+    merged = relay.transform.MergeSupported()(annotated)
+    partitioned = relay.transform.PartitionGraph()(merged)
+
+
+@reg.register("add", "target.test")
+def add(attrs, args):
+    return True
+
+
+if __name__ == "__main__":
+    test_graph_partitioning_flow()


### PR DESCRIPTION
This PR makes changes to the GraphPartition pass to support producing functions with multiple outputs as well as introducing a new pass, MergeSupported, to handle the merging of supported operators into legal partitions.

It is only a draft to demonstrate the progress we are making in this area. Our goal is to implement the design described in the RFC here: (). We will contribute these components as separate PRs once the design has been agreed upon.

To illustrate what happens, here is a graph before and after the partitioning flow ('add' is supported by the 'test' target, whereas 'subtract' is not):

```
def @main(%in_1: Tensor[(10, 10), float32], %in_2: Tensor[(10, 10), float32], %in_3: Tensor[(10, 10), float32], %in_4: Tensor[(10, 10), float32], %in_5: Tensor[(10, 10), float32], %in_6: Tensor[(10, 10), float32], %in_7: Tensor[(10, 10), float32], %in_8: Tensor[(10, 10), float32], %in_9: Tensor[(10, 10), float32], %in_10: Tensor[(10, 10), float32]) -> Tensor[(10, 10), float32] {
  %0 = add(%in_1, %in_2) /* ty=Tensor[(10, 10), float32] */;
  %1 = add(%in_3, %in_4) /* ty=Tensor[(10, 10), float32] */;
  %2 = add(%0, %1) /* ty=Tensor[(10, 10), float32] */;
  %3 = subtract(%in_5, %in_6) /* ty=Tensor[(10, 10), float32] */;
  %4 = subtract(%in_7, %3) /* ty=Tensor[(10, 10), float32] */;
  %5 = add(%2, %4) /* ty=Tensor[(10, 10), float32] */;
  %6 = subtract(%in_8, %5) /* ty=Tensor[(10, 10), float32] */;
  %7 = add(%in_9, %5) /* ty=Tensor[(10, 10), float32] */;
  %8 = add(%6, %7) /* ty=Tensor[(10, 10), float32] */;
  add(%in_10, %8) /* ty=Tensor[(10, 10), float32] */
}
```

```
def @test_4(%test_4_i5: Tensor[(10, 10), float32], %test_4_i0: Tensor[(10, 10), float32], %test_4_i1: Tensor[(10, 10), float32], %test_4_i2: Tensor[(10, 10), float32], %test_4_i3: Tensor[(10, 10), float32], %test_4_i4: Tensor[(10, 10), float32], Inline=1, Compiler="test", ExternalSymbol="test_4", Primitive=1) -> (Tensor[(10, 10), float32], Tensor[(10, 10), float32]) {
  %0 = add(%test_4_i0, %test_4_i1) /* ty=Tensor[(10, 10), float32] */;
  %1 = add(%test_4_i2, %test_4_i3) /* ty=Tensor[(10, 10), float32] */;
  %2 = add(%0, %1) /* ty=Tensor[(10, 10), float32] */;
  %3 = add(%2, %test_4_i4) /* ty=Tensor[(10, 10), float32] */;
  %4 = add(%test_4_i5, %3) /* ty=Tensor[(10, 10), float32] */;
  (%4, %3)
}

def @default_1(%default_1_i0: Tensor[(10, 10), float32], %default_1_i1: Tensor[(10, 10), float32], Inline=1, Compiler="default", ExternalSymbol="default_1", Primitive=1) -> Tensor[(10, 10), float32] {
  subtract(%default_1_i0, %default_1_i1) /* ty=Tensor[(10, 10), float32] */
}

def @test_0(%test_0_i0: Tensor[(10, 10), float32], %test_0_i1: Tensor[(10, 10), float32], %test_0_i2: Tensor[(10, 10), float32], Inline=1, Compiler="test", ExternalSymbol="test_0", Primitive=1) -> Tensor[(10, 10), float32] {
  %5 = add(%test_0_i1, %test_0_i2) /* ty=Tensor[(10, 10), float32] */;
  add(%test_0_i0, %5) /* ty=Tensor[(10, 10), float32] */
}

def @default_3(%default_3_i0: Tensor[(10, 10), float32], %default_3_i1: Tensor[(10, 10), float32], %default_3_i2: Tensor[(10, 10), float32], Inline=1, Compiler="default", ExternalSymbol="default_3", Primitive=1) -> Tensor[(10, 10), float32] {
  %6 = subtract(%default_3_i1, %default_3_i2) /* ty=Tensor[(10, 10), float32] */;
  subtract(%default_3_i0, %6) /* ty=Tensor[(10, 10), float32] */
}

def @main(%in_1: Tensor[(10, 10), float32], %in_2: Tensor[(10, 10), float32], %in_3: Tensor[(10, 10), float32], %in_4: Tensor[(10, 10), float32], %in_5: Tensor[(10, 10), float32], %in_6: Tensor[(10, 10), float32], %in_7: Tensor[(10, 10), float32], %in_8: Tensor[(10, 10), float32], %in_9: Tensor[(10, 10), float32], %in_10: Tensor[(10, 10), float32]) -> Tensor[(10, 10), float32] {
  %7 = @default_3(%in_7, %in_5, %in_6) /* ty=Tensor[(10, 10), float32] */;
  %8 = @test_4(%in_9, %in_1, %in_2, %in_3, %in_4, %7) /* ty=(Tensor[(10, 10), float32], Tensor[(10, 10), float32]) */;
  %9 = %8.1;
  %10 = @default_1(%in_8, %9) /* ty=Tensor[(10, 10), float32] */;
  %11 = %8.0;
  @test_0(%in_10, %10, %11) /* ty=Tensor[(10, 10), float32] */
}
```

This is the same example as demonstrated here [https://discuss.tvm.ai/t/relay-improved-graph-partitioning-algorithm/5830 ](https://discuss.tvm.ai/t/relay-improved-graph-partitioning-algorithm/5830).