### PR TITLE
[Frontend][Torch] Fix up graph input handling

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1012,8 +1012,8 @@ def _get_op_inputs(op_node, input_vars):
 
 
 def _update_inputs_from_pairs(name_input_pairs, input_vars):
-    for input_name, input in name_input_pairs:
-        input_vars[input_name] = input
+    for input_name, inp in name_input_pairs:
+        input_vars[input_name] = inp
 
 
 def _report_missing_conversion(op_names):
@@ -1040,7 +1040,7 @@ def _check_inputs(graph, input_shapes):
     """
     ir_inputs = _get_graph_input_names(graph)
 
-    if type(input_shapes) is not list:
+    if not isinstance(input_shapes, list):
         msg = "Graph inputs input_shapes should be list"
         raise RuntimeError(msg)
     missing_inputs = len(ir_inputs) - len(input_shapes)
@@ -1048,16 +1048,16 @@ def _check_inputs(graph, input_shapes):
         msg = "Missing {} graph input(s) in input_shapes".format(missing_inputs)
         raise RuntimeError(msg)
 
-    for num, input in enumerate(input_shapes):
+    for num, inp in enumerate(input_shapes):
         if num < len(ir_inputs):
-            if type(input) is not tuple:
+            if not isinstance(inp, tuple):
                 msg = "Graph input {} is not a tuple".format(num)
                 raise RuntimeError(msg)
-            if (len(input) != 2 or type(input[0]) is not str):
-                msg = "Graph input {} is not valid, expected ('name', shape)".format(input)
+            if (len(inp) != 2 or not isinstance(inp[0], str)):
+                msg = "Graph input {} is not valid, expected ('name', shape)".format(inp)
                 raise RuntimeError(msg)
         else:
-            msg = "Unused graph input {} in input_shapes".format(input)
+            msg = "Unused graph input {} in input_shapes".format(inp)
             logging.warning(msg)
 
 
@@ -1158,9 +1158,9 @@ def _get_relay_input_vars(graph, input_shapes):
     ir_inputs = _get_graph_input_names(graph)
     for idx, ir_input in enumerate(ir_inputs):
         name, shape = input_shapes[idx]
-        input = _expr.var(name, shape=shape)
+        inp = _expr.var(name, shape=shape)
         # Translate from graph input to user input name
-        input_vars[ir_input] = input
+        input_vars[ir_input] = inp
 
     return input_vars
 
@@ -1358,7 +1358,7 @@ def convert_operators(operators, input_vars, ret_names):
             assert len(inputs) == 1
             unpacked_names = _get_output_names(op_node)
             _update_inputs_from_pairs(zip(unpacked_names, inputs[0]),
-                                       input_vars)
+                                      input_vars)
         elif operator == "prim::If":
             if_out = convert_if(op_node, input_vars)
             input_vars[node_name] = if_out
@@ -1367,7 +1367,7 @@ def convert_operators(operators, input_vars, ret_names):
             unpacked_names = _get_output_names(op_node)
             assert len(loop_out) == len(unpacked_names)
             _update_inputs_from_pairs(zip(unpacked_names, loop_out),
-                                       input_vars)
+                                      input_vars)
         else:
             relay_op = _convert_map[operator]
             relay_out = relay_op(inputs, _get_input_types(op_node))
@@ -1377,7 +1377,7 @@ def convert_operators(operators, input_vars, ret_names):
                 # See _adaptive_max_2d above for example
                 out_names = _get_output_names(op_node)
                 _update_inputs_from_pairs(zip(out_names, relay_out),
-                                           input_vars)
+                                          input_vars)
             else:
                 input_vars[node_name] = relay_out
 
@@ -1453,8 +1453,8 @@ def from_pytorch(script_module, input_shapes, custom_convert_map=None):
         weight_quant_params = qnn_torch.get_weight_quant_params(script_module)
         qnn_torch.add_input_quant_params_to_op_inputs(graph)
         qnn_torch.add_quant_params_to_inputs(input_vars,
-                                              packed_param_map,
-                                              weight_quant_params)
+                                             packed_param_map,
+                                             weight_quant_params)
         qnn_torch.add_quant_params(tvm_params, weight_quant_params)
         _convert_map.update(qnn_torch.convert_map)
 

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -102,7 +102,7 @@ def get_weight_quant_params(script_module):
 
 
 def add_quant_params_to_inputs(input_vars, packed_param_map,
-                                quant_params):
+                               quant_params):
     """
     Add quant params to inputs so that they can be referenced by other
     ops later. Weights are quantized here.

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -101,20 +101,19 @@ def get_weight_quant_params(script_module):
     return quant_params
 
 
