### PR TITLE
[Bugfix] Fixed bug where shifting by out-of-bounds value results in no compute code being emitted.

### DIFF
--- a/src/tir/ir/op.cc
+++ b/src/tir/ir/op.cc
@@ -454,6 +454,9 @@ PrimExpr operator>>(PrimExpr a, PrimExpr b) {
   BinaryOpMatchTypes(a, b);
   TVM_INDEX_CONST_PROPAGATION({
       const DataType& rtype = a.dtype();
+      if (pb) CHECK(pb->value >= 0 && pb->value < rtype.bits()) <<
+                "Shift amount must be non-negative and less than " << rtype.bits()
+                << " for type " << rtype;
       if (pa && pb) return IntImm(rtype, (pa->value >> pb->value));
       if (pb) {
         if (pb->value == 0) return a;
@@ -469,6 +472,9 @@ PrimExpr operator<<(PrimExpr a, PrimExpr b) {
   BinaryOpMatchTypes(a, b);
   TVM_INDEX_CONST_PROPAGATION({
       const DataType& rtype = a.dtype();
+      if (pb) CHECK(pb->value >= 0 && pb->value < rtype.bits()) <<
+                "Shift amount must be non-negative and less than " << rtype.bits()
+                << " for type " << rtype;
       if (pa && pb) return IntImm(rtype, (pa->value << pb->value));
       if (pb) {
         if (pb->value == 0) return a;

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -187,6 +187,7 @@ def test_bitwise():
     assert(x >> tvm.tir.const(1, "int32x2")).dtype == "int32x2"
     assert(te.var("z", "int8x2") << tvm.tir.const(1, "int8x2")).dtype == "int8x2"
 
+
 def test_float_bitwise():
     t = tvm.tir.const(1.5,dtype='float32')
     for test in [lambda lhs, rhs : lhs << rhs,
@@ -205,6 +206,7 @@ def test_float_bitwise():
     except RuntimeError:
         pass
 
+
 def test_shift_bounds():
     for test in [lambda lhs, rhs : lhs << rhs,
                     lambda lhs, rhs : lhs >> rhs]:
@@ -218,7 +220,7 @@ def test_shift_bounds():
 
         #positive case
         for testcase in [(x,0), (x,16), (x,31)]:
-            assert test(*testcase).args[1] == testcase[1]
+            assert test(*testcase)
 
 
 def test_divide_by_zero():

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -187,7 +187,6 @@ def test_bitwise():
     assert(x >> tvm.tir.const(1, "int32x2")).dtype == "int32x2"
     assert(te.var("z", "int8x2") << tvm.tir.const(1, "int8x2")).dtype == "int8x2"
 
-
 def test_float_bitwise():
     t = tvm.tir.const(1.5,dtype='float32')
     for test in [lambda lhs, rhs : lhs << rhs,
@@ -205,6 +204,21 @@ def test_float_bitwise():
         assert False
     except RuntimeError:
         pass
+
+def test_shift_bounds():
+    for test in [lambda lhs, rhs : lhs << rhs,
+                    lambda lhs, rhs : lhs >> rhs]:
+        #negative case
+        for testcase in [(x,-1), (x,32)]:
+            try:
+                test(*testcase)
+                assert False
+            except tvm.TVMError:
+                pass
+
+        #positive case
+        for testcase in [(x,0), (x,16), (x,31)]:
+            assert test(*testcase).args[1] == testcase[1]
 
 
 def test_divide_by_zero():

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -208,6 +208,7 @@ def test_float_bitwise():
 
 
 def test_shift_bounds():
+    x = te.var('x')
     for test in [lambda lhs, rhs : lhs << rhs,
                     lambda lhs, rhs : lhs >> rhs]:
         #negative case
@@ -220,7 +221,7 @@ def test_shift_bounds():
 
         #positive case
         for testcase in [(x,0), (x,16), (x,31)]:
-            assert test(*testcase)
+            test(*testcase)
 
 
 def test_divide_by_zero():
@@ -309,6 +310,7 @@ if __name__ == "__main__":
     test_all()
     test_bitwise()
     test_float_bitwise()
+    test_shift_bounds()
     test_divide_by_zero()
     test_isnan()
     test_equality()


### PR DESCRIPTION
## Bug

For operations `<<` and `>>` when the RHS is an IntImm with values that are negative or greater than or equal to the number of bits in the integer being shifted results in LLVM emitting no code for the `tvm.compute`. 

## Example

```
a = te.var(name='a', dtype='int32')
shape = (1,)
c = te.compute(shape,lambda i: (4 * a) + (a >> 33))
s = te.create_schedule([c.op])
f = tvm.build(s,[a,c])
print("default_function_compute" in f.get_source()) #prints False
c_tvm= tvm.nd.array(np.zeros(shape,dtype='int32'))
f(5,c_tvm) 
print(c_tvm.asnumpy()[0]) #prints 0 instead of 20
```
## Fix

Limit the RHS immediate values of `<<` and `>>` to be within a valid range. For example the new behaviour would be: 
```
a = te.var(name='a', dtype='int64')
a << 64 #raises TVMError
a << -1 #raises TVMError
a >> 31 #no error
```

## Explanation 

LLVM constant folding silently replaces an out-of-bounds shift to an `undef` as seen [here](https://llvm.org/doxygen/ConstantFold_8cpp_source.html#l01232). Then any other parts of the expression are composed with the undef ( `(4 * a) + undef -> undef` in above example) and become undef as well. Therefore the `tvm.compute` is producing an `undef` which is optimized away by LLVM resulting in no compute code being generated at all.

A review would be much appreciated!

@tqchen 
