### PR TITLE
[BYOC] Refine AnnotateTarget and MergeCompilerRegion Passes

### DIFF
--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -56,10 +56,17 @@ def _register_external_op_helper(op_name, supported=True):
     return _func_wrapper
 
 
-_register_external_op_helper("nn.batch_norm")
 _register_external_op_helper("nn.conv2d")
 _register_external_op_helper("nn.dense")
 _register_external_op_helper("nn.relu")
 _register_external_op_helper("add")
 _register_external_op_helper("subtract")
 _register_external_op_helper("multiply")
+
+
+@reg.register("nn.batch_norm", "target.dnnl")
+def batch_norm(attrs, args):
+    """Check if the external DNNL codegen should be used.
+    FIXME(@zhiics, @comaniac): Turn off due to not support of multiple outputs.
+    """
+    return False

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -587,14 +587,14 @@ def PartitionGraph():
 
 
 
-def AnnotateTarget(target):
+def AnnotateTarget(targets):
     """Annotate ops in an experession with a provied compiler/target and then
     use it for codegen.
 
     Parameters
     ----------
-    target : String
-        The target compiler used for codegen.
+    target : List[String]
+        The list of target compilers used for codegen.
 
     Returns
     -------
@@ -602,7 +602,7 @@ def AnnotateTarget(target):
         The annotated pass that wrapps ops with subgraph_start and
         subgraph_end.
     """
-    return _ffi_api.AnnotateTarget(target)
+    return _ffi_api.AnnotateTarget(targets)
 
 
 def Inline():

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -593,7 +593,7 @@ def AnnotateTarget(targets):
 
     Parameters
     ----------
-    target : List[String]
+    targets : str or List[str]
         The list of target compilers used for codegen.
 
     Returns