-def add_quant_params_to_outputs(outputs, output_index_map,
-                                packed_param_map, quant_params):
+def add_quant_params_to_inputs(input_vars, packed_param_map,
+                                quant_params):
     """
-    Add quant params to outputs so that they can be referenced by other
+    Add quant params to inputs so that they can be referenced by other
     ops later. Weights are quantized here.
     """
     for node_name, packed_param_name in packed_param_map.items():
         qparam = quant_params[packed_param_name]
-        output_index_map[node_name] = len(outputs)
         qweight = relay.qnn.op.quantize(qparam.weight_var, qparam.scale,
                                         qparam.zero_point, out_dtype="int8",
                                         axis=0)
         param_tup = (qweight, qparam.scale, qparam.zero_point, qparam.bias_var)
-        outputs.append(param_tup)
+        input_vars[node_name] = param_tup
 
 
 def _get_quant_param_for_input(input_value):

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -101,10 +101,10 @@ def get_weight_quant_params(script_module):
     return quant_params
 
 
-def add_quant_params_to_inputs(input_vars, packed_param_map,
-                               quant_params):
+def add_quant_params_to_outputs(outputs, packed_param_map,
+                                quant_params):
     """
-    Add quant params to inputs so that they can be referenced by other
+    Add quant params to outputs so that they can be referenced by other
     ops later. Weights are quantized here.
     """
     for node_name, packed_param_name in packed_param_map.items():
@@ -113,7 +113,7 @@ def add_quant_params_to_inputs(input_vars, packed_param_map,
                                         qparam.zero_point, out_dtype="int8",
                                         axis=0)
         param_tup = (qweight, qparam.scale, qparam.zero_point, qparam.bias_var)
-        input_vars[node_name] = param_tup
+        outputs[node_name] = param_tup
 
 
 def _get_quant_param_for_input(input_value):

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -28,7 +28,6 @@ from torch.quantization import fuse_modules, QuantWrapper
 
 import tvm
 from tvm import relay
-from tvm.relay.frontend.pytorch import get_graph_input_names
 from tvm.contrib.download import download_testdata
 
 
@@ -39,7 +38,7 @@ def torch_version_check():
 
 def get_tvm_runtime(script_module, input_name, ishape):
 
-    input_shapes = {input_name: ishape}
+    input_shapes = [(input_name, ishape)]
     mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
 
     with relay.build_config(opt_level=3):
@@ -287,7 +286,7 @@ def test_quantized_modules():
         with torch.no_grad():
             pt_result = script_module(inp.clone()).numpy()
 
-        input_name = get_graph_input_names(script_module)[0]
+        input_name = "input"
         runtime = get_tvm_runtime(script_module, input_name, ishape)
         runtime.set_input(input_name, inp.numpy().copy())
         runtime.run()
@@ -383,7 +382,7 @@ def test_quantized_imagenet():
         with torch.no_grad():
             pt_result = script_module(pt_inp).numpy()
 
-        input_name = get_graph_input_names(script_module)[0]
+        input_name = "image"
         runtime = get_tvm_runtime(script_module, input_name, (1, 3, 224, 224))
         runtime.set_input(input_name, inp)
         runtime.run()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -28,7 +28,6 @@ import torchvision
 from tvm import relay
 from tvm.contrib import graph_runtime
 from tvm.relay.testing.config import ctx_list
