### PR TITLE
[Relay][AnnotateTarget] Propagate types during Annotation + Support Tuple

### DIFF
--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -62,6 +62,16 @@ class AnnotateTargetWrapper : public ExprMutator {
         return true;
       }
     }
+    if (expr->IsInstance<TupleNode>()) {
+      Tuple tuple = Downcast<Tuple>(expr);
+      for (auto field : tuple->fields) {
+        if (!field->IsInstance<CallNode>() ||
+            field.as<CallNode>()->op != compiler_begin_op) {
+          return false;
+        }
+      }
+      return true;
+    }
     return false;
   }
 
@@ -118,8 +128,18 @@ class AnnotateTargetWrapper : public ExprMutator {
 
     auto tup = Downcast<Tuple>(new_e);
     Array<Expr> new_fields;
+    bool all_fields_supported = true;
     for (auto field : tup->fields) {
-      new_fields.push_back(InsertEnd(field));
+      if (!IsSupported(field)) {
+        all_fields_supported = false;
+      }
+    }
+    for (auto field : tup->fields) {
+      if (all_fields_supported) {
+        new_fields.push_back(InsertBegin(InsertEnd(field)));
+      } else {
+        new_fields.push_back(InsertEnd(field));
+      }
     }
     return Tuple(new_fields);
   }

--- a/tests/python/relay/test_annotate_target.py
+++ b/tests/python/relay/test_annotate_target.py
@@ -247,6 +247,51 @@ def test_type_propagation():
         return mod
 
     result = transform.AnnotateTarget(target)(before())
+
+
+def test_tuple():
+    target = "test_tuple"
+
+    @reg.register("nn.relu", "target." + target)
+    def relu(attrs, args):
+        return True
+    
+    @reg.register("concatenate", "target." + target)
+    def concatenate(attrs, args):
+        return True
+
+    """Test that TupleNode is included in annotation when surrounded by supported nodes."""
+    def before():
+        x = relay.var("x", shape=(10, 5))
+        y = relay.var("y", shape=(10, 5))
+        a_1 = relay.nn.relu(x)
+        a_2 = relay.nn.relu(y)
+        out = relay.concatenate((a_1, a_2), axis=1)
+        f = relay.Function([x, y], out)
+        mod = tvm.IRModule.from_expr(f)
+        return mod
+
+    def after():
+        x = relay.var("x", shape=(10, 5))
+        y = relay.var("y", shape=(10, 5))
+        cb_1 = relay.annotation.compiler_begin(x, target)
+        cb_2 = relay.annotation.compiler_begin(y, target)
+        a_1 = relay.nn.relu(cb_1)
+        a_2 = relay.nn.relu(cb_2)
+        ce_1 = relay.annotation.compiler_end(a_1, target)
+        ce_2 = relay.annotation.compiler_end(a_2, target)
+        cb_3 = relay.annotation.compiler_begin(ce_1, target)
+        cb_4 = relay.annotation.compiler_begin(ce_2, target)
+        tup = relay.Tuple([cb_3, cb_4])
+        ce_3 = relay.annotation.compiler_end(tup, target)
+        cb_3 = relay.annotation.compiler_begin(ce_3, target)
+        out = relay.op._make.concatenate(cb_3, 1)
+        ce_4 = relay.annotation.compiler_end(out, target)
+        f = relay.Function([x, y], ce_4)
+        mod = tvm.IRModule.from_expr(f)
+        return mod
+
+    result = transform.AnnotateTarget(target)(before())
     expected = transform.InferType()(after())
     assert tvm.ir.structural_equal(expected, result)
 
@@ -254,5 +299,6 @@ def test_type_propagation():
 if __name__ == "__main__":
     test_multiple_ends()
     test_type_propagation()
+    test_tuple()
     test_extern_dnnl()
     test_extern_dnnl_mobilenet()


### PR DESCRIPTION
This PR includes two fixes to AnnotateTarget pass and testcases for each.

1. Include TupleNode in annotation when args are also supported. This prevents Tuple from breaking a model into multiple subgraphs when all ops are supported by the external codegen. This is needed to support annotation of concatenate op. Added `test_tuple` test for this fix.

2. AnnotateTarget is mutating the graph by adding `compiler.begin` and `compiler.end` nodes. The nodes from this **modified graph** are then passed to the registered FTVMAnnotateTarget python functions. Therefore since the modified nodes did not have type information  yet, the python annotation functions could not access the checked_type of the args. I fixed this by manually copying checked_type when new nodes are created in the AnnotateTarget pass. However, we should consider refactoring this pass so that only the unmodified original nodes are passed to FTVMAnnotateTarget functions. Added `test_type_propagation` for this. Without this fix, the testcase would give the error: `ValueError: The type checker has not populated the checked_type for this node`.