### PR TITLE
[LLVM] Include Support/Host.h for declaration of getDefaultTargetTriple

### DIFF
--- a/src/target/llvm/llvm_common.h
+++ b/src/target/llvm/llvm_common.h
@@ -63,6 +63,7 @@
 #include <llvm/Support/Alignment.h>
 #endif
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Host.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/Casting.h>


### PR DESCRIPTION
In newer versions of LLVM, this header is no longer included by one of the already included headers in `llvm_common.h`, so include it explicitly.