### PR TITLE
[REFACTOR][TIR][TARGET] Make target codegen take IRModule and PrimFunc.

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <algorithm>
 #include <limits>
+#include <type_traits>
 
 namespace tvm {
 
@@ -307,6 +308,17 @@ class Integer : public IntImm {
    * \param other The other value.
    */
   Integer(IntImm other) : IntImm(std::move(other)) {}  // NOLINT(*)
+  /*!
+   * \brief Constructor from enum
+   * \tparam Enum The enum type.
+   * \param value The enum value.
+   */
+  template<typename ENum,
+           typename = typename std::enable_if<std::is_enum<ENum>::value>::type>
+  explicit Integer(ENum value) : Integer(static_cast<int>(value)) {
+    static_assert(std::is_same<int, typename std::underlying_type<ENum>::type>::value,
+                  "declare enum to be enum int to use visitor");
+  }
   /*!
    * \brief Assign an expression to integer.
    * \param other another expression.

--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -213,6 +213,27 @@ constexpr const char* kCallingConv = "calling_conv";
  * \sa tvm::Target
  */
 constexpr const char* kTarget = "target";
+
+/*!
+ * \brief Global linker symbol of the function in generated code.
+ *
+ *  This option forces the code generator to name the
+ *  function with the given.
+ *
+ *  For example, we could set a global_symbol of a function
+ *  early to make sure that we can always refer to it by
+ *  the symbol name in the generated DLL.
+ *
+ *  We should not set the attribute for local functions,
+ *  so that the compiler can freely rename them.
+ *
+ *  A unique global symbol will be automatically assigned
+ *  to each function in the module before the target code
+ *  generation phase.
+ *
+ * Type: String
+ */
+constexpr const char* kGlobalSymbol = "global_symbol";
 }  // namespace attr
 }  // namespace tvm
 #endif  // TVM_IR_FUNCTION_H_

--- a/include/tvm/ir/type.h
+++ b/include/tvm/ir/type.h
@@ -114,7 +114,8 @@ class PrimTypeNode : public TypeNode {
   TVM_DECLARE_FINAL_OBJECT_INFO(PrimTypeNode, TypeNode);
 };
 
-/*!
+
+/*
  * \brief Managed reference to PrimTypeNode.
  * \sa PrimTypeNode
  */
@@ -124,10 +125,52 @@ class PrimType : public Type {
    * \brief Constructor
    * \param dtype The corresponding dtype.
    */
-  TVM_DLL PrimType(runtime::DataType dtype);
+  TVM_DLL explicit PrimType(runtime::DataType dtype);
 
   TVM_DEFINE_OBJECT_REF_METHODS(PrimType, Type, PrimTypeNode);
 };
