### PR TITLE
[CI][DOCS] Make sure to refresh the cython part

### DIFF
--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -32,6 +32,7 @@ rm -rf docs/vta/tutorials
 # cleanup stale log files
 find . -type f -path "*.log" | xargs rm -f
 find . -type f -path "*.pyc" | xargs rm -f
+make cython3
 
 cd docs
 PYTHONPATH=`pwd`/../python make html

--- a/tests/scripts/task_sphinx_precheck.sh
+++ b/tests/scripts/task_sphinx_precheck.sh
@@ -23,7 +23,11 @@ set -o pipefail
 
 cleanup()
 {
-  rm -rf /tmp/$$.*
+    # cat error log if non zero exit
+    if [ $? ]; then
+        cat /tmp/$$.log.txt
+    fi
+    rm -rf /tmp/$$.*
 }
 trap cleanup 0
 
@@ -31,6 +35,7 @@ trap cleanup 0
 rm -rf docs/tutorials
 rm -rf docs/vta/tutorials
 find . -type f -path "*.pyc" | xargs rm -f
+make cython3
 
 echo "PreCheck sphinx doc generation WARNINGS.."
 cd docs


### PR DESCRIPTION
https://github.com/apache/incubator-tvm/issues/5285

Fixes a previous flaky error due to out-dated cython version in docs build. It happens rarely since we only infrequently updated the cython source