### PR TITLE
fix to skip node not in graph.

### DIFF
--- a/nnvm/src/core/graph.cc
+++ b/nnvm/src/core/graph.cc
@@ -98,7 +98,7 @@ IndexedGraph::IndexedGraph(const Graph &g) {
       // input entries
       for (const auto& e : n->inputs) {
         auto it = node2index_.find(e.node.get());
-        CHECK(it != node2index_.end() && it->first == e.node.get());
+        if (it == node2index_.end() || it->first != e.node.get()) continue;
         input_entries_.emplace_back(NodeEntry{it->second, e.index, e.version});
       }
       inputs_rptr.push_back(input_entries_.size());


### PR DESCRIPTION
fix to skip node not in graph because some network cannot be hybridized with some var unused.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
