### PR TITLE
[TIR] Add bound check for make_const

### DIFF
--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -831,7 +831,7 @@ def test_cast_simplify():
         ck.verify(tvm.tir.Cast(dtype1, x - x), tvm.tir.const(0, dtype1))
         ck.verify(tvm.tir.Cast(dtype1, x == x), tvm.tir.const(1, dtype1))
         for dtype2 in dtypes:
-            for i in [0, 1, 2, 3]:
+            for i in [0, 1]:
                 ck.verify(tvm.tir.Cast(dtype1, tvm.tir.const(i, dtype2)), tvm.tir.const(i, dtype1))
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_target_codegen_cuda.py
+++ b/tests/python/unittest/test_target_codegen_cuda.py
@@ -133,7 +133,7 @@ def test_cuda_make_int8x4():
         a = tvm.nd.empty(np_a.shape, dtype, ctx)
         fun(a)
         np.testing.assert_equal(a.asnumpy(), np_a)
-    check_cuda(64, 0xAB)
+    check_cuda(64, 127)
     check_cuda(64, 0)
     check_cuda(64, -3)
 

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -27,6 +27,51 @@ def test_const():
     assert isinstance(x, tvm.tir.IntImm)
 
 
+def test_const_bounds_int():
+    for signed_bits in [8,16,32]:
+        dtype = 'int' + str(signed_bits)
+        int_max = (1 << (signed_bits - 1))- 1
+        int_min = - (1 << (signed_bits - 1))
+        try:
+            tvm.tir.const(int_min - 1,dtype)
+            assert False
+        except tvm.TVMError:
+            pass
+
+        try:
+            tvm.tir.const(int_max + 1,dtype)
+            assert False
+        except tvm.TVMError:
+            pass
+
+        assert tvm.tir.const(int_min,dtype).value == int_min
+        assert tvm.tir.const(int_max, dtype).value == int_max
+        assert tvm.tir.const(1, dtype).value == 1
+        assert tvm.tir.const(0, dtype).value == 0
+
+
+def test_const_bounds_uint():
+    for unsigned_bits in [1,8,16,32]:
+        dtype = 'uint' + str(unsigned_bits)
+        uint_max = (1 << unsigned_bits) - 1
+        try:
+            tvm.tir.const(dtype, uint_max + 1)
+            assert False
+        except tvm.TVMError:
+            pass
+
+        assert tvm.tir.const(uint_max,dtype).value == uint_max
+        assert tvm.tir.const(1, dtype).value == 1
+        assert tvm.tir.const(0, dtype).value == 0
+
+    large_uint_imm = tvm.tir.const((1 << 64) - 1, 'uint64')
+    assert large_uint_imm.name == "tvm_large_uint_imm"
+    low = large_uint_imm.args[0].value
+    high = large_uint_imm.args[1].value
+    assert low  | (high << 32) == (1 << 64) - 1
+
+
+
 def test_scalar_dtype_inference():
     for data in [True, np.bool(1), np.uint8(1), np.uint16(1), np.uint32(1), np.uint64(1),
                  np.int8(1), np.int16(1), np.int32(1), np.int64(1),
@@ -327,6 +372,8 @@ if __name__ == "__main__":
     test_cast()
     test_attr()
     test_const()
+    test_const_bounds_int()
+    test_const_bounds_uint()
     test_scalar_dtype_inference()
     test_make()
     test_ir()

--- a/tests/python/unittest/test_tir_transform_narrow_datatype.py
+++ b/tests/python/unittest/test_tir_transform_narrow_datatype.py
@@ -130,7 +130,7 @@ def test_multilanes():
     # i32 -> i32
     check(const(2 ** 10, dtype='int32'), 2,
           target_bits=32, target_dtype='int32')
-    check(const(2 ** 32, dtype='int32'), 2,
+    check(const(2 ** 31 - 1, dtype='int32'), 2,
           target_bits=32, target_dtype='int32')
     # i64 -> i32
     check(const(2 ** 10, dtype='int64'), 2,


### PR DESCRIPTION
## Bug 

Casting values which are known at compile time results in strange behaviour. For example `1 * tir.Cast("bool", 77)` becomes `77` after the rewrite_simplify pass instead of `1`. 

However if that value was passed in at runtime then the expect result of `1` would be printed.

## Example
```
print(tvm.arith.Analyzer().rewrite_simplify(1 * tir.Cast('bool', 77))) #prints 77

a =te.var('a')
shape = (1,)
c = te.compute(shape,lambda i: 1 * tir.Cast('bool',a))
s = te.create_schedule([c.op])
f = tvm.build(s,[a,c])
c_tvm = tvm.nd.array(np.zeros(shape,dtype='int32'))
f(77,c_tvm) 

assert c_tvm.asnumpy()[0] == 1
```

## Explanation

When a `Cast(dtype, value)` call is used on a compile time value then it is replaced with an `IntImm` with the `dtype` and `value` from the call. However, the `value` is stored as a C++ `int64_t` and thus does not limit the `value` to a sensible range . If the resulting `IntImm` is later used in an expression that results in a type promotion unexpected behaviour such as the example above occurs where the `Cast` effectively does nothing. 

## Fix 

My fix is to ensure that as the `IntImm` is created it takes the type bounds into account. After the fix the above example would behave as expected.
```
print(tvm.arith.Analyzer().rewrite_simplify(1 * tir.Cast('bool', 77))) #prints 1
```

A review would be much appreciated!

@tqchen @vinx13  @ZihengJiang 
