### PR TITLE
[FIX] Fixed merging behaviour in AnnotateRegionSet

### DIFF
--- a/src/relay/analysis/annotated_region_set.cc
+++ b/src/relay/analysis/annotated_region_set.cc
@@ -55,13 +55,17 @@ void AnnotatedRegionSetNode::MergeRegions(AnnotatedRegion src,
   }
   // if any of the outputs of src are inputs of dest, they become internal nodes
   // so remove them from outs
+  std::vector<Expr> ins_to_remove;
   for (const auto& input : dest->ins) {
     auto call = Downcast<Call>(input);
     auto it = std::find(src->outs.begin(), src->outs.end(), call->args[0]);
     if (it != src->outs.end()) {
       dest->outs.remove(*it);
-      dest->ins.remove(input);
+      ins_to_remove.push_back(input);
     }
+  }
+  for (const auto& input : ins_to_remove) {
+    dest->ins.remove(input);
   }
   regions_.erase(src);
 }


### PR DESCRIPTION
This is a small fix to the PR that introduces AnnotatedRegionSet.

Deleting items from a list while iterating it seems to result in undefined behaviour which sometimes segfaults. This makes sure all the item deletion happens separately.