### PR TITLE
[Strategy][ARM CPU] Remove contrib spatial pack schedule of depthwise convolution

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -105,11 +105,13 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nchw),
                     wrap_topi_schedule(topi.arm_cpu.schedule_depthwise_conv2d_nchw),
                     name="depthwise_conv2d_nchw.arm_cpu")
-            strategy.add_implementation(
-                wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nchw_spatial_pack),
-                wrap_topi_schedule(topi.arm_cpu.schedule_depthwise_conv2d_nchw_spatial_pack),
-                name="depthwise_conv2d_nchw_spatial_pack.arm_cpu",
-                plevel=15)
+            # This schedule has incorrect result on some hardware platforms (like NV Jetson TX2)
+            # Let us comment it out but not remove.
+            # strategy.add_implementation(
+            #     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nchw_spatial_pack),
+            #     wrap_topi_schedule(topi.arm_cpu.schedule_depthwise_conv2d_nchw_spatial_pack),
+            #     name="depthwise_conv2d_nchw_spatial_pack.arm_cpu",
+            #     plevel=15)
         elif layout == "NHWC":
             assert kernel_layout == "HWOI"
             logger.warning("depthwise_conv2d with layout NHWC is not optimized for arm cpu.")

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -105,8 +105,11 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nchw),
                     wrap_topi_schedule(topi.arm_cpu.schedule_depthwise_conv2d_nchw),
                     name="depthwise_conv2d_nchw.arm_cpu")
+            # TODO:
             # This schedule has incorrect result on some hardware platforms (like NV Jetson TX2)
             # Let us comment it out but not remove.
+            # see discussion:
+            # https://discuss.tvm.ai/t/autotuner-incorrect-result-after-tuning-mobilenetv2-on-arm-cpu/6088
             # strategy.add_implementation(
             #     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nchw_spatial_pack),
             #     wrap_topi_schedule(topi.arm_cpu.schedule_depthwise_conv2d_nchw_spatial_pack),

--- a/topi/python/topi/arm_cpu/depthwise_conv2d.py
+++ b/topi/python/topi/arm_cpu/depthwise_conv2d.py
@@ -139,6 +139,11 @@ def schedule_depthwise_conv2d_nchw(cfg, outs):
     return s
 
 
+# TODO:
+# This schedule has incorrect result on some hardware platforms (like NV Jetson TX2)
+# Let us comment it out but not remove.
+# see discussion:
+# https://discuss.tvm.ai/t/autotuner-incorrect-result-after-tuning-mobilenetv2-on-arm-cpu/6088
 @autotvm.register_topi_compute("depthwise_conv2d_nchw_spatial_pack.arm_cpu")
 def depthwise_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding, dilation, out_dtype):
     """TOPI compute callback for depthwise_conv2d nchw


### PR DESCRIPTION
The spatial pack schedule of depthwise convolution is under the tag of `contrib` before introducing op strategy. However, as this discuss: https://discuss.tvm.ai/t/autotuner-incorrect-result-after-tuning-mobilenetv2-on-arm-cpu/6088, we maybe will meet incorrect result use this schedule. I ever met this problem on some hardware platform too. However, it is not 100% could produce and happened rarely. Correct result should be firstly, so let us make our previous depthwise schedule be the default, not the `contrib` spatial pack schedule.

@icemelon9 Could you help to review the code? 
