### PR TITLE
[Topi x86] Missing vectorize for depthwise conv2d.

### DIFF
--- a/topi/python/topi/x86/depthwise_conv2d.py
+++ b/topi/python/topi/x86/depthwise_conv2d.py
@@ -220,6 +220,7 @@ def _schedule_depthwise_conv2d_NCHWc_impl(s, cfg, data_vec, kernel_vec, conv_out
     _, ic_chunk, oh, ow, ic_block = s[C].op.axis
     ow_chunk, ow_block = s[C].split(ow, factor=tile_ow)
     s[C].reorder(ic_chunk, oh, ow_chunk, ow_block, ic_block)
+    s[C].vectorize(ic_block)
     parallel_axis = s[C].fuse(ic_chunk, oh)
     s[C].parallel(parallel_axis)
     s[CC].compute_at(s[C], ow_chunk)


### PR DESCRIPTION
@yzhliu @kevinthesun 

Missing vectorize. I checked the TVM IR, this can vectorize the stores of partial outputs registers to memory. I did not any see perf benefit, because it might be negligible. But, we should do this explicitly. We already do this for conv2d_avx_common.