+
+
+/*!
+ * \brief Low-level raw pointer type.
+ *
+ *  PointerType represents type hints in the TIR to be
+ *  passed to the final code generator.
+ *
+ *  PointerType should not occur in the high-level analysis.
+ *
+ * \sa PointerType
+ */
+class PointerTypeNode : public TypeNode {
+ public:
+  /*!
+   * \brief The type of the element which the pointer points to.
+   */
+  Type element_type;
+
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("element_type", &element_type);
+  }
+
+  static constexpr const char* _type_key = "PointerType";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PointerTypeNode, TypeNode);
+};
+
+/*
+ * \brief Managed reference to PointerTypeNode.
+ * \sa PointerTypeNode
+ */
+class PointerType : public Type {
+ public:
+  /*!
+   * \brief Constructor
+   * \param element_type The type of the element which the pointer points to.
+   */
+  TVM_DLL explicit PointerType(Type element_type);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(PointerType, Type, PointerTypeNode);
+};
+
 
 /*! \brief Possible kinds of TypeVars. */
 enum TypeKind : int {
@@ -281,6 +324,15 @@ class TupleType : public Type {
  */
 inline Type VoidType() {
   return TupleType::Empty();
+}
+
+/*!
+ * \brief Check whether the tyep represents void.
+ * \return The check result.
+ */
+inline bool IsVoidType(const Type& type) {
+  auto* n = type.as<TupleTypeNode>();
+  return n && n->fields.size() == 0;
 }
 
 /*!

--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -55,22 +55,27 @@ namespace tir {
  */
 class VarNode : public PrimExprNode {
  public:
-  /*! \brief constructor */
-  VarNode() {}
-  VarNode(DataType dtype, std::string name_hint);
-
   /*!
    * \brief The hint to the variable name.
    * \note Each variable is uniquely identified by its address.
    */
   std::string name_hint;
+  /*!
+   * \brief type annotaion of the variable.
+   *
+   * It is an optional field that provides a refined type of the variable than dtype.
+   *
+   * \sa tvm/ir/type.h for discussion of relations between runtime::DataType and Type.
+   */
+  Type type_annotation;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("dtype", &dtype);
     v->Visit("name", &name_hint);
+    v->Visit("type_annotation", &type_annotation);
   }
 
-  static constexpr const char* _type_key = "Variable";
+  static constexpr const char* _type_key = "tir.Var";
   TVM_DECLARE_BASE_OBJECT_INFO(VarNode, PrimExprNode);
 };
 
@@ -78,20 +83,25 @@ class VarNode : public PrimExprNode {
 class Var : public PrimExpr {
  public:
   explicit Var(ObjectPtr<Object> n) : PrimExpr(n) {}
-  /*! \brief constructor
+  /*!
+   * \brief Constructor
    * \param name_hint variable name
-   * \param t data type
+   * \param dtype data type
    */
   TVM_DLL explicit Var(std::string name_hint = "v",
-                       DataType t = DataType::Int(32));
+                       DataType dtype = DataType::Int(32));
+  /*!
+   * \brief Constructor which provides a more detailed type annotation.
+   * \param name_hint variable name.
+   * \param type_annotation The type annotation.
+   */
+  TVM_DLL explicit Var(std::string name_hint, Type type_annotation);
   /*!
    * \brief Make a new copy of var with same type, append suffix
    * \param suffix The suffix to be appended.
    * \return the new Var copy
    */
-  Var copy_with_suffix(const std::string& suffix) const {
-    return Var((*this)->name_hint + suffix, (*this)->dtype);
-  }
+  TVM_DLL Var copy_with_suffix(const std::string& suffix) const;
   /*!
    * \brief Get pointer to the internal value.
    * \return the corresponding Variable.
@@ -116,15 +126,7 @@ class Var : public PrimExpr {
  */
 class SizeVarNode : public VarNode {
  public:
-  /*! \brief constructor */
-  SizeVarNode() {}
-  /*! \brief constructor
-   * \param dtype data type
-   * \param name_hint variable name
-   */
-  SizeVarNode(DataType dtype, std::string name_hint);
-
-  static constexpr const char* _type_key = "SizeVar";
+  static constexpr const char* _type_key = "tir.SizeVar";
   TVM_DECLARE_FINAL_OBJECT_INFO(SizeVarNode, VarNode);
 };
 
@@ -132,12 +134,13 @@ class SizeVarNode : public VarNode {
 class SizeVar : public Var {
  public:
   explicit SizeVar(ObjectPtr<Object> n) : Var(n) {}
-  /*! \brief constructor
+  /*!
+   * \brief constructor
    * \param name_hint variable name
    * \param t data type
    */
   TVM_DLL explicit SizeVar(std::string name_hint = "s",
-                            DataType t = DataType::Int(32));
+                           DataType t = DataType::Int(32));
   /*!
    * \brief Get pointer to the internal value.
    * \return the corresponding Variable.

--- a/include/tvm/tir/function.h
+++ b/include/tvm/tir/function.h
@@ -171,6 +171,16 @@ constexpr const char* kDeviceThreadAxis = "tir.device_thread_axis";
  * Type: Integer
  */
 constexpr const char* kNoAlias = "tir.noalias";
+
+/*!
+ * \brief Mark the function as the entry function of
+ *        the final generated runtime module.
+ *
+ * Type: Integer
+ *
+ * \note There can only be one entry function per module.
+ */
+constexpr const char* kIsEntryFunc = "tir.is_entry_func";
 }  // namespace attr
 }  // namespace tir
 }  // namespace tvm

--- a/include/tvm/tir/ir_pass.h
+++ b/include/tvm/tir/ir_pass.h
@@ -30,6 +30,7 @@
 #include <tvm/te/schedule.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/buffer.h>
+#include <tvm/tir/function.h>
 #include <tvm/tir/lowered_func.h>
 
 #include <unordered_map>
@@ -514,6 +515,19 @@ LoweredFunc CombineContextCall(LoweredFunc f);
  * \return Transformed function.
  */
 LoweredFunc PointerValueTypeRewrite(LoweredFunc f);
+
+
+/*!
+ * \brief Rewrite the pointer content type of arguments,
+ *  as well as Alloc internal to the function to use
+ *  the most frequently accessed type for load/store
+ *  to avoid pointer casting in backend when possible.
+ *
+ * \note implemeneted in storage_rewrite.cc
+ * \param f The function to be trasnformed
+ * \return Transformed function.
+ */
+PrimFunc PointerValueTypeRewrite(PrimFunc f);
 
 /*!
  * \brief Lower attached storage access information on device.

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -52,9 +52,22 @@ namespace tvm {
  * This function could return a more refined type than
  * the runtime type provided by expr->dtype
  *
+ * \param expr The input parameter.
+ * \return The result type.
+ *
  * \sa tvm/ir/type.h for discussion about the relation between Type and runtime::DataType.
  */
 TVM_DLL Type GetType(const PrimExpr& expr);