@@ -602,7 +602,9 @@ def AnnotateTarget(targets):
         The annotated pass that wrapps ops with subgraph_start and
         subgraph_end.
     """
-    return _ffi_api.AnnotateTarget(targets)
+    if isinstance(targets, str):
+        targets = [targets]
+    return _ffi_api.AnnotateTarget([tvm.runtime.container.String(t) for t in targets])
 
 
 def Inline():

--- a/src/relay/analysis/annotated_region_set.cc
+++ b/src/relay/analysis/annotated_region_set.cc
@@ -21,6 +21,7 @@
 
 #include <tvm/relay/expr.h>
 #include <tvm/ir/error.h>
+#include <tvm/runtime/container.h>
 
 #include <unordered_map>
 #include <vector>
@@ -31,7 +32,7 @@ namespace relay {
 
 AnnotatedRegion AnnotatedRegionSetNode::GetRegion(const Expr& expr) const {
   for (auto candidate : regions_) {
-    if (candidate->nodes.find(expr) != candidate->nodes.end()) {
+    if (candidate->nodes_.find(expr) != candidate->nodes_.end()) {
       return candidate;
     }
   }
@@ -45,26 +46,26 @@ void AnnotatedRegionSetNode::MergeRegions(AnnotatedRegion src,
   }
 
   // Merge src to dest and erase src.
-  dest->nodes.insert(src->nodes.begin(), src->nodes.end());
-  for (const auto& input : src->ins) {
-    dest->ins.push_back(input);
+  dest->nodes_.insert(src->nodes_.begin(), src->nodes_.end());
+  for (const auto& input : src->ins_) {
+    dest->ins_.push_back(input);
   }
-  for (const auto& output : src->outs) {
-    dest->outs.push_back(output);
+  for (const auto& output : src->outs_) {
+    dest->outs_.push_back(output);
   }
   // if any of the outputs of src are inputs of dest, they become internal nodes
   // so remove them from outs
   std::vector<Expr> ins_to_remove;
-  for (const auto& input : dest->ins) {
+  for (const auto& input : dest->ins_) {
     auto call = Downcast<Call>(input);
-    auto it = src->nodes.find(call->args[0]);
-    if (it != src->nodes.end()) {
-      dest->outs.remove(*it);
+    auto it = src->nodes_.find(call->args[0]);
+    if (it != src->nodes_.end()) {
+      dest->outs_.remove(*it);
       ins_to_remove.push_back(input);
     }
   }
   for (const auto& input : ins_to_remove) {
-    dest->ins.remove(input);
+    dest->ins_.remove(input);
   }
   regions_.erase(src);
 }
@@ -74,25 +75,21 @@ void AnnotatedRegionSetNode::AddToRegion(AnnotatedRegion dest, const Expr& expr)
   if (src.defined()) {
     MergeRegions(src, dest);
   } else {
-    dest->nodes.insert(expr);
+    dest->nodes_.insert(expr);
   }
 }
 
-AnnotatedRegion AnnotatedRegionSetNode::MakeRegion() {
+AnnotatedRegion AnnotatedRegionSetNode::MakeRegion(std::string target) {
   auto ret = regions_.emplace(AnnotatedRegion());
-  (*ret.first)->id = region_id_++;
+  (*ret.first)->id_ = region_id_++;
+  (*ret.first)->target_ = target;
   return *ret.first;
 }
 
 class AnnotatedRegionSet::Creator : public ExprVisitor {
  public:
-  Creator(const Op& region_begin_op, const Op& region_end_op) :
-    begin_op_(region_begin_op), end_op_(region_end_op) {}
-
-  AnnotatedRegionSet Create(const Expr& expr) {
-    VisitExpr(expr);
-    return std::move(region_set_);
-  }
+  Creator(const Op& region_begin_op, const Op& region_end_op)
+      : begin_op_(region_begin_op), end_op_(region_end_op) {}
 
   void VisitExpr_(const CallNode* call) {
     auto op_node = call->op.as<OpNode>();
@@ -115,22 +112,34 @@ class AnnotatedRegionSet::Creator : public ExprVisitor {
                       << "Cannot find the corresponding region for start annotation:\n"
                       << AsText(GetRef<Call>(call), false));
       }
-      region->ins.push_back(GetRef<Call>(call));
+      region->ins_.push_back(GetRef<Call>(call));
     } else {
       CHECK_EQ(call->op, end_op_);
       // The annotation node is inserted on edge so it must have only one argument.
       CHECK_EQ(call->args.size(), 1U);
+      std::string target = call->attrs.as<CompilerAttrs>()->compiler;
 
       // Check if the argument already belongs to a region
       auto region = region_set_->GetRegion(call->args[0]);
       if (!region.defined()) {
-        region = region_set_->MakeRegion();
-        region->nodes.insert(call->args[0]);
+        // Create a new region if the argument is not belonged to any regions yet.
+        region = region_set_->MakeRegion(target);
+        region->nodes_.insert(call->args[0]);
       }
-      region->nodes.insert(GetRef<Call>(call));
-      region->outs.push_back(GetRef<Call>(call));
+      else {
+        // If the argument is belonged to a region, it must have the same target.
+        // Otherwise we should see a region_begin op.
+        CHECK_EQ(region->GetTarget(), target);
+      }
+      region->nodes_.insert(GetRef<Call>(call));
+      region->outs_.push_back(GetRef<Call>(call));
     }
     ExprVisitor::VisitExpr_(call);
+  }
+
+  AnnotatedRegionSet Create(const Expr& expr) {
+    VisitExpr(expr);
+    return std::move(region_set_);
   }
 
   void VisitExpr_(const TupleNode* op) {

--- a/src/relay/analysis/annotated_region_set.cc
+++ b/src/relay/analysis/annotated_region_set.cc
@@ -79,7 +79,7 @@ void AnnotatedRegionSetNode::AddToRegion(AnnotatedRegion dest, const Expr& expr)
   }
 }
 
-AnnotatedRegion AnnotatedRegionSetNode::MakeRegion(std::string target) {
+AnnotatedRegion AnnotatedRegionSetNode::MakeRegion(const std::string& target) {
   auto ret = regions_.emplace(AnnotatedRegion());
   (*ret.first)->id_ = region_id_++;
   (*ret.first)->target_ = target;

--- a/src/relay/analysis/annotated_region_set.cc
+++ b/src/relay/analysis/annotated_region_set.cc
@@ -125,8 +125,7 @@ class AnnotatedRegionSet::Creator : public ExprVisitor {
         // Create a new region if the argument is not belonged to any regions yet.
         region = region_set_->MakeRegion(target);
         region->nodes_.insert(call->args[0]);
-      }
-      else {
+      } else {
         // If the argument is belonged to a region, it must have the same target.
         // Otherwise we should see a region_begin op.
         CHECK_EQ(region->GetTarget(), target);

--- a/src/relay/analysis/annotated_region_set.h
+++ b/src/relay/analysis/annotated_region_set.h
@@ -32,6 +32,7 @@
 #include <tvm/relay/expr.h>
 #include <tvm/ir/error.h>
 #include <tvm/relay/expr_functor.h>
+#include <tvm/runtime/container.h>
 #include <tvm/relay/transform.h>
 
 #include <string>
@@ -49,33 +50,39 @@ class AnnotatedRegionSet;
 class AnnotatedRegionNode : public Object {
  public:
   void VisitAttrs(AttrVisitor* v) {
-    v->Visit("id", &id);
-    Array<Expr> nodes_array(nodes.begin(), nodes.end());
+    v->Visit("id", &id_);
+    v->Visit("target", &target_);
+    Array<Expr> nodes_array(nodes_.begin(), nodes_.end());
     v->Visit("nodes", &nodes_array);
-    Array<Expr> args_array(ins.begin(), ins.end());
+    Array<Expr> args_array(ins_.begin(), ins_.end());
     v->Visit("args", &args_array);
-    Array<Expr> rets_array(outs.begin(), outs.end());
+    Array<Expr> rets_array(outs_.begin(), outs_.end());
     v->Visit("rets", &rets_array);
   }
 
   /*! \brief Get the region ID. */
   int GetID() const {
-    return id;
+    return id_;
+  }
+
+  /*! \brief Get the region target. */
+  std::string GetTarget() const {
+    return target_;
   }
 
   /*! \brief Get the region's inputs. */
   std::list<Expr> GetInputs() const {
-    return ins;
+    return ins_;
   }
 
   /*! \brief Get the region's outputs. */
   std::list<Expr> GetOutputs() const {
-    return outs;
+    return outs_;
   }
 
   /*! \brief Get the region's nodes. */
   std::unordered_set<Expr, ObjectHash, ObjectEqual> GetNodes() const {
-    return nodes;
+    return nodes_;
   }
 
   static constexpr const char* _type_key = "relay.AnnotatedRegion";
@@ -83,13 +90,15 @@ class AnnotatedRegionNode : public Object {
 
  protected:
   /*! \brief The region ID. */
-  int id{-1};
+  int id_{-1};
+  /*! \brief The target for this region. */
+  std::string target_ = "default";
   /*! \brief The inputs to this region. */
-  std::list<Expr> ins;
+  std::list<Expr> ins_;
   /*! \brief The outputs of this region */
-  std::list<Expr> outs;
+  std::list<Expr> outs_;
   /*! \brief Nodes in this region. */
-  std::unordered_set<Expr, ObjectHash, ObjectEqual> nodes;
+  std::unordered_set<Expr, ObjectHash, ObjectEqual> nodes_;
 
   friend class AnnotatedRegionSet;
   friend class AnnotatedRegionSetNode;
@@ -184,11 +193,11 @@ class AnnotatedRegionSetNode : public Object {
   void AddToRegion(AnnotatedRegion dest, const Expr& expr);
 
   /*!
-   * \brief Make a new region.
+   * \brief Make a new region for a target.
    *
    * \return The new region.
    */
-  AnnotatedRegion MakeRegion();
+  AnnotatedRegion MakeRegion(std::string target);
 
   std::unordered_set<AnnotatedRegion, ObjectHash, ObjectEqual> regions_;
   /*! \brief The next region ID to assign. */

--- a/src/relay/analysis/annotated_region_set.h
+++ b/src/relay/analysis/annotated_region_set.h
@@ -197,7 +197,7 @@ class AnnotatedRegionSetNode : public Object {
    *
    * \return The new region.
    */
-  AnnotatedRegion MakeRegion(std::string target);
+  AnnotatedRegion MakeRegion(const std::string& target);
 
   std::unordered_set<AnnotatedRegion, ObjectHash, ObjectEqual> regions_;
   /*! \brief The next region ID to assign. */

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -53,19 +53,12 @@ class CodegenDNNL : public ExprVisitor, public CodegenCBase {
   }
 
   void VisitExpr_(const TupleGetItemNode* op) final {
-    VisitExpr(op->tuple);
-    CHECK(out_.size() > static_cast<size_t>(op->index));
-
-    // Only keep the item we want for the child node.
-    // FIXME(@comaniac): The other items should still be requried for the primary outputs.
-    auto item = out_[op->index];
-    out_.clear();
-    out_.push_back(item);
+    // Do nothing
   }
 
   void VisitExpr_(const CallNode* call) final {
     std::ostringstream decl_stream;
-
+    std::ostringstream buf_stream;
     // Args: ID
     std::vector<std::string> args;
 
@@ -103,45 +96,20 @@ class CodegenDNNL : public ExprVisitor, public CodegenCBase {
       }
     }
 
-    // Analyze the output buffers
-    std::vector<Type> out_types;
-    if (call->checked_type()->IsInstance<TupleTypeNode>()) {
-      auto type_node = call->checked_type().as<TupleTypeNode>();
-      for (auto field : type_node->fields) {
-        CHECK(field->IsInstance<TensorTypeNode>());
-        out_types.push_back(field);
-      }
-    } else if (call->checked_type()->IsInstance<TensorTypeNode>()) {
-      CHECK(call->checked_type()->IsInstance<TensorTypeNode>());
-      out_types.push_back(call->checked_type());
-    } else {
-      LOG(FATAL) << "Unrecognized type node: " << AsText(call->checked_type(), false);
+    // Analyze the output buffer
+    auto type_node = call->checked_type().as<TensorTypeNode>();
+    CHECK(type_node);
+    const auto& dtype = GetDtypeString(type_node);
+    std::string out = "buf_" + std::to_string(buf_idx_++);
+    auto out_shape = GetShape(call->checked_type());
+    int out_size = 1;
+    for (size_t i = 0; i < out_shape.size(); ++i) {
+      out_size *= out_shape[i];
     }
-
-    out_.clear();
-    for (auto out_type : out_types) {
-      const auto& dtype = GetDtypeString(out_type.as<TensorTypeNode>());
-
-      std::string out = "buf_" + std::to_string(buf_idx_++);
-      auto out_shape = GetShape(out_type);
-      int out_size = 1;
-      for (size_t i = 0; i < out_shape.size(); ++i) {
-        out_size *= out_shape[i];
-      }
-      this->PrintIndents();
-      std::ostringstream buf_stream;
-      buf_stream << "float* " << out << " = (float*)std::malloc(4 * " << out_size << ");";
-      buf_decl_.push_back(buf_stream.str());
-      decl_stream << ", " << out;
-
-      // Update output buffer
-      Output output;
-      output.name = out;
-      output.dtype = dtype;
-      output.need_copy = true;
-      output.size = out_size;
-      out_.push_back(output);
-    }
+    this->PrintIndents();
+    buf_stream << "float* " << out << " = (float*)std::malloc(4 * " << out_size << ");";
+    buf_decl_.push_back(buf_stream.str());
+    decl_stream << ", " << out;
 
     // Attach attribute arguments
     for (size_t i = 0; i < args.size(); ++i) {
@@ -149,6 +117,15 @@ class CodegenDNNL : public ExprVisitor, public CodegenCBase {
     }
     decl_stream << ");";
     ext_func_body.push_back(decl_stream.str());
+
+    // Update output buffer
+    out_.clear();
+    Output output;
+    output.name = out;
+    output.dtype = dtype;
+    output.need_copy = true;
+    output.size = out_size;
+    out_.push_back(output);
   }
 
   std::string JIT(void) {

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -924,13 +924,6 @@ IRModule VMCompiler::OptimizeModule(const IRModule& mod, const TargetsMap& targe
   pass_seqs.push_back(transform::LambdaLift());
   pass_seqs.push_back(transform::InlinePrimitives());
 
-  // Manifest the allocations.
-  pass_seqs.push_back(transform::ManifestAlloc(this->target_host_));
-  // Compute away possibly introduced constant computation.
-  pass_seqs.push_back(transform::FoldConstant());
-  // Fuse the shape functions.
-  pass_seqs.push_back(transform::FuseOps());
-
   // Inline the functions that are lifted to the module scope. We perform this
   // pass after all other optimization passes but before the memory allocation
   // pass. This is because memory allocation pass will insert `invoke_tvm_op`
@@ -938,6 +931,12 @@ IRModule VMCompiler::OptimizeModule(const IRModule& mod, const TargetsMap& targe
   // external codegen.
   pass_seqs.push_back(transform::Inline());
 
+  // Manifest the allocations.
+  pass_seqs.push_back(transform::ManifestAlloc(this->target_host_));
+  // Compute away possibly introduced constant computation.
+  pass_seqs.push_back(transform::FoldConstant());
+  // Fuse the shape functions.
+  pass_seqs.push_back(transform::FuseOps());
   // Manifest the allocations needed for the shape functions.
   pass_seqs.push_back(transform::ManifestAlloc(this->target_host_));
 

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -158,11 +158,12 @@ class AnnotateTargetWrapper : public ExprMutator {
       // if it is in the target list.
       Function func = Downcast<Function>(cn->op);
       CHECK(func.defined());
-      auto comp_name = func->GetAttr<tir::StringImm>(attr::kComposite);
+      auto comp_name = func->GetAttr<String>(attr::kComposite);
       if (comp_name.defined()) {
-        size_t i = comp_name->value.find('.');
+        std::string comp_name_str = comp_name;
+        size_t i = comp_name_str.find('.');
         if (i != std::string::npos) {
-          std::string comp_target = comp_name->value.substr(0, i);
+          std::string comp_target = comp_name_str.substr(0, i);
           for (const auto& target : this->targets_) {
             if (std::string(target) == comp_target) {
               supported_targets.push_back(comp_target);

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -40,8 +40,7 @@ const PackedFunc* end_op = runtime::Registry::Get("relay.op.annotation._make.com
 // be handled by a specific compiler.
 class AnnotateTargetWrapper : public ExprMutator {
  public:
-  explicit AnnotateTargetWrapper(Array<runtime::String> targets)
-    : targets_(std::move(targets)) {}
+  explicit AnnotateTargetWrapper(Array<runtime::String> targets) : targets_(std::move(targets)) {}
 
   /*!
    * \brief This function annotates a compiler end and a compiler begin to all arguments.
@@ -243,8 +242,7 @@ Pass AnnotateTarget(const Array<runtime::String>& targets) {
   return transform::Sequential({func_pass, InferType()}, "AnnotateTarget");
 }
 
-TVM_REGISTER_GLOBAL("relay._transform.AnnotateTarget")
-.set_body_typed(AnnotateTarget);
+TVM_REGISTER_GLOBAL("relay._transform.AnnotateTarget").set_body_typed(AnnotateTarget);
 
 }  // namespace transform
 

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -154,7 +154,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto target_n_args = AnnotateArgs(expr->fields);
     auto new_expr = Tuple(std::get<1>(target_n_args));
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
   Expr VisitExpr_(const TupleGetItemNode* op) final {
@@ -164,7 +164,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto target_n_args = AnnotateArgs(Array<Expr>({expr->tuple}));
     auto new_expr = TupleGetItem(std::get<1>(target_n_args)[0], expr->index);
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
   Expr VisitExpr_(const FunctionNode* fn) final {
@@ -193,7 +193,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto target_n_args = AnnotateArgs({let->value, let->body});
     auto new_expr = Let(let->var, std::get<1>(target_n_args)[0], std::get<1>(target_n_args)[1]);
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
   Expr VisitExpr_(const IfNode* op) final {
@@ -205,7 +205,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto new_expr = If(std::get<1>(target_n_args)[0], std::get<1>(target_n_args)[1],
                        std::get<1>(target_n_args)[2]);
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
   Expr VisitExpr_(const RefCreateNode* op) final {
@@ -215,7 +215,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto target_n_args = AnnotateArgs(Array<Expr>({expr->value}));
     auto new_expr = RefCreate(std::get<1>(target_n_args)[0]);
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
   Expr VisitExpr_(const RefReadNode* op) final {
@@ -225,7 +225,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto target_n_args = AnnotateArgs(Array<Expr>({expr->ref}));
     auto new_expr = RefRead(std::get<1>(target_n_args)[0]);
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
   Expr VisitExpr_(const RefWriteNode* op) final {
@@ -235,7 +235,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     auto target_n_args = AnnotateArgs(Array<Expr>({expr->ref, expr->value}));
     auto new_expr = RefWrite(std::get<1>(target_n_args)[0], std::get<1>(target_n_args)[1]);
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
-    return new_expr;
+    return std::move(new_expr);
   }
 
  private:

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -145,6 +145,9 @@ class AnnotateTargetWrapper : public ExprMutator {
       Op op = Downcast<Op>(cn->op);
       CHECK(op.defined());
       for (const auto& target : this->targets_) {
+        if (!Op::HasAttr("target." + std::string(target))) {
+          continue;
+        }
         auto fannotate = Op::GetAttr<FTVMAnnotateTarget>("target." + std::string(target));
         if (fannotate.count(op) && fannotate[op](cn->attrs, cn->args)) {
           supported_targets.push_back(target);

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -199,9 +199,6 @@ class IndexedForwardGraph::Creator : private ExprVisitor {
 
   // Post order tree
   void VisitExpr_(const FunctionNode* op) final {
-    if (op->GetAttr<tir::StringImm>(attr::kCompiler).defined()) {
-      return;
-    }
     for (auto param : op->params) {
       this->Update(param, nullptr, kOpaque);
     }

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -199,6 +199,9 @@ class IndexedForwardGraph::Creator : private ExprVisitor {
 
   // Post order tree
   void VisitExpr_(const FunctionNode* op) final {
+    if (op->GetAttr<tir::StringImm>(attr::kCompiler).defined()) {
+      return;
+    }
     for (auto param : op->params) {
       this->Update(param, nullptr, kOpaque);
     }

--- a/src/relay/transforms/merge_compiler_regions.cc
+++ b/src/relay/transforms/merge_compiler_regions.cc
@@ -46,183 +46,12 @@
 
 namespace tvm {
 namespace relay {
-namespace partitioning {
+namespace merge_compiler_region {
 
 // Cache compiler_begin and compiler_end annotation ops for equivalence check to
 // reduce registry lookup overhead.
 static const Op& compiler_begin_op = Op::Get("annotation.compiler_begin");
 static const Op& compiler_end_op = Op::Get("annotation.compiler_end");
-
-/*! \brief This is a pre-requisite pass to merge-supported pass.
- *  The AnnotateRestDefault pass will put "default" Compiler Annotations to
- *  nodes that are not annotated already. This is there to ensure that the
- *  user will not leave un-annotated nodes MergeCompilerRegions pass is run.
- *  Why? Because, MergeCompilerRegions pass assumes every node to be annotated.
- */
-class AnnotateRestDefault : public ExprMutator {
- public:
-  explicit AnnotateRestDefault(const Expr& expr) {
-    regions_ = AnnotatedRegionSet::Create(expr, compiler_begin_op, compiler_end_op);
-  }
-
-  Expr Annotate(const Expr& expr) {
-    // Its a function that is being passed on to annotate
-    func_ = Downcast<Function>(expr);
-
-    // Corner Case CC1 : If the last node does not belong
-    // to a region node to add a compiler_end
-    auto region = regions_->GetRegion(func_->body);
-    auto mutated_expr = this->VisitExpr(expr);
-    if (!region.defined()) {
-      func_ = Downcast<Function>(mutated_expr);
-      // CC1 : add that compiler end after mutation
-      auto body = InsertEnd(func_->body);
-      func_ = Function(func_->params, body, body->checked_type_, {}, DictAttrs());
-      return Downcast<Expr>(func_);
-    }
-    return mutated_expr;
-  }
-
-  /*! \brief This function adds compiler ends to nodes that
-   * don't belong to a region already (default).
-   * \param expr The expression to add a compiler end to.
-   * \return expr The expression with or without a compiler end added.
-   */
-  Expr InsertEnd(const Expr& expr) {
-    if (annotated_nodes_.find(expr) == annotated_nodes_.end() && !expr->IsInstance<VarNode>() &&
-        !expr->IsInstance<ConstantNode>()) {
-      const auto* end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
-      CHECK(end_op);
-      Expr end = (*end_op)(expr, target_);
-      return end;
-    }
-    return expr;
-  }
-
-  /*! \brief This function adds compiler begins to nodes that
-   * don't belong to a region already (default).
-   * \param expr The expression to add a compiler begin to.
-   * \return expr The expression with or without a compiler begin added.
-   */
-  Expr InsertBegin(const Expr& expr) {
-    const auto* begin_op = runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
-    CHECK(begin_op);
-    Expr begin = (*begin_op)(expr, target_);
-    annotated_nodes_.insert(begin);
-    return begin;
-  }
-
-  Expr VisitExpr_(const CallNode* cn) final {
-    auto region = regions_->GetRegion(GetRef<Call>(cn));
-    auto new_e = ExprMutator::VisitExpr_(cn);
-    Call call = Downcast<Call>(new_e);
-
-    // Add compiler ends if the parent isn't annotated
-    Array<Expr> args;
-    for (auto arg : call->args) {
-      args.push_back(InsertEnd(arg));
-    }
-
-    Expr updated_call = Call(call->op, args, call->attrs);
-    if (!region.defined()) {
-      // if the current node does not belong to annotated region
-      // annotate the all incoming edges (args)
-      // with "default" compiler_begin annotations.
-      Array<Expr> compiler_begins;
-      for (auto arg : args) {
-        compiler_begins.push_back(InsertBegin(arg));
-      }
-      updated_call = Call(call->op, compiler_begins, call->attrs);
-    } else {
-      annotated_nodes_.insert(updated_call);
-    }
-    return updated_call;
-  };
-
-  Expr VisitExpr_(const TupleNode* op) {
-    auto region = regions_->GetRegion(GetRef<Tuple>(op));
-    auto new_e = ExprMutator::VisitExpr_(op);
-    Tuple tup = Downcast<Tuple>(new_e);
-
-    Array<Expr> fields;
-    for (auto field : tup->fields) {
-      fields.push_back(InsertEnd(field));
-    }
-
-    Expr updated_tuple = Tuple(fields);
-    if (!region.defined()) {
-      Array<Expr> compiler_begins;
-      for (const auto& field : fields) {
-        compiler_begins.push_back(InsertBegin(field));
-      }
-      updated_tuple = Tuple(compiler_begins);
-    } else {
-      annotated_nodes_.insert(updated_tuple);
-    }
-    return updated_tuple;
-  }
-
-  Expr VisitExpr_(const TupleGetItemNode* op) {
-    auto region = regions_->GetRegion(GetRef<TupleGetItem>(op));
-    auto new_e = ExprMutator::VisitExpr_(op);
-    auto get = Downcast<TupleGetItem>(new_e);
-
-    auto updated_tuple = InsertEnd(get->tuple);
-    Expr updated_get = TupleGetItem(updated_tuple, get->index);
-    if (!region.defined()) {
-      updated_get = TupleGetItem(InsertBegin(updated_tuple), get->index);
-    } else {
-      annotated_nodes_.insert(updated_get);
-    }
-    return updated_get;
-  }
-
-  Expr VisitExpr_(const IfNode* op) {
-    auto region = regions_->GetRegion(GetRef<If>(op));
-    auto new_e = ExprMutator::VisitExpr_(op);
-    auto iff = Downcast<If>(new_e);
-
-    if (!region.defined()) {
-      return If(InsertBegin(InsertEnd(iff->cond)), InsertBegin(InsertEnd(iff->true_branch)),
-                InsertBegin(InsertEnd(iff->false_branch)));
-    } else {
-      Expr updated_iff =
-          If(InsertEnd(iff->cond), InsertEnd(iff->true_branch), InsertEnd(iff->false_branch));
-      annotated_nodes_.insert(updated_iff);
-      return updated_iff;
-    }
-  }
-
-  Expr VisitExpr_(const LetNode* op) {
-    auto new_e = ExprMutator::VisitExpr_(op);
-    auto let = Downcast<Let>(new_e);
-    return Let(let->var, InsertEnd(let->value), InsertEnd(let->body));
-  }
-
-  Expr VisitExpr_(const RefCreateNode* op) {
-    auto new_e = ExprMutator::VisitExpr_(op);
-    auto create = Downcast<RefCreate>(new_e);
-    return RefCreate(InsertEnd(create->value));
-  }
-
-  Expr VisitExpr_(const RefReadNode* op) {
-    auto new_e = ExprMutator::VisitExpr_(op);
-    auto read = Downcast<RefRead>(new_e);
-    return RefRead(InsertEnd(read->ref));
-  }
-
-  Expr VisitExpr_(const RefWriteNode* op) {
-    auto new_e = ExprMutator::VisitExpr_(op);
-    auto write = Downcast<RefWrite>(new_e);
-    return RefWrite(InsertEnd(write->ref), InsertEnd(write->value));
-  }
-
- private:
-  AnnotatedRegionSet regions_;
-  const std::string target_ = "default";
-  Function func_;
-  std::unordered_set<Expr, ObjectHash, ObjectEqual> annotated_nodes_;
-};
 
 class MergeAnnotations : public ExprMutator {
  public:
@@ -333,37 +162,30 @@ class RegionMerger : public ExprVisitor {
 };
 
 Expr MergeCompilerRegions(const Expr& expr) {
-  // Annotate all the nodes that aren't annotated as 'default'.
-  AnnotateRestDefault anno_default(expr);
-  auto expr_all_annotated = anno_default.Annotate(expr);
-
   // Create regions using the annotations.
-  AnnotatedRegionSet regions =
-      AnnotatedRegionSet::Create(expr_all_annotated, compiler_begin_op, compiler_end_op);
+  AnnotatedRegionSet regions = AnnotatedRegionSet::Create(expr, compiler_begin_op, compiler_end_op);
 
-  // By now, all the nodes have some sort of annotation.
-  // Region merger is an ExprVisitor that will update the
-  // AnnotatedRegionSet, merging all the regions that can be merged.
+  // Analyze the graph to explore the opportunities of merging regions.
   RegionMerger merger(regions);
-  merger.VisitExpr(expr_all_annotated);
+  merger.VisitExpr(expr);
 
-  // This updates the expression to remove annotations that are now
-  // 'internal' to a merged region.
+  // Remove annotations that are not in the region boundaries.
   MergeAnnotations merge_anno(regions);
-  return merge_anno.Mutate(expr_all_annotated);
+  auto new_expr = merge_anno.Mutate(expr);
+  return new_expr;
 }
 
-}  // namespace partitioning
+}  // namespace merge_compiler_region
 
 namespace transform {
 
 Pass MergeCompilerRegions() {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> part_func =
       [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(partitioning::MergeCompilerRegions(f));
+        return Downcast<Function>(merge_compiler_region::MergeCompilerRegions(f));
       };
-  auto partitioned = CreateFunctionPass(part_func, 0, "MergeCompilerRegions", {});
-  return Sequential({partitioned, InferType()});
+  auto merged = CreateFunctionPass(part_func, 0, "MergeCompilerRegions", {});
+  return Sequential({merged, InferType()});
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.MergeCompilerRegions")

--- a/src/relay/transforms/merge_compiler_regions.cc
+++ b/src/relay/transforms/merge_compiler_regions.cc
@@ -92,10 +92,9 @@ class RegionMerger : public ExprVisitor {
         auto begin = Downcast<Call>(arg);
         CHECK_EQ(begin->op, compiler_begin_op);
         auto parent_region = regions_->GetRegion(begin->args[0]);
-        if (!parent_region.defined()) {
-          continue;
+        if (parent_region.defined()) {
+          mergeable_regions.insert(parent_region);
         }
-        mergeable_regions.insert(parent_region);
       }
 
       // Propogate all the parent restrictions to the current region.
@@ -140,6 +139,7 @@ class RegionMerger : public ExprVisitor {
   std::unordered_set<int> merged_regions_;
   std::unordered_map<int, std::unordered_set<int>> region_restrictions_;
 };
+
 class MergeAnnotations : public ExprMutator {
  public:
   explicit MergeAnnotations(AnnotatedRegionSet regions) : regions_(regions) {}
@@ -175,8 +175,7 @@ Expr MergeCompilerRegions(const Expr& expr) {
 
   // Remove annotations that are not in the region boundaries.
   MergeAnnotations merge_anno(regions);
-  auto new_expr = merge_anno.Mutate(expr);
-  return new_expr;
+  return merge_anno.Mutate(expr);
 }
 
 }  // namespace merge_compiler_region

--- a/src/runtime/contrib/dnnl/dnnl.cc
+++ b/src/runtime/contrib/dnnl/dnnl.cc
@@ -169,11 +169,9 @@ extern "C" void dnnl_relu(float* data, float* out, int p_N_, int p_C_, int p_H_,
   read_from_dnnl_memory(out, dst_memory);
 }
 
-extern "C" void dnnl_bn(float* data, float* gamma, float* beta, float* mean, float* variance,
-                        float* out, float* new_mean, float* new_variance, int p_N_, int p_C_,
+extern "C" void dnnl_bn(float* data, float* gamma, float* beta, float* mean,
+                        float* variance, float* out, int p_N_, int p_C_,
                         int p_H_, int p_W_, int p_E_) {
-  // FIXME(@comaniac): BN has 3 outputs: out, new_mean and new_variance, but we do not update
-  // the rest two because no one cares about them for now. Should update it in the future.
   using tag = memory::format_tag;
   using dt = memory::data_type;
 

--- a/src/runtime/contrib/dnnl/dnnl_kernel.h
+++ b/src/runtime/contrib/dnnl/dnnl_kernel.h
@@ -44,8 +44,8 @@ extern "C" TVM_DLL void dnnl_dense(float* data, float* weight, float* out, int p
 extern "C" TVM_DLL void dnnl_relu(float* data, float* out, int p_N_, int p_C_, int p_H_, int p_W_);
 
 extern "C" TVM_DLL void dnnl_bn(float* data, float* gamma, float* beta, float* mean,
-                                float* variance, float* out, float* new_mean, float* new_variance,
-                                int p_n_, int p_c_, int p_h_, int p_w_, int p_e_);
+                                float* variance, float* out, int p_n_, int p_c_, int p_h_, int p_w_,
+                                int p_e_);
 
 extern "C" TVM_DLL void dnnl_add(float* data, float* weight, float* out, int p_n_, int p_c_,
                                  int p_h_, int p_w_);

--- a/tests/python/relay/test_annotated_regions.py
+++ b/tests/python/relay/test_annotated_regions.py
@@ -15,13 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=no-else-return, unidiomatic-typecheck, invalid-name
+import tvm
 from tvm import relay
 from tvm.relay.op.annotation import compiler_begin, compiler_end
 
 
-def check_region(region_set, args, nodes, rets):
+def check_region(region_set, target, args, nodes, rets):
     region = region_set.get_region(args[0])
     assert region
+    assert target == region.target
     assert set(args) == set(region.args)
     assert set(nodes) == set(region.nodes)
     assert set(rets) == set(region.rets)
@@ -51,24 +53,28 @@ def test_region_set_creator_diamond():
     assert len(region_set) == 4
     check_region(
         region_set,
+        'test_target',
         [cb_1],
         [cb_1, O_1, ce_1, ce_2],
         [ce_1, ce_2],
     )
     check_region(
         region_set,
+        'test_target',
         [cb_2],
         [cb_2, O_2, ce_3],
         [ce_3],
     )
     check_region(
         region_set,
+        'default',
         [cb_d],
         [cb_d, X, ce_d],
         [ce_d],
     )
     check_region(
         region_set,
+        'test_target',
         [cb_3, cb_4],
         [cb_3, cb_4, O_3, ce_4],
         [ce_4],
@@ -88,7 +94,9 @@ def test_region_set_creator_merged():
     cb_3 = compiler_begin(ce_3, 'test_target')
     cb_4 = compiler_begin(ce_d, 'test_target')
     O_3 = relay.add(cb_3, cb_4)
-    ce_4 = compiler_end(O_3, 'test_target')
+    O_4 = relay.add(cb_3, cb_4)
+    O_5 = relay.Tuple([O_3, O_4])
+    ce_4 = compiler_end(O_5, 'test_target')
     merged = relay.Function([data], ce_4)
 
     region_set = relay.analysis.AnnotatedRegionSet(merged,
@@ -97,20 +105,23 @@ def test_region_set_creator_merged():
     assert len(region_set) == 3
     check_region(
         region_set,
+        'test_target',
         [cb_1],
         [cb_1, O_1, O_2, ce_2, ce_3],
         [ce_2, ce_3],
     )
     check_region(
         region_set,
+        'default',
         [cb_d],
         [cb_d, X, ce_d],
         [ce_d],
     )
     check_region(
         region_set,
+        'test_target',
         [cb_3, cb_4],
-        [cb_3, cb_4, O_3, ce_4],
+        [cb_3, cb_4, O_3, O_4, O_5, ce_4],
         [ce_4],
     )
 
@@ -118,4 +129,3 @@ def test_region_set_creator_merged():
 if __name__ == "__main__":
     test_region_set_creator_diamond()
     test_region_set_creator_merged()
-

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -339,8 +339,12 @@ def test_composite_function():
 
 if __name__ == "__main__":
     test_extern_dnnl()
+<<<<<<< HEAD
     #test_extern_dnnl_mobilenet()
+=======
+>>>>>>> Skip e2e test
     test_composite_function()
+    #test_extern_dnnl_mobilenet()
     test_multiple_ends()
     test_type_propagation()
     test_tuple()

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -365,10 +365,6 @@ def test_multiple_runs():
 
 if __name__ == "__main__":
     test_extern_dnnl()
-<<<<<<< HEAD
-    #test_extern_dnnl_mobilenet()
-=======
->>>>>>> Skip e2e test
     test_composite_function()
     #test_extern_dnnl_mobilenet()
     test_multiple_ends()

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -229,7 +229,7 @@ def test_multiple_ends():
 def test_type_propagation():
     target = "test_type_propagation"
 
-    @reg.register("nn.relu", "target.test_type_propagation" + target)
+    @reg.register("nn.relu", "target." + target)
     def relu(attrs, args): # pylint: disable=unused-variable
         return args[0].checked_type.dtype == "float32"
 
@@ -281,7 +281,7 @@ def test_tuple():
         tup = relay.Tuple([cb_3, cb_4])
         ce_3 = relay.annotation.compiler_end(tup, target)
         cb_3 = relay.annotation.compiler_begin(ce_3, target)
-        out = relay.op.concatenate(cb_3, 1)
+        out = relay.op._make.concatenate(cb_3, 1)
         ce_4 = relay.annotation.compiler_end(out, target)
         f = relay.Function([x, y], ce_4)
         mod = tvm.IRModule.from_expr(f)

--- a/tests/python/relay/test_pass_merge_compiler_regions.py
+++ b/tests/python/relay/test_pass_merge_compiler_regions.py
@@ -69,14 +69,16 @@ def test_diamond_graph_fanouts():
         O_2 = relay.nn.relu(O_1)
         ce_3 = compiler_end(O_2, "test")
 
-        X = relay.tanh(ce_2)
+        cb_3 = compiler_begin(ce_2, "default")
+        X = relay.tanh(cb_3)
+        ce_4 = compiler_end(X, "default")
 
-        cb_3 = compiler_begin(ce_3, "test")
-        cb_4 = compiler_begin(X, "test")
-        O_3 = relay.add(cb_3, cb_4)
-        ce_4 = compiler_end(O_3, "test")
+        cb_4 = compiler_begin(ce_3, "test")
+        cb_5 = compiler_begin(ce_4, "test")
+        O_3 = relay.add(cb_4, cb_5)
+        ce_5 = compiler_end(O_3, "test")
 
-        func = relay.Function([data], ce_4)
+        func = relay.Function([data], ce_5)
         return func
 
     result = run_opt_pass(diamond_graph_fanouts(), relay.transform.MergeCompilerRegions())
@@ -171,20 +173,27 @@ def test_example_graph():
         node1 = relay.add(begin2, begin3)
         node2 = relay.add(node0, node1)
 
-        node3 = relay.subtract(in_5, in_6)
-        node4 = relay.subtract(in_7, node3)
+        dbegin0 = compiler_begin(in_5, "default")
+        dbegin1 = compiler_begin(in_6, "default")
+        dbegin2 = compiler_begin(in_7, "default")
+        node3 = relay.subtract(dbegin0, dbegin1)
+        node4 = relay.subtract(dbegin2, node3)
+        dend0 = compiler_end(node4, "default")
 
-        begin4 = compiler_begin(node4, "test")
+        begin4 = compiler_begin(dend0, "test")
         begin5 = compiler_begin(in_9, "test")
         node5 = relay.add(node2, begin4)
         end1 = compiler_end(node5, "test")
 
-        node6 = relay.subtract(in_8, end1)
+        dbegin4 = compiler_begin(end1, "default")
+        dbegin5 = compiler_begin(in_8, "default")
+        node6 = relay.subtract(dbegin5, dbegin4)
+        dend1 = compiler_end(node6, "default")
 
         node7 = relay.add(begin5, node5)
         end2 = compiler_end(node7, "test")
         begin6 = compiler_begin(end2, "test")
-        begin7 = compiler_begin(node6, "test")
+        begin7 = compiler_begin(dend1, "test")
 
         node8 = relay.add(begin7, begin6)
 

--- a/tests/python/relay/test_pass_merge_compiler_regions.py
+++ b/tests/python/relay/test_pass_merge_compiler_regions.py
@@ -30,9 +30,9 @@ def test_diamond_graph_fanouts():
     X = not supported by target
 
        O         O
-      / \       /               \
+      / \\      /               \\
      O   X --> O    +       +    X
-      \ /              \ /
+     \\ /             \\ /
        O                O
 
     Note that we can't just merge the three supported operators together,
@@ -45,17 +45,20 @@ def test_diamond_graph_fanouts():
         ce_1 = compiler_end(O_1, "test")
         ce_2 = compiler_end(O_1, "test")
         cb_2 = compiler_begin(ce_1, "test")
+        cb_3 = compiler_begin(ce_2, "default")
         O_2 = relay.nn.relu(cb_2)
         ce_3 = compiler_end(O_2, "test")
 
-        X = relay.tanh(ce_2)
 
-        cb_3 = compiler_begin(ce_3, "test")
-        cb_4 = compiler_begin(X, "test")
-        O_3 = relay.add(cb_3, cb_4)
-        ce_4 = compiler_end(O_3, "test")
+        X = relay.tanh(cb_3)
+        ce_4 = compiler_end(X, "default")
 
-        diamond = relay.Function([data], ce_4)
+        cb_4 = compiler_begin(ce_3, "test")
+        cb_5 = compiler_begin(ce_4, "test")
+        O_3 = relay.add(cb_4, cb_5)
+        ce_5 = compiler_end(O_3, "test")
+
+        diamond = relay.Function([data], ce_5)
         return diamond
 
     def expected():
@@ -85,7 +88,7 @@ def test_example_graph():
     """This tests the merging algorithm on the example used in the RFC.
 
     See the RFC here: https://discuss.tvm.ai/t/relay-improved-graph-partitioning-algorithm/5830