-from tvm.relay.frontend.pytorch import get_graph_input_names
 
 
 sys.setrecursionlimit(10000)
@@ -169,8 +168,8 @@ def verify_model(model_name, input_data=[],
     else:
         trace = trace.cpu()
 
-    input_names = get_graph_input_names(trace)
-    input_shapes = dict(zip(input_names,
+    input_names = ["input{}".format(idx) for idx, inp in enumerate(baseline_input)]
+    input_shapes = list(zip(input_names,
                             [inp.shape for inp in baseline_input]))
     mod, params = relay.frontend.from_pytorch(trace, input_shapes,
                                               custom_convert_map)
@@ -890,11 +889,12 @@ def test_3d_models():
 
 def verify_script_model(pt_model, ishapes):
     script_module = torch.jit.script(pt_model)
-    input_names = get_graph_input_names(script_module)
-    input_shapes = dict(zip(input_names, ishapes))
 
-    inputs = [torch.randn(input_shapes[input_name], dtype=torch.float)
-              for input_name in input_names]
+    input_names = ["i{}".format(idx) for idx, ish in enumerate(ishapes)]
+    input_shapes = list(zip(input_names, ishapes))
+
+    inputs = [torch.randn(shape, dtype=torch.float)
+              for name, shape in input_shapes]
 
     mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -894,7 +894,7 @@ def verify_script_model(pt_model, ishapes):
     input_shapes = list(zip(input_names, ishapes))
 
     inputs = [torch.randn(shape, dtype=torch.float)
-              for name, shape in input_shapes]
+              for shape in ishapes]
 
     mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
 

--- a/topi/tests/python/test_topi_vision.py
+++ b/topi/tests/python/test_topi_vision.py
@@ -103,11 +103,14 @@ def verify_get_valid_counts(dshape, score_threshold, id_index, score_index):
         tvm.testing.assert_allclose(tvm_out1.asnumpy(), np_out1, rtol=1e-3)
         tvm.testing.assert_allclose(tvm_out2.asnumpy(), np_out2, rtol=1e-3)
 
+    """ Skip this test as it is intermittent
+        see https://github.com/apache/incubator-tvm/pull/4901#issuecomment-595040094
     for device in ['llvm', 'cuda', 'opencl']:
         # Disable opencl test for now
         if device != "llvm" and device != "cuda":
             continue
         check_device(device)
+    """
 
 
 def test_get_valid_counts():

--- a/tutorials/frontend/from_pytorch.py
+++ b/tutorials/frontend/from_pytorch.py
@@ -47,7 +47,6 @@ from tvm import relay
 import numpy as np
 
 from tvm.contrib.download import download_testdata
-from tvm.relay.frontend.pytorch import get_graph_input_names
 
 # PyTorch imports
 import torch
@@ -90,10 +89,10 @@ img = np.expand_dims(img, 0)
 # Import the graph to Relay
 # -------------------------
 # Convert PyTorch graph to Relay graph.
-input_name = get_graph_input_names(scripted_model)[0]  # only one input
-shape_dict = {input_name: img.shape}
+input_name = 'input0'  # only one input, set it to this name
+shape_list = [(input_name, img.shape)]
 mod, params = relay.frontend.from_pytorch(scripted_model,
-                                          shape_dict)
+                                          shape_list)
 
 ######################################################################
 # Relay Build


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

From: https://discuss.tvm.ai/t/pytorch-frontend-graph-input-names-can-change-using-loaded-torchscript/6055

Split as two commits to make it easier to review:

* Simplify operator input handling 
   * remove outputs and output_index_map and extend use of input_vars
* Allow user supplied input names to override graph inputs
   * PyTorch inputs now expected as list rather than dictionary - [(name, shape), (name, shape)...]
   * Input names given with from_pytorch() are now set as the graph input names and should be used in set_input()

Review request: @masahi 