### PR TITLE
[CI] Change MxNet from MKL verion to regular CPU version

### DIFF
--- a/docker/install/ubuntu_install_mxnet.sh
+++ b/docker/install/ubuntu_install_mxnet.sh
@@ -20,4 +20,4 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install mxnet-mkl==1.6.0
+pip3 install mxnet==1.6.0


### PR DESCRIPTION
Because mxnet-mkl doesn't support AMD cpu. see #5240

cc @tqchen @anijain2305 @shoubhik 