### PR TITLE
[BUGFIX] Fix CRT static test bug

### DIFF
--- a/apps/bundle_deploy/demo_static.c
+++ b/apps/bundle_deploy/demo_static.c
@@ -99,11 +99,11 @@ int main(int argc, char **argv) {
          max_index, max_iter);
   printf("timing: %.2f ms (create), %.2f ms (set_input), %.2f ms (run), "
          "%.2f ms (get_output), %.2f ms (destroy)\n",
-         (t1.tv_sec-t0.tv_sec)*1000000 + (t1.tv_usec-t0.tv_usec)/1000.f,
-         (t2.tv_sec-t1.tv_sec)*1000000 + (t2.tv_usec-t1.tv_usec)/1000.f,
-         (t3.tv_sec-t2.tv_sec)*1000000 + (t3.tv_usec-t2.tv_usec)/1000.f,
-         (t4.tv_sec-t3.tv_sec)*1000000 + (t4.tv_usec-t3.tv_usec)/1000.f,
-         (t5.tv_sec-t4.tv_sec)*1000000 + (t5.tv_usec-t4.tv_usec)/1000.f);
+         (t1.tv_sec-t0.tv_sec)*1000 + (t1.tv_usec-t0.tv_usec)/1000.f,
+         (t2.tv_sec-t1.tv_sec)*1000 + (t2.tv_usec-t1.tv_usec)/1000.f,
+         (t3.tv_sec-t2.tv_sec)*1000 + (t3.tv_usec-t2.tv_usec)/1000.f,
+         (t4.tv_sec-t3.tv_sec)*1000 + (t4.tv_usec-t3.tv_usec)/1000.f,
+         (t5.tv_sec-t4.tv_sec)*1000 + (t5.tv_usec-t4.tv_usec)/1000.f);
 
   return 0;
 }

--- a/apps/bundle_deploy/demo_static.c
+++ b/apps/bundle_deploy/demo_static.c
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <sys/time.h>
+#include <stdlib.h>
 #include <float.h>
 
 #include "bundle.h"
@@ -56,7 +57,7 @@ int main(int argc, char **argv) {
   DLDataType dtype = {kDLFloat, 32, 1};
   input.dtype = dtype;
   int64_t shape [4] = {1, 3, 224, 224};
-  input.shape = &shape;
+  input.shape = shape;
   input.strides = NULL;
   input.byte_offset = 0;
 
@@ -74,8 +75,8 @@ int main(int argc, char **argv) {
   output.ndim = 2;
   DLDataType out_dtype = {kDLFloat, 32, 1};
   output.dtype = out_dtype;
-  int64_t out_shape [2] = {1, OUTPUT_LEN};
-  output.shape = &out_shape;
+  int64_t out_shape[2] = {1, OUTPUT_LEN};
+  output.shape = out_shape;
   output.strides = NULL;
   output.byte_offset = 0;
 
@@ -103,6 +104,6 @@ int main(int argc, char **argv) {
          (t3.tv_sec-t2.tv_sec)*1000000 + (t3.tv_usec-t2.tv_usec)/1000.f,
          (t4.tv_sec-t3.tv_sec)*1000000 + (t4.tv_usec-t3.tv_usec)/1000.f,
          (t5.tv_sec-t4.tv_sec)*1000000 + (t5.tv_usec-t4.tv_usec)/1000.f);
-  
+
   return 0;
 }

--- a/apps/bundle_deploy/test_static.c
+++ b/apps/bundle_deploy/test_static.c
@@ -112,11 +112,11 @@ int main(int argc, char **argv) {
 
   printf("timing: %.2f ms (create), %.2f ms (set_input), %.2f ms (run), "
          "%.2f ms (get_output), %.2f ms (destroy)\n",
-         (t1.tv_sec-t0.tv_sec)*1000000 + (t1.tv_usec-t0.tv_usec)/1000.f,
-         (t2.tv_sec-t1.tv_sec)*1000000 + (t2.tv_usec-t1.tv_usec)/1000.f,
-         (t3.tv_sec-t2.tv_sec)*1000000 + (t3.tv_usec-t2.tv_usec)/1000.f,
-         (t4.tv_sec-t3.tv_sec)*1000000 + (t4.tv_usec-t3.tv_usec)/1000.f,
-         (t5.tv_sec-t4.tv_sec)*1000000 + (t5.tv_usec-t4.tv_usec)/1000.f);
+         (t1.tv_sec-t0.tv_sec)*1000 + (t1.tv_usec-t0.tv_usec)/1000.f,
+         (t2.tv_sec-t1.tv_sec)*1000 + (t2.tv_usec-t1.tv_usec)/1000.f,
+         (t3.tv_sec-t2.tv_sec)*1000 + (t3.tv_usec-t2.tv_usec)/1000.f,
+         (t4.tv_sec-t3.tv_sec)*1000 + (t4.tv_usec-t3.tv_usec)/1000.f,
+         (t5.tv_sec-t4.tv_sec)*1000 + (t5.tv_usec-t4.tv_usec)/1000.f);
 
   free(json_data);
   free(params_data);

--- a/apps/bundle_deploy/test_static.c
+++ b/apps/bundle_deploy/test_static.c
@@ -21,6 +21,8 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
 #include <sys/time.h>
 #include <sys/stat.h>
 
@@ -71,8 +73,8 @@ int main(int argc, char **argv) {
   input.ndim = 2;
   DLDataType dtype = {kDLFloat, 32, 1};
   input.dtype = dtype;
-  int64_t shape [2] = {10, 5};
-  input.shape = &shape;
+  int64_t shape[2] = {10, 5};
+  input.shape = shape;
   input.strides = NULL;
   input.byte_offset = 0;
 
@@ -90,15 +92,15 @@ int main(int argc, char **argv) {
   output.ndim = 2;
   DLDataType out_dtype = {kDLFloat, 32, 1};
   output.dtype = out_dtype;
-  int64_t out_shape [2] = {10, 5};
-  output.shape = &out_shape;
+  int64_t out_shape[2] = {10, 5};
+  output.shape = out_shape;
   output.strides = NULL;
   output.byte_offset = 0;
-  
+
   tvm_runtime_get_output(handle, 0, &output);
   gettimeofday(&t4, 0);
 
-  for (auto i = 0; i < 10 * 5; ++i) {
+  for (int i = 0; i < 10 * 5; ++i) {
     assert(fabs(output_storage[i] - result_storage[i]) < 1e-5f);
     if (fabs(output_storage[i] - result_storage[i]) >= 1e-5f) {
       printf("got %f, expected %f\n", output_storage[i], result_storage[i]);
@@ -118,6 +120,6 @@ int main(int argc, char **argv) {
 
   free(json_data);
   free(params_data);
-  
+
   return 0;
 }

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -32,6 +32,7 @@ rm -rf docs/vta/tutorials
 # cleanup stale log files
 find . -type f -path "*.log" | xargs rm -f
 find . -type f -path "*.pyc" | xargs rm -f
+make cython3
 
 cd docs
 PYTHONPATH=`pwd`/../python make html

--- a/tests/scripts/task_sphinx_precheck.sh
+++ b/tests/scripts/task_sphinx_precheck.sh
@@ -23,7 +23,11 @@ set -o pipefail
 
 cleanup()
 {
-  rm -rf /tmp/$$.*
+    # cat error log if non zero exit
+    if [ $? ]; then
+        cat /tmp/$$.log.txt
+    fi
+    rm -rf /tmp/$$.*
 }
 trap cleanup 0
 
@@ -31,6 +35,7 @@ trap cleanup 0
 rm -rf docs/tutorials
 rm -rf docs/vta/tutorials
 find . -type f -path "*.pyc" | xargs rm -f
+make cython3
 
 echo "PreCheck sphinx doc generation WARNINGS.."
 cd docs


### PR DESCRIPTION
Fixed a segfault caused by wrongly assigning the address of the array pointer to the shape instead of the array. This problem was revealed by a compiler warning .

This PR fixes the recent compiler flaky error on i386