### PR TITLE
[RELAY][BYOC] Add support for composite functions in BYOC

### DIFF
--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -378,9 +378,12 @@ def MergeComposite(pattern_table):
     Parameters
     ----------
     pattern_table : list(tuple)
-        A list of (pattern_name, pattern) tuples.
+        A list of (pattern_name, pattern, check) tuples.
         The order of the patterns in the list will determine the order
         of priority in which they are matched.
+        'check' is a function to check whether an extracted pattern matches.
+        It can be implemented by pattern writer but if not specified it will
+        always return True.
 
     Returns
     -------
@@ -390,11 +393,19 @@ def MergeComposite(pattern_table):
     """
     pattern_names = []
     patterns = []
-    for pattern_name, pattern in pattern_table:
+    checks = []
+    for tup in pattern_table:
+        if len(tup) == 2:
+            pattern_name, pattern = tup
+            check = lambda extract: True
+        elif len(tup) == 3:
+            pattern_name, pattern, check = tup
+
         pattern_names.append(pattern_name)
         patterns.append(pattern)
+        checks.append(check)
 
-    return _ffi_api.MergeComposite(pattern_names, patterns)
+    return _ffi_api.MergeComposite(pattern_names, patterns, *checks)
 
 
 def MergeCompilerRegions():

--- a/src/relay/transforms/merge_composite.cc
+++ b/src/relay/transforms/merge_composite.cc
@@ -25,11 +25,11 @@
  * Relay operators map to a single external operator.
  */
 
-#include <tvm/te/operation.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/op_attr_types.h>
 #include <tvm/relay/transform.h>
+#include <tvm/te/operation.h>
 
 namespace tvm {
 namespace relay {
@@ -37,11 +37,12 @@ namespace merge_composite {
 
 class MergeCompositeWrapper : public ExprMutator {
  public:
-  explicit MergeCompositeWrapper(const std::string& pattern_name, const Expr& pattern, const PackedFunc& check)
-    : pattern_name_(pattern_name), pattern_(pattern), check_(check) {}
+  explicit MergeCompositeWrapper(const std::string& pattern_name, const Expr& pattern,
+                                 const PackedFunc& check)
+      : pattern_name_(pattern_name), pattern_(pattern), check_(check) {}
 
   Expr ExtractPattern(const Var& pattern, const Expr& root,
-          Map<std::string, Array<Expr>>* var_map) {
+                      Map<std::string, Array<Expr>>* var_map) {
     if (var_map->find(pattern->name_hint()) == var_map->end()) {
       // if we haven't encountered this var yet, make a new free var and associate
       // it with the value at 'root'
@@ -62,12 +63,12 @@ class MergeCompositeWrapper : public ExprMutator {
   }
 
   Expr ExtractPattern(const Constant& pattern, const Expr& root,
-          Map<std::string, Array<Expr>>* var_map) {
+                      Map<std::string, Array<Expr>>* var_map) {
     return root;
   }
 
   Expr ExtractPattern(const TupleGetItem& pattern, const Expr& root,
-      Map<std::string, Array<Expr>>* var_map, Map<Expr, Expr>* call_map) {
+                      Map<std::string, Array<Expr>>* var_map, Map<Expr, Expr>* call_map) {
     if (!root->IsInstance<TupleGetItemNode>()) {
       return Expr();
     }
@@ -75,14 +76,12 @@ class MergeCompositeWrapper : public ExprMutator {
     if (pattern->index != root_node->index) {
       return Expr();
     }
-    if (pattern->tuple->IsInstance<CallNode>() &&
-        root_node->tuple->IsInstance<CallNode>()) {
+    if (pattern->tuple->IsInstance<CallNode>() && root_node->tuple->IsInstance<CallNode>()) {
       Expr new_arg;
       if (call_map->find(pattern->tuple) != call_map->end()) {
         new_arg = (*call_map)[pattern->tuple];
       } else {
-        new_arg = ExtractPattern(Downcast<Call>(pattern->tuple),
-                                 Downcast<Call>(root_node->tuple),
+        new_arg = ExtractPattern(Downcast<Call>(pattern->tuple), Downcast<Call>(root_node->tuple),
                                  var_map, call_map);
         call_map->Set(pattern->tuple, new_arg);
       }
@@ -104,20 +103,18 @@ class MergeCompositeWrapper : public ExprMutator {
    * and free variables. The free variables indicate where the pattern can 'attach' in your
    * graph. This function takes the final call node of the pattern and the call node currently
    * being traversed in the Relay graph. It traverses through the pattern in lockstep with call node
-   * from the graph (referred to as the 'root' node here) to check they're identical. If at any point
-   * they differ, an empty expression is returned to signify the extract failed. If a free var is
-   * reached in the pattern, the corresponding value in the root is associated with the name of the
-   * free var (via the var_map) so that when we construct the composite function, the inputs match
-   * up correctly with the rest of the graph. The return value of this function when successful is
-   * a new Relay expression ready to be wrapped into a composite function.
+   * from the graph (referred to as the 'root' node here) to check they're identical. If at any
+   * point they differ, an empty expression is returned to signify the extract failed. If a free var
+   * is reached in the pattern, the corresponding value in the root is associated with the name of
+   * the free var (via the var_map) so that when we construct the composite function, the inputs
+   * match up correctly with the rest of the graph. The return value of this function when
+   * successful is a new Relay expression ready to be wrapped into a composite function.
    */
-  Expr ExtractPattern(const Call& pattern, const Call& root,
-          Map<std::string, Array<Expr>>* var_map, Map<Expr, Expr>* call_map) {
+  Expr ExtractPattern(const Call& pattern, const Call& root, Map<std::string, Array<Expr>>* var_map,
+                      Map<Expr, Expr>* call_map) {
     // check to make sure both calls are to operators (not functions)
-    if (!pattern->op->IsInstance<OpNode>() || !root->op->IsInstance<OpNode>())
-      return Expr();
-    if (pattern->op.as<OpNode>()->name != root->op.as<OpNode>()->name)
-      return Expr();
+    if (!pattern->op->IsInstance<OpNode>() || !root->op->IsInstance<OpNode>()) return Expr();
+    if (pattern->op.as<OpNode>()->name != root->op.as<OpNode>()->name) return Expr();
 
     unsigned int i = 0;
     Array<Expr> new_args;
@@ -133,27 +130,20 @@ class MergeCompositeWrapper : public ExprMutator {
             return Expr();
           }
           // if it's a call node, recursively call this function
-          new_arg = ExtractPattern(Downcast<Call>(arg),
-                                  Downcast<Call>(root->args[i]),
-                                  var_map, call_map);
+          new_arg =
+              ExtractPattern(Downcast<Call>(arg), Downcast<Call>(root->args[i]), var_map, call_map);
           call_map->Set(arg, new_arg);
         }
       } else if (arg->IsInstance<VarNode>()) {
         // if there's a var in the pattern, it must be a free var
         // so call the function to update the var_map
-        new_arg = ExtractPattern(Downcast<Var>(arg),
-                                 root->args[i],
-                                 var_map);
+        new_arg = ExtractPattern(Downcast<Var>(arg), root->args[i], var_map);
       } else if (arg->IsInstance<ConstantNode>()) {
         // if there's a constant, simply get the corresponding
         // value of the constant from the root
-        new_arg = ExtractPattern(Downcast<Constant>(arg),
-                                 root->args[i],
-                                 var_map);
+        new_arg = ExtractPattern(Downcast<Constant>(arg), root->args[i], var_map);
       } else if (arg->IsInstance<TupleGetItemNode>()) {
-        new_arg = ExtractPattern(Downcast<TupleGetItem>(arg),
-                                 root->args[i],
-                                 var_map, call_map);
+        new_arg = ExtractPattern(Downcast<TupleGetItem>(arg), root->args[i], var_map, call_map);
       }
       if (!new_arg.defined()) {
         return Expr();
@@ -169,8 +159,7 @@ class MergeCompositeWrapper : public ExprMutator {
     if (call->op->IsInstance<FunctionNode>()) {
       Function func = Downcast<Function>(call->op);
       CHECK(func.defined());
-      const auto name_node =
-          func->GetAttr<tir::StringImm>(attr::kComposite);
+      const auto name_node = func->GetAttr<tir::StringImm>(attr::kComposite);
       // don't step into existing composite functions
       if (name_node.defined() && name_node->value != "") {
         tvm::Array<tvm::relay::Expr> new_args;
@@ -184,8 +173,7 @@ class MergeCompositeWrapper : public ExprMutator {
 
     Expr expr = ExprMutator::VisitExpr_(cn);
     call = Downcast<Call>(expr);
-    if (!call->op->IsInstance<OpNode>())
-      return std::move(call);
+    if (!call->op->IsInstance<OpNode>()) return std::move(call);
 
     // only call patterns are supported
     Call pattern = Downcast<Call>(pattern_);
@@ -219,8 +207,8 @@ class MergeCompositeWrapper : public ExprMutator {
   PackedFunc check_;
 };
 
-Expr MergeComposite(const Expr& expr,
-    const Array<tir::StringImm>& pattern_names, const Array<Expr>& patterns, const std::vector<PackedFunc>& checks) {
+Expr MergeComposite(const Expr& expr, const Array<tir::StringImm>& pattern_names,
+                    const Array<Expr>& patterns, const std::vector<PackedFunc>& checks) {
   CHECK_EQ(pattern_names.size(), patterns.size());
   Expr merged_expr = expr;
   // merge the patterns one-by-one in order
@@ -238,8 +226,7 @@ Expr MergeComposite(const Expr& expr,
 namespace transform {
 
 Pass MergeComposite(const tvm::Array<tir::StringImm>& pattern_names,
-    const tvm::Array<Expr>& patterns,
-    const std::vector<PackedFunc>& checks) {
+                    const tvm::Array<Expr>& patterns, const std::vector<PackedFunc>& checks) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
         return Downcast<Function>(
@@ -249,12 +236,11 @@ Pass MergeComposite(const tvm::Array<tir::StringImm>& pattern_names,
   return func_pass;
 }
 
-TVM_REGISTER_GLOBAL("relay._transform.MergeComposite")
-.set_body([](TVMArgs args, TVMRetValue* rv) {
+TVM_REGISTER_GLOBAL("relay._transform.MergeComposite").set_body([](TVMArgs args, TVMRetValue* rv) {
   tvm::Array<tir::StringImm> pattern_names = args[0];
   tvm::Array<Expr> patterns = args[1];
   std::vector<PackedFunc> checks;
-  for (int i=2;i<args.size();i++) {
+  for (int i = 2; i < args.size(); i++) {
     checks.push_back(args[i]);
   }
   *rv = MergeComposite(pattern_names, patterns, checks);

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -732,6 +732,43 @@ def test_tuple_get_item_merge():
     assert tvm.ir.structural_equal(result, expected, map_free_vars=True)
 
 
+def test_pattern_with_check():
+    def before():
+        x = relay.var('x', shape=(1, 10, 10, 10))
+        w = relay.var('w', shape=(10, 10, 3, 3))
+        b = relay.var('b', shape=(8,))
+        conv = relay.nn.conv2d(x,
+                               w,
+                               kernel_size=(3, 3),
+                               kernel_layout="OIHW",
+                               data_layout="NHWC")
+        bias = relay.nn.bias_add(conv, b)
+        relu = relay.nn.relu(bias)
+        return relay.Function([x, w, b], relu)
+
+    def _check_true(extract):
+        conv = extract.args[0].args[0]
+        return conv.attrs.data_layout == "NHWC"
+
+    def _check_false(extract):
+        conv = extract.args[0].args[0]
+        return conv.attrs.data_layout == "NCHW"
+
+    pattern_table_true = [
+        ("conv_bias_relu", make_conv_bias_relu_pattern(), _check_true)
+    ]
+    pattern_table_false = [
+        ("conv_bias_relu", make_conv_bias_relu_pattern(), _check_false)
+    ]
+
+    result = run_opt_pass(before(), relay.transform.MergeComposite(pattern_table_false))
+    expected = run_opt_pass(before(), relay.transform.InferType())
+    assert tvm.ir.structural_equal(result, expected, map_free_vars=True)
+
+    result = run_opt_pass(before(), relay.transform.MergeComposite(pattern_table_true))
+    assert result.body.op.attrs["Composite"] == "conv_bias_relu"
+
+
 if __name__ == "__main__":
     test_simple_merge()
     test_branch_merge()
@@ -741,3 +778,4 @@ if __name__ == "__main__":
     test_multiple_input_subgraphs()
     test_reuse_call_merge()
     test_tuple_get_item_merge()
+    test_pattern_with_check()


### PR DESCRIPTION
This PR includes two changes to support composite functions as part of the BYOC flow. First, 'check' functions have been added to the MergeComposite pass. Currently you can only do structural pattern matches which don't test any attributes or tensor sizes. The check function accepts the matching expression and can implement arbitrary logic to test whether that match should be supported. See the new test for an example which queries convolution layout.

The other change enables the annotation of composite functions in the AnnotateTarget pass. For a composite function to be recognised, you must name it according to the convention:

{compiler}.{composite_name}
eg. dnnl.add_relu