### PR TITLE
[LLVM] Do not use x86_vcvtph2ps_256 intrinsic with LLVM 11+

### DIFF
--- a/src/target/llvm/codegen_x86_64.cc
+++ b/src/target/llvm/codegen_x86_64.cc
@@ -82,7 +82,6 @@ llvm::Value* CodeGenX86_64::VisitExpr_(const CastNode* op) {
     CHECK_EQ(from.lanes(), to.lanes());
     CHECK_NOTNULL(target_machine_);
 
-    const auto has_f16c = TargetHasFeature(*target_machine_, "f16c");
     const auto has_avx512 = TargetHasFeature(*target_machine_, "avx512f");
 
     if (from.lanes() >= 16 && has_avx512) {
@@ -101,6 +100,10 @@ llvm::Value* CodeGenX86_64::VisitExpr_(const CastNode* op) {
           });
     }
 
+#if TVM_LLVM_VERSION <= 100
+    // The intrinsic x86_vcvtph2ps_256 was removed in LLVM 11.
+    const auto has_f16c = TargetHasFeature(*target_machine_, "f16c");
+
     if (from.lanes() >= 8 && has_f16c) {
       return CallVectorIntrin(
           ::llvm::Intrinsic::x86_vcvtph2ps_256, 8,
@@ -109,6 +112,7 @@ llvm::Value* CodeGenX86_64::VisitExpr_(const CastNode* op) {
               DataType::Int(16, from.lanes()), tir::CallNode::reinterpret, {op->value},
               tir::CallNode::PureIntrinsic))});
     }
+#endif
   }
 
   return CodeGenCPU::VisitExpr_(op);


### PR DESCRIPTION
This intrinsic was removed in LLVM 11.