-    Blue nodes are adds, red nodes are subtracts.
+    Blue nodes are adds (target: test), red nodes are subtracts (target: default).
     """
     def annotated():
         in_1 = relay.var('in_1', shape=(10, 10), dtype='float32')
@@ -112,21 +115,30 @@ def test_example_graph():
         node2 = relay.add(begin4, begin5)
         end2 = compiler_end(node2, "test")
 
-        node3 = relay.subtract(in_5, in_6)
-        node4 = relay.subtract(in_7, node3)
+        dbegin0 = compiler_begin(in_5, "default")
+        dbegin1 = compiler_begin(in_6, "default")
+        node3 = relay.subtract(dbegin0, dbegin1)
+        dbegin2 = compiler_begin(in_7, "default")
+        dend1 = compiler_end(node3, "default")
+        dbegin3 = compiler_begin(dend1, "default")
+        node4 = relay.subtract(dbegin2, dbegin3)
+        dend2 = compiler_end(node4, "default")
 
         begin6 = compiler_begin(end2, "test")
-        begin7 = compiler_begin(node4, "test")
+        begin7 = compiler_begin(dend2, "test")
         node5 = relay.add(begin6, begin7)
         end3 = compiler_end(node5, "test")
         end4 = compiler_end(node5, "test")
-        node6 = relay.subtract(in_8, end3)
+        dbegin4 = compiler_begin(in_8, "default")
+        dbegin5 = compiler_begin(end3, "default")
+        node6 = relay.subtract(dbegin4, dbegin5)
         begin8 = compiler_begin(in_9, "test")
         begin9 = compiler_begin(end4, "test")
         node7 = relay.add(begin8, begin9)
         end5 = compiler_end(node7, "test")
 
-        begin10 = compiler_begin(node6, "test")
+        dend3 = compiler_end(node6, "default")
+        begin10 = compiler_begin(dend3, "test")
         begin11 = compiler_begin(end5, "test")
         node8 = relay.add(begin10, begin11)
         end6 = compiler_end(node8, "test")

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -457,10 +457,8 @@ def test_extern_dnnl_mobilenet():
         batch_size=1, dtype='float32')
 
     mod = transform.AnnotateTarget(["dnnl"])(mod)
-    mod = transform.MergeCompilerRegions()
+    mod = transform.MergeCompilerRegions()(mod)
     mod = transform.PartitionGraph()(mod)
-    # FIXME(@comaniac): Still try to fuse global function when lowering
-    print(mod)
     i_data = np.random.uniform(0, 1, ishape).astype(dtype)
 
     ref_mod, params = relay.testing.mobilenet.get_workload(batch_size=1,

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -17,6 +17,7 @@
 """Unit tests for graph partitioning."""
 import os
 import sys
+
 import numpy as np
 import pytest
 
@@ -26,8 +27,12 @@ from tvm import relay
 from tvm import runtime
 from tvm.relay import transform
 from tvm.contrib import util
-from tvm.relay.op.annotation import compiler_begin, compiler_end
+from tvm.relay import transform
+from tvm.relay.backend import compile_engine
 from tvm.relay.expr_functor import ExprMutator
+from tvm.relay.op.annotation import compiler_begin, compiler_end
+from tvm.runtime import container
+
 
 # Leverage the pass manager to write a simple white list based annotator
 @transform.function_pass(opt_level=0)
@@ -188,6 +193,7 @@ def check_result(mod, map_inputs, out_shape, result, tol=1e-5, target="llvm",
         return lib
 
     def check_vm_result():
+        compile_engine.get().clear()
         with relay.build_config(opt_level=3):
             exe = relay.vm.compile(mod, target=target, params=params)
         code, lib = exe.save()
@@ -199,6 +205,7 @@ def check_result(mod, map_inputs, out_shape, result, tol=1e-5, target="llvm",
         tvm.testing.assert_allclose(out.asnumpy(), result, rtol=tol, atol=tol)
 
     def check_graph_runtime_result():
+        compile_engine.get().clear()
         with relay.build_config(opt_level=3):
             json, lib, param = relay.build(mod, target=target, params=params)
         lib = update_lib(lib)
@@ -449,10 +456,11 @@ def test_extern_dnnl_mobilenet():
     mod, params = relay.testing.mobilenet.get_workload(
         batch_size=1, dtype='float32')
 
-    op_list = ["nn.conv2d", "nn.dense", "nn.relu", "add"]
-    mod["main"] = relay.build_module.bind_params_by_name(mod["main"], params)
-    mod = WhiteListAnnotator(op_list, "dnnl")(mod)
+    mod = transform.AnnotateTarget(["dnnl"])(mod)
+    mod = transform.MergeCompilerRegions()
     mod = transform.PartitionGraph()(mod)
+    # FIXME(@comaniac): Still try to fuse global function when lowering
+    print(mod)
     i_data = np.random.uniform(0, 1, ishape).astype(dtype)
 
     ref_mod, params = relay.testing.mobilenet.get_workload(batch_size=1,

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -858,6 +858,7 @@ if __name__ == "__main__":
     test_extern_ccompiler_default_ops()
     test_extern_ccompiler()
     test_extern_dnnl()
+    # TODO(@comaniac, @zhiics): Fix constant node and re-open this case.
     #test_extern_dnnl_mobilenet()
     test_function_lifting()
     test_function_lifting_inline()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -456,6 +456,7 @@ def test_extern_dnnl_mobilenet():
     mod, params = relay.testing.mobilenet.get_workload(
         batch_size=1, dtype='float32')
 
+    mod["main"] = relay.build_module.bind_params_by_name(mod["main"], params)
     mod = transform.AnnotateTarget(["dnnl"])(mod)
     mod = transform.MergeCompilerRegions()(mod)
     mod = transform.PartitionGraph()(mod)


### PR DESCRIPTION
Since we are working on TRT support with BYOC infra, we added some features and fixed some bugs in AnnotateTarget and MergeCompilerRegion passes. Here are the change logs:

**Refactor 1**: Both AnnotateTarget and MergeCompilerRegion passes output a graph with all ops annotated. Ops that will be handled by TVM will also be annotated with target "default".
 - Accordingly, we don't need AnnotateRestDefault anymore.
 - Accordingly, we don't remove default annotation at the end of MergeCompilerRegion.
 - A workaround that adds a temporary pass to remove all default annotations. A TODO was added to remind us improving partition graph pass later.
 - Fixed the issue that AnnotateRestDefault mis-annotated composite functions (because we integrate this pass into AnnotateTarget.)
 - Fixed the namespace of MergeCompilerRegion.
 - Fixed type propagation and tuple bug in AnnotateTarget pass (@trevor-m ).

**Refactor 2**: Support multiple runs for AnnotateTarget. Users may run AnnotateTarget multiple times because different targets may need the Relay graph at different stage (e.g., before or after QnnCanonicalize pass). This refactor makes sure AnnotateTarget pass can handle a Relay graph that has been annotated.

**Refactor 3**:  Support Multiple Targets in AnnotateTarget pass. In case more than one targets can take the same Relay graph, we intend to run AnnotateTarget once to annotate all of them to open global optimization opportunities for future developments.
- Now AnnotateTarget takes either a target string or a list of targets. AnnotateTarget will invoke target specific op-based rule functions in order.
- Accordingly, now regions in AnnotateRegionSet also have target attribute.



cc @zhiics, @trevor-m, @mbaret, @manupa-arm 