### PR TITLE
[TVM] ref_counter -> ref_counter_

### DIFF
--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -795,7 +795,7 @@ inline void Object::IncRef() {
 }
 
 inline void Object::DecRef() {
-  if (--ref_counter == 0) {
+  if (--ref_counter_ == 0) {
     if (this->deleter_ != nullptr) {
       (*this->deleter_)(this);
     }


### PR DESCRIPTION
Fix missing `_` in `ref_counter`. This code path only gets exercised with `-DTVM_OBJECT_ATOMIC_REF_COUNTER=0`.