### PR TITLE
[RUNTIME]fix unused-value warning

### DIFF
--- a/src/runtime/crt/crt_runtime_api.c
+++ b/src/runtime/crt/crt_runtime_api.c
@@ -79,7 +79,7 @@ int TVMModGetFunction(TVMModuleHandle mod,
   if (!strcmp(func_name, "load_params")) {
     *out = &TVMGraphRuntime_LoadParams;
   } else {
-    status -1;
+    status = -1;
   }
   return status;
 }


### PR DESCRIPTION
miss "=", and clang report the value of status-1 unused, but in fact it should be status=-1.