+
+/*!
+ * \brief Get the implied DataType for storing values with type during runtime.
+ *
+ * \param type The input type.
+ * \return The result runtime::DataType.
+ *
+ * \sa tvm/ir/type.h for discussion about the relation between Type and runtime::DataType.
+ */
+TVM_DLL runtime::DataType GetRuntimeDataType(const Type& type);
 
 /*!
  * Query the maximum possible value of dtype.

--- a/python/tvm/ir/__init__.py
+++ b/python/tvm/ir/__init__.py
@@ -17,7 +17,7 @@
 # pylint: disable=unused-import
 """Common data structures across all IR variants."""
 from .base import SourceName, Span, Node, EnvFunc, load_json, save_json
-from .type import Type, TypeKind, PrimType, TypeVar, GlobalTypeVar, TupleType
+from .type import Type, TypeKind, PrimType, PointerType, TypeVar, GlobalTypeVar, TupleType
 from .type import TypeConstraint, FuncType, IncompleteType, RelayRefType
 from .tensor_type import TensorType
 from .type_relation import TypeCall, TypeRelation

--- a/python/tvm/ir/json_compact.py
+++ b/python/tvm/ir/json_compact.py
@@ -72,7 +72,15 @@ def create_updater_06_to_07():
             return item
         return _convert
 
+    def _update_tir_var(new_name):
+        def _convert(item, _):
+            item["type_key"] = new_name
+            item["attrs"]["type_annotation"] = "0"
+            return item
+        return _convert
+
     node_map = {
+        # Base IR
         "relay.TypeVar": _ftype_var,
         "relay.GlobalTypeVar": _ftype_var,
         "relay.Type": _rename("Type"),
@@ -91,6 +99,9 @@ def create_updater_06_to_07():
         "relay.PassContext": _rename("transform.PassContext"),
         "relay.ModulePass": _rename("transform.ModulePass"),
         "relay.Sequantial": _rename("transform.Sequantial"),
+        # TIR
+        "Variable": _update_tir_var("tir.Var"),
+        "SizeVar": _update_tir_var("tir.SizeVar"),
     }
     return create_updater(node_map, "0.6", "0.7")
 

--- a/python/tvm/ir/type.py
+++ b/python/tvm/ir/type.py
@@ -46,6 +46,7 @@ class TypeKind(IntEnum):
     TypeData = 6
 
 
+@tvm._ffi.register_object("PrimType")
 class PrimType(Type):
     """Primitive data type in the low level IR
 
@@ -57,6 +58,20 @@ class PrimType(Type):
     def __init__(self, dtype):
         self.__init_handle_by_constructor__(
             _ffi_api.PrimType, dtype)
+
+
+@tvm._ffi.register_object("PointerType")
+class PointerType(Type):
+    """PointerType used in the low-level TIR.
+
+    Parameters
+    ----------
+    element_type : tvm.ir.Type
+        The type of pointer's element.
+    """
+    def __init__(self, element_type):
+        self.__init_handle_by_constructor__(
+            _ffi_api.PointerType, element_type)
 
 
 @tvm._ffi.register_object("TypeVar")

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -288,7 +288,7 @@ class CmpExpr(PrimExprWithOp):
 class LogicalExpr(PrimExprWithOp):
     pass
 
-@tvm._ffi.register_object("Variable")
+@tvm._ffi.register_object("tir.Var")
 class Var(PrimExprWithOp):
     """Symbolic variable.
 
@@ -297,7 +297,7 @@ class Var(PrimExprWithOp):
     name : str
         The name
 
-    dtype : str
+    dtype : Union[str, tvm.irType]
         The data type
     """
     def __init__(self, name, dtype):
@@ -305,7 +305,7 @@ class Var(PrimExprWithOp):
             _ffi_api.Var, name, dtype)
 
 
-@tvm._ffi.register_object
+@tvm._ffi.register_object("tir.SizeVar")
 class SizeVar(Var):
     """Symbolic variable to represent a tensor index size
        which is greater or equal to zero.

--- a/src/arith/domain_touched.cc
+++ b/src/arith/domain_touched.cc
@@ -68,7 +68,7 @@ class FuncTouchedDomain final : public StmtExprVisitor {
 
   /* TODO: Thread extent unitest not generated.*/
   void VisitStmt_(const AttrStmtNode* op) final {
-    if (op->attr_key == attr::thread_extent) {
+    if (op->attr_key == tir::attr::thread_extent) {
       const IterVarNode* thread_axis = op->node.as<IterVarNode>();
       CHECK(thread_axis);
       const VarNode* var = thread_axis->var.get();

--- a/src/arith/ir_mutator_with_analyzer.cc
+++ b/src/arith/ir_mutator_with_analyzer.cc
@@ -92,8 +92,8 @@ VisitStmt_(const IfThenElseNode* op) {
 
 Stmt IRMutatorWithAnalyzer::
 VisitStmt_(const AttrStmtNode* op) {
-  if (op->attr_key == attr::thread_extent ||
-      op->attr_key == attr::virtual_thread) {
+  if (op->attr_key == tir::attr::thread_extent ||
+      op->attr_key == tir::attr::virtual_thread) {
     IterVar iv = Downcast<IterVar>(op->node);
     CHECK_NE(iv->thread_tag.length(), 0U);
     analyzer_->Bind(iv->var,

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -40,7 +40,7 @@ using runtime::PackedFunc;
 using tir::LoweredFunc;
 
 bool LLVMEnabled() {
-  const runtime::PackedFunc* pf = runtime::Registry::Get("codegen.build_llvm");
+  const runtime::PackedFunc* pf = runtime::Registry::Get("target.build.llvm");
   return pf != nullptr;
 }
 

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -45,6 +45,27 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 });
 
 
+PointerType::PointerType(Type element_type) {
+  ObjectPtr<PointerTypeNode> n = make_object<PointerTypeNode>();
+  n->element_type = std::move(element_type);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(PointerTypeNode);
+
+TVM_REGISTER_GLOBAL("ir.PointerType")
+.set_body_typed([](Type element_type) {
+  return PointerType(element_type);
+});
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+.set_dispatch<PointerTypeNode>([](const ObjectRef& ref, ReprPrinter* p) {
+    auto* node = static_cast<const PointerTypeNode*>(ref.get());
+    p->Print(node->element_type);
+    p->stream << '*';
+});
+
+
 TypeVar::TypeVar(std::string name, TypeKind kind) {
   ObjectPtr<TypeVarNode> n = make_object<TypeVarNode>();
   n->name_hint = std::move(name);

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -139,7 +139,7 @@ bool RuntimeEnabled(const std::string& target) {
   } else if (target == "vulkan") {
     f_name = "device_api.vulkan";
   } else if (target == "stackvm") {
-    f_name = "codegen.build_stackvm";
+    f_name = "target.build.stackvm";
   } else if (target == "rpc") {
     f_name = "device_api.rpc";
   } else if (target == "micro_dev") {

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -42,7 +42,7 @@ class CodeGenCPU : public CodeGenLLVM {
             llvm::LLVMContext* ctx,
             bool system_lib,
             bool dynamic_lookup) override;
-  void AddFunction(const LoweredFunc& f) override;
+  void AddFunction(const PrimFunc& f) override;
   void AddMainFunction(const std::string& entry_func_name) override;
   std::unique_ptr<llvm::Module> Finish() override;
   void VisitStmt_(const AssertStmtNode* op) override;

--- a/src/target/llvm/codegen_x86_64.cc
+++ b/src/target/llvm/codegen_x86_64.cc
@@ -88,7 +88,7 @@ llvm::Value* CodeGenX86_64::VisitExpr_(const CastNode* op) {
     if (from.lanes() >= 16 && has_avx512) {
       return CallVectorIntrin(
           ::llvm::Intrinsic::x86_avx512_mask_vcvtph2ps_512, 16,
-          LLVMType(DataType::Float(32, from.lanes())),
+          DTypeToLLVMType(DataType::Float(32, from.lanes())),
           {
             MakeValue(tir::CallNode::make(
                 DataType::Int(16, from.lanes()), tir::CallNode::reinterpret, {op->value},
@@ -103,7 +103,8 @@ llvm::Value* CodeGenX86_64::VisitExpr_(const CastNode* op) {
 
     if (from.lanes() >= 8 && has_f16c) {
       return CallVectorIntrin(
-          ::llvm::Intrinsic::x86_vcvtph2ps_256, 8, LLVMType(DataType::Float(32, from.lanes())),
+          ::llvm::Intrinsic::x86_vcvtph2ps_256, 8,
+          DTypeToLLVMType(DataType::Float(32, from.lanes())),
           {MakeValue(tir::CallNode::make(
               DataType::Int(16, from.lanes()), tir::CallNode::reinterpret, {op->value},
               tir::CallNode::PureIntrinsic))});

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -26,9 +26,11 @@
 
 #include <tvm/tir/expr.h>
 #include <tvm/tir/stmt.h>
+#include <tvm/tir/function.h>
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/target/codegen.h>
 #include <tvm/tir/lowered_func.h>
+#include <tvm/runtime/container.h>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -62,8 +64,9 @@ class CodeGenC :
   /*!
    * \brief Add the function to the generated module.
    * \param f The function to be compiled.
+   * \param whether to append return 0 in the end.
    */
-  void AddFunction(LoweredFunc f);
+  void AddFunction(const PrimFunc& f);
   /*!
    * \brief Finalize the compilation and return the code.
    * \return The code.
@@ -93,15 +96,25 @@ class CodeGenC :
   }
   // The following parts are overloadable print operations.
   /*!
+   * \brief Print the function header before the argument list
+   *
+   *  Example: stream << "void";
+   */
+  virtual void PrintFuncPrefix(); // NOLINT(*)
+  /*!
+   * \brief Print the final return at the end the function.
+   */
+  virtual void PrintFinalReturn(); // NOLINT(*)
+  /*!
    * \brief Insert statement before function body.
    * \param f The function to be compiled.
    */
-  virtual void PreFunctionBody(LoweredFunc f) {}
+  virtual void PreFunctionBody(const PrimFunc& f) {}
   /*!
    * \brief Initialize codegen state for generating f.
    * \param f The function to be compiled.
    */
-  virtual void InitFuncState(LoweredFunc f);
+  virtual void InitFuncState(const PrimFunc& f);
   // expression
   void VisitExpr_(const VarNode* op, std::ostream& os) override;  // NOLINT(*)
   void VisitExpr_(const LoadNode* op, std::ostream& os) override;  // NOLINT(*)
@@ -148,6 +161,12 @@ class CodeGenC :
    * \param os The stream to print the ctype into
    */
   virtual void PrintType(DataType t, std::ostream& os); // NOLINT(*)
+  /*!
+   * Print Type represetnation of type type.
+   * \param type The type representation.
+   * \param os The stream to print the ctype into
+   */
+  virtual void PrintType(const Type& type, std::ostream& os); // NOLINT(*)
   /*!
    * \brief Print expr representing the thread tag
    * \param IterVar iv The thread index to be binded;
@@ -223,12 +242,6 @@ class CodeGenC :
   // override
   void PrintSSAAssign(
       const std::string& target, const std::string& src, DataType t) final;
-  /*! \brief restrict keyword */
-  std::string restrict_keyword_{""};
-  /*! \brief the storage scope of allocation */
-  std::unordered_map<const VarNode*, std::string> alloc_storage_scope_;
-  /*! \brief the data type of allocated buffers */
-  std::unordered_map<const VarNode*, DataType> handle_data_type_;
   /*! \brief reserves common C keywords */
   void ReserveKeywordsAsUnique();
 
@@ -236,6 +249,13 @@ class CodeGenC :
   bool IsVolatile(const VarNode *buf_var) const {
     return volatile_buf_.count(buf_var) != 0;
   }
+
+  /*! \brief restrict keyword */
+  std::string restrict_keyword_{""};
+  /*! \brief the storage scope of allocation */
+  std::unordered_map<const VarNode*, std::string> alloc_storage_scope_;
+  /*! \brief the data type of allocated buffers */
+  std::unordered_map<const VarNode*, DataType> handle_data_type_;
 
  private:
   /*! \brief whether to print in SSA form */

--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -36,10 +36,10 @@ class CodeGenCHost final : public CodeGenC {
  public:
   CodeGenCHost();
   void Init(bool output_ssa, bool emit_asserts);
-  void AddFunction(LoweredFunc f);
-  std::string Finish();
 
   void PrintType(DataType t, std::ostream& os) final; // NOLINT(*)
+  void PrintFuncPrefix() final; // NOLINT(*)
+  void PrintFinalReturn() final; // NOLINT(*)
 
   // overload visitor functions
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final; // NOLINT(*)

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -43,9 +43,9 @@ void CodeGenCUDA::Init(bool output_ssa) {
   CHECK_EQ(vid_global_barrier_state_, runtime::symbol::tvm_global_barrier_state);
 }
 
-void CodeGenCUDA::AddFunction(LoweredFunc f) {
-  this->stream << "extern \"C\" __global__ ";
-  CodeGenC::AddFunction(f);
+
+void CodeGenCUDA::PrintFuncPrefix() {
+  stream << "extern \"C\" __global__ void";
 }
 
 std::string CodeGenCUDA::Finish() {
@@ -424,11 +424,11 @@ void CodeGenCUDA::VisitExpr_(const CallNode *op, std::ostream& os) {
 }
 
 void CodeGenCUDA::VisitStmt_(const AttrStmtNode* op) {
-  if (op->attr_key == attr::fragment_shape) {
+  if (op->attr_key == tir::attr::fragment_shape) {
     const VarNode* buffer = op->node.as<VarNode>();
     const StringImmNode* shape_str = op->value.as<StringImmNode>();
     fragment_shapes[buffer] = shape_str->value;
-  } else if (op->attr_key == attr::fragment_layout) {
+  } else if (op->attr_key == tir::attr::fragment_layout) {
     const VarNode* buffer = op->node.as<VarNode>();
     const StringImmNode* layout_str = op->value.as<StringImmNode>();
     fragment_layouts[buffer] = layout_str->value;

--- a/src/target/source/codegen_cuda.h
+++ b/src/target/source/codegen_cuda.h
@@ -37,12 +37,12 @@ class CodeGenCUDA final : public CodeGenC {
  public:
   CodeGenCUDA();
   void Init(bool output_ssa);
-  void AddFunction(LoweredFunc f);
   std::string Finish();
   bool need_include_path() {
     return (enable_fp16_ || enable_int8_ || need_math_constants_h_ || need_mma_h_);
   }
   // override behavior
+  void PrintFuncPrefix() final;
   void VisitStmt_(const ForNode* op) final;
   void PrintStorageSync(const CallNode* op) final;
   void PrintStorageScope(const std::string& scope, std::ostream& os) final;  // NOLINT(*)

--- a/src/target/source/codegen_metal.h
+++ b/src/target/source/codegen_metal.h
@@ -34,10 +34,10 @@ namespace codegen {
 class CodeGenMetal final : public CodeGenC {
  public:
   CodeGenMetal();
-  void AddFunction(LoweredFunc f);
   // override print thread tag.
   void PrintArgUnionDecl();
-  void InitFuncState(LoweredFunc f) final;
+  void AddFunction(const PrimFunc& f); // NOLINT(*)
+  void InitFuncState(const PrimFunc& f) final;
   void PrintStorageScope(const std::string& scope, std::ostream& os) final; // NOLINT(*)
   void PrintStorageSync(const CallNode* op) final;  // NOLINT(*)
   void PrintType(DataType t, std::ostream& os) final; // NOLINT(*)
@@ -50,9 +50,10 @@ class CodeGenMetal final : public CodeGenC {
       const std::string& vec, DataType t, int i, const std::string& value) final;
   // overload visitor
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final; // NOLINT(*)
-
   // overload visitor
   void VisitExpr_(const CallNode* op, std::ostream& os) final; // NOLINT(*)
+  // reuse parent's function.
+  using CodeGenC::PrintType;
 
  private:
   int thread_index_bits_{32};

--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -34,11 +34,11 @@ namespace codegen {
 class CodeGenOpenCL final : public CodeGenC {
  public:
   CodeGenOpenCL();
-  void AddFunction(LoweredFunc f);
   std::string Finish();
 
   // override print thread tag.
-  void InitFuncState(LoweredFunc f) final;
+  void InitFuncState(const PrimFunc& f) final;
+  void PrintFuncPrefix() final; // NOLINT(*)
   void BindThreadIndex(const IterVar& iv) final;  // NOLINT(*)
   void PrintStorageScope(const std::string& scope, std::ostream& os) final; // NOLINT(*)
   void PrintStorageSync(const CallNode* op) final;  // NOLINT(*)
@@ -56,9 +56,6 @@ class CodeGenOpenCL final : public CodeGenC {
   // overload visitor
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final; // NOLINT(*)
   void VisitExpr_(const FloatImmNode *op, std::ostream& os) final; // NOLINT(*)
-  // overload min and max to avoid ambiguous call errors
-  void VisitExpr_(const MinNode *op, std::ostream& os) final;
-  void VisitExpr_(const MaxNode *op, std::ostream& os) final;
 
  private:
   // whether enable fp16 and fp64 extension

--- a/src/target/source/codegen_opengl.h
+++ b/src/target/source/codegen_opengl.h
@@ -37,10 +37,10 @@ namespace codegen {
 class CodeGenOpenGL final : public CodeGenC {
  public:
   CodeGenOpenGL();
-  void AddFunction(LoweredFunc f);
   std::unordered_map<std::string, runtime::OpenGLShader> Finish();
 
-  void InitFuncState(LoweredFunc f) final;
+  void AddFunction(const PrimFunc& f);
+  void InitFuncState(const PrimFunc& f) final;
   void BindThreadIndex(const IterVar& iv) final;
   void VisitStmt_(const StoreNode* op) final;
   std::string TexelFetch(const VarNode* buffer, PrimExpr index);

--- a/src/target/source/codegen_vhls.h
+++ b/src/target/source/codegen_vhls.h
@@ -15,7 +15,7 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */
+5B5B */
 
 /*!
  * \file codegen_vhls.h
@@ -37,10 +37,11 @@ class CodeGenVivadoHLS final : public CodeGenC {
  public:
   void Init(bool output_ssa);
   void PrintType(DataType t, std::ostream& os);
-  void AddFunction(LoweredFunc f);
-  void PreFunctionBody(LoweredFunc f);
-  void VisitExpr_(const MinNode *op, std::ostream& os);
-  void VisitExpr_(const MaxNode *op, std::ostream& os);
+
+  void PrintFuncPrefix() final;
+  void PreFunctionBody(const PrimFunc& f) final;
+  void VisitExpr_(const MinNode *op, std::ostream& os) final;
+  void VisitExpr_(const MaxNode *op, std::ostream& os) final;
 };
 
 }  // namespace codegen

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -53,7 +53,7 @@ class CodeGenSPIRV:
    * \param f The function to be added.
    * \return The final spirv module.
    */
-  virtual std::vector<uint32_t> BuildFunction(const LoweredFunc& f);
+  virtual std::vector<uint32_t> BuildFunction(const PrimFunc& f);
   /*!
    * \brief Create Value for expression e
    * \param e The expression to be created value for.

--- a/src/target/stackvm/codegen_stackvm.h
+++ b/src/target/stackvm/codegen_stackvm.h
@@ -56,7 +56,7 @@ class CodeGenStackVM
    * \note Only call compile once,
    *  create a new codegen object each time.
    */
-  StackVM Compile(LoweredFunc f);
+  StackVM Compile(const PrimFunc& f);
   /*! \brief Push stmt to generate new code */
   void Push(const Stmt& n);
   /*! \brief Push expr to generate new code */

--- a/src/te/operation/cross_thread_reduction.cc
+++ b/src/te/operation/cross_thread_reduction.cc
@@ -91,7 +91,7 @@ Stmt MakeCrossThreadReduction(
       freduce_args, CallNode::Intrinsic));
   reduce_body = AttrStmtNode::make(
       reduces[0]->combiner,
-      attr::reduce_scope,
+      tir::attr::reduce_scope,
       make_zero(DataType::Handle()),
       reduce_body);
   std::vector<Stmt> assigns(size);
@@ -109,7 +109,7 @@ Stmt MakeCrossThreadReduction(
     body = AllocateNode::make(
       res_handles[idx - 1], reduces[idx - 1]->dtype, {1}, const_true(), body);
     body = AttrStmtNode::make(
-      res_handles[idx - 1], attr::storage_scope, StringImmNode::make("local"), body);
+      res_handles[idx - 1], tir::attr::storage_scope, StringImmNode::make("local"), body);
   }
   body = Substitute(body, value_map);
   return MergeNest(nest, body);

--- a/src/te/operation/extern_op.cc
+++ b/src/te/operation/extern_op.cc
@@ -165,7 +165,8 @@ Stmt ExternOpNode::BuildProvide(
     const std::unordered_map<IterVar, Range>& dom_map,
     bool debug_keep_trivial_loop) const {
   CHECK_EQ(stage->op.operator->(), this);
-  Stmt ret = AttrStmtNode::make(make_zero(DataType::Int(32)), attr::extern_scope, 0, this->body);
+  Stmt ret = AttrStmtNode::make(
+      make_zero(DataType::Int(32)), tir::attr::extern_scope, 0, this->body);
   auto f_push_bind = [&ret](Buffer buffer, Tensor tensor) {
     Array<ObjectRef> bind_spec;
     Array<PrimExpr> tuple;
@@ -176,7 +177,7 @@ Stmt ExternOpNode::BuildProvide(
       tuple.push_back(buffer->shape[k]);
     }
     ret = AttrStmtNode::make(
-        bind_spec, attr::buffer_bind_scope,
+        bind_spec, tir::attr::buffer_bind_scope,
         CallNode::make(DataType::Handle(), intrinsic::tvm_tuple, tuple, CallNode::Intrinsic), ret);
   };
   for (size_t i = output_placeholders.size(); i != 0; --i) {

--- a/src/te/operation/hybrid_op.cc
+++ b/src/te/operation/hybrid_op.cc
@@ -186,7 +186,8 @@ Stmt HybridOpNode::BuildProvide(
     const std::unordered_map<IterVar, Range> &dom_map,
     bool debug_keep_trivial_loop) const {
   CHECK_EQ(stage->op.operator->(), this);
-  Stmt ret = AttrStmtNode::make(make_zero(DataType::Int(32)), attr::extern_scope, 0, this->body);
+  Stmt ret = AttrStmtNode::make(
+      make_zero(DataType::Int(32)), tir::attr::extern_scope, 0, this->body);
   std::unordered_map<Tensor, Tensor> rmap;
   for (int i = 0; i < this->num_outputs(); ++i) {
     rmap[outputs[i]] = stage->op.output(i);

--- a/src/te/operation/op_util.cc
+++ b/src/te/operation/op_util.cc
@@ -168,7 +168,7 @@ MakeLoopNest(const Stage& stage,
     // annotate the extent of the IterVar
     if (!new_loop_var) {
       nest[i + 1].emplace_back(
-          AttrStmtNode::make(iv, attr::loop_scope, iv->var, no_op));
+          AttrStmtNode::make(iv, tir::attr::loop_scope, iv->var, no_op));
     }
   }
   // message passing to get offset of root iter vars.

--- a/src/te/operation/scan_op.cc
+++ b/src/te/operation/scan_op.cc
@@ -287,10 +287,10 @@ Stmt ScanOpNode::BuildProvide(
     bool debug_keep_trivial_loop) const {
   CHECK_EQ(stage->op.operator->(), this);
   Stmt provide = AttrStmtNode::make(
-      stage->op, attr::scan_update_scope, this->scan_axis->var,
+      stage->op, tir::attr::scan_update_scope, this->scan_axis->var,
       EvaluateNode::make(0));
   Stmt init = AttrStmtNode::make(
-      stage->op, attr::scan_init_scope, 0,
+      stage->op, tir::attr::scan_init_scope, 0,
       EvaluateNode::make(0));
   size_t begin_scan = 0;
   for (size_t  i = 0; i < stage->leaf_iter_vars.size(); ++i) {

--- a/src/te/schedule/schedule_ops.cc
+++ b/src/te/schedule/schedule_ops.cc
@@ -85,7 +85,7 @@ class InjectAttach : public StmtMutator {
     auto stmt = StmtMutator::VisitStmt(input_stmt);
     const AttrStmtNode* op = stmt.as<AttrStmtNode>();
     if (op != nullptr &&
-        op->attr_key == attr::loop_scope) {
+        op->attr_key == tir::attr::loop_scope) {
       if (attach_spec_->attach_type == kScope &&
           op->node == attach_spec_->attach_ivar) {
         CHECK(!found_attach)
@@ -131,8 +131,8 @@ class InjectScanStep : public StmtMutator {
     // update
     const AttrStmtNode* op = stmt.as<AttrStmtNode>();
     if (op != nullptr &&
-        ((op->attr_key == attr::scan_update_scope && !is_init_) ||
-         (op->attr_key == attr::scan_init_scope && is_init_))) {
+        ((op->attr_key == tir::attr::scan_update_scope && !is_init_) ||
+         (op->attr_key == tir::attr::scan_init_scope && is_init_))) {
       if (op->node.same_as(scan_op_)) {
         found_attach = true;
         stmt = AttrStmtNode::make(
@@ -187,15 +187,15 @@ class SchedulePostProc : public StmtExprMutator {
   }
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
-    if (op->attr_key == attr::loop_scope ||
-        op->attr_key == attr::scan_init_scope) {
+    if (op->attr_key == tir::attr::loop_scope ||
+        op->attr_key == tir::attr::scan_init_scope) {
       return this->VisitStmt(op->body);
-    } else if (op->attr_key == attr::scan_update_scope) {
+    } else if (op->attr_key == tir::attr::scan_update_scope) {
       const ScanOpNode* scan = op->node.as<ScanOpNode>();
       CHECK(scan);
       var_value_[scan->scan_axis->var.get()] = op->value;
       return this->VisitStmt(op->body);
-    } else if (op->attr_key == attr::thread_extent) {
+    } else if (op->attr_key == tir::attr::thread_extent) {
       // delete duplicated thread extent attr
       auto it = thread_extent_scope_.find(op->node.get());
       if (it != thread_extent_scope_.end()) {

--- a/src/tir/ir/lowered_func.cc
+++ b/src/tir/ir/lowered_func.cc
@@ -31,5 +31,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 });
 
 TVM_REGISTER_NODE_TYPE(LoweredFuncNode);
+
+
 }  // namespace tir
 }  // namespace tvm

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -83,8 +83,8 @@ def test_meta_data():
     text_no_meta = str(f)
     assert "channels=2" in text
     assert "channels=2" in text_no_meta
-    assert "meta[SizeVar][0]" in text
-    assert "meta[SizeVar][0]" in text_no_meta
+    assert "meta[tir.SizeVar][0]" in text
+    assert "meta[tir.SizeVar][0]" in text_no_meta
     assert "type_key" in text
     assert "type_key" not in text_no_meta
 

--- a/tests/python/relay/test_json_compact.py
+++ b/tests/python/relay/test_json_compact.py
@@ -108,8 +108,32 @@ def test_global_var():
     assert isinstance(tvar, tvm.ir.GlobalVar)
 
 
+def test_tir_var():
+    nodes = [
+        {"type_key": ""},
+        {"type_key": "Variable",
+         "attrs": {"dtype": "int32", "name": "x"}},
+        {"type_key": "SizeVar",
+         "attrs": {"dtype": "int32", "name": "y"}},
+    ]
+    data = {
+        "root" : 1,
+        "nodes": nodes,
+        "attrs": {"tvm_version": "0.6.0"},
+        "b64ndarrays": [],
+    }
+    x = tvm.ir.load_json(json.dumps(data))
+    assert isinstance(x, tvm.tir.Var)
+    assert x.name == "x"
+    data["root"] = 2
+    y = tvm.ir.load_json(json.dumps(data))
+    assert isinstance(y, tvm.tir.SizeVar)
+    assert y.name == "y"
+
+
 if __name__ == "__main__":
     test_type_var()
     test_incomplete_type()
     test_func_tuple_type()
     test_global_var()
+    test_tir_var()

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -265,7 +265,18 @@ def test_prim_func():
     assert func.attrs is None
 
 
+def test_vars():
+    x = tvm.tir.Var("xyz", "int8")
+    assert x.dtype == "int8"
+    ptype = tvm.ir.PointerType(tvm.ir.PrimType("float"))
+    x = tvm.tir.Var("xyz", ptype)
+    assert x.dtype == "handle"
+    assert x.type_annotation == ptype
+    assert isinstance(ptype.element_type, tvm.ir.PrimType)
+
+
 if __name__ == "__main__":
+    test_vars()
     test_prim_func()
     test_cast()
     test_attr()


### PR DESCRIPTION
As part of the unified IR refactor.
This PR refactors the target codegen to use IRModule containing tir::PrimFuncs.

In order to break the refactor into several steps without breaking the codebase,
we built an conversion pass to convert Array<LoweredFunc> into IRModule.

The follow-up refactors will gradually move the passes covered by IRModule up
until we cover all the passes. Then we can remove the additional redundant
concepts such as LoweredFunc.
