### PR TITLE
[FRONTEND][MXNET] Use leaky by default for LeakyReLU

### DIFF
--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -510,7 +510,7 @@ def _mx_pad(inputs, attrs):
                       pad_mode=pad_mode)
 
 def _mx_leaky_relu(inputs, attrs):
-    act_type = attrs.get_str("act_type")
+    act_type = attrs.get_str("act_type", "leaky")
     if act_type == "leaky":
         return _op.nn.leaky_relu(inputs[0], alpha=attrs.get_float("slope", 0.25))
     if act_type == "prelu":

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -107,6 +107,14 @@ def test_forward_resnet():
         mx_sym = model_zoo.mx_resnet(18)
         verify_mxnet_frontend_impl(mx_sym)
 
+def test_forward_leaky_relu():
+    data = mx.sym.var('data')
+    data = mx.sym.concat(data, -data, dim=1)  # negative part explicitly
+    mx_sym = mx.sym.LeakyReLU(data)
+    verify_mxnet_frontend_impl(mx_sym, (1, 3, 100, 100), (1, 6, 100, 100))
+    mx_sym = mx.sym.LeakyReLU(data, act_type='leaky')
+    verify_mxnet_frontend_impl(mx_sym, (1, 3, 100, 100), (1, 6, 100, 100))
+
 def test_forward_elu():
     data = mx.sym.var('data')
     data = mx.sym.concat(data, -data, dim=1)  # negative part explicitly
@@ -979,6 +987,7 @@ if __name__ == '__main__':
     test_forward_mlp()
     test_forward_vgg()
     test_forward_resnet()
+    test_forward_leaky_relu()
     test_forward_elu()
     test_forward_rrelu()
     test_forward_prelu()


### PR DESCRIPTION
c.f. https://mxnet.apache.org/api/python/docs/api/symbol/symbol.html#mxnet.symbol.LeakyReLU

@maheshambule @alexgl-github @kevinthesun Could you review?