### PR TITLE
[NODE] General serialzation of leaf objects into bytes.

### DIFF
--- a/python/tvm/ir/json_compact.py
+++ b/python/tvm/ir/json_compact.py
@@ -79,8 +79,16 @@ def create_updater_06_to_07():
             return item
         return _convert
 
+    def _update_global_key(item, _):
+        item["repr_str"] = item["global_key"]
+        del item["global_key"]
+        return item
+
     node_map = {
         # Base IR
+        "SourceName": _update_global_key,
+        "EnvFunc": _update_global_key,
+        "relay.Op": _update_global_key,
         "relay.TypeVar": _ftype_var,
         "relay.GlobalTypeVar": _ftype_var,
         "relay.Type": _rename("Type"),

--- a/src/ir/env_func.cc
+++ b/src/ir/env_func.cc
@@ -69,7 +69,7 @@ TVM_REGISTER_GLOBAL("ir.EnvFuncGetPackedFunc")
 
 TVM_REGISTER_NODE_TYPE(EnvFuncNode)
 .set_creator(CreateEnvNode)
-.set_global_key([](const Object* n) -> std::string {
+.set_repr_bytes([](const Object* n) -> std::string {
     return static_cast<const EnvFuncNode*>(n)->name;
   });
 

--- a/src/ir/op.cc
+++ b/src/ir/op.cc
@@ -223,7 +223,7 @@ ObjectPtr<Object> CreateOp(const std::string& name) {
 
 TVM_REGISTER_NODE_TYPE(OpNode)
 .set_creator(CreateOp)
-.set_global_key([](const Object* n) {
+.set_repr_bytes([](const Object* n) {
     return static_cast<const OpNode*>(n)->name;
   });
 

--- a/src/ir/span.cc
+++ b/src/ir/span.cc
@@ -56,7 +56,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 TVM_REGISTER_NODE_TYPE(SourceNameNode)
 .set_creator(GetSourceNameNode)
-.set_global_key([](const Object* n) {
+.set_repr_bytes([](const Object* n) {
     return static_cast<const SourceNameNode*>(n)->name;
   });
 

--- a/src/node/container.cc
+++ b/src/node/container.cc
@@ -48,7 +48,21 @@ struct StringObjTrait {
   }
 };
 
-TVM_REGISTER_REFLECTION_VTABLE(runtime::StringObj, StringObjTrait);
+struct RefToObjectPtr : public ObjectRef {
+  static ObjectPtr<Object> Get(const ObjectRef& ref) {
+    return GetDataPtr<Object>(ref);
+  }
+};
+
+TVM_REGISTER_REFLECTION_VTABLE(runtime::StringObj, StringObjTrait)
+.set_creator([](const std::string& bytes) {
+  return RefToObjectPtr::Get(runtime::String(bytes));
+})
+.set_repr_bytes([](const Object* n) -> std::string {
+  return GetRef<runtime::String>(
+      static_cast<const runtime::StringObj*>(n)).operator std::string();
+});
+
 
 struct ADTObjTrait {
   static constexpr const std::nullptr_t VisitAttrs = nullptr;

--- a/src/node/reflection.cc
+++ b/src/node/reflection.cc
@@ -178,13 +178,13 @@ ReflectionVTable* ReflectionVTable::Global() {
 
 ObjectPtr<Object>
 ReflectionVTable::CreateInitObject(const std::string& type_key,
-                                   const std::string& global_key) const {
+                                   const std::string& repr_bytes) const {
   uint32_t tindex = Object::TypeKey2Index(type_key);
   if (tindex >= fcreate_.size() || fcreate_[tindex] == nullptr) {
     LOG(FATAL) << "TypeError: " << type_key
                << " is not registered via TVM_REGISTER_NODE_TYPE";
   }
-  return fcreate_[tindex](global_key);
+  return fcreate_[tindex](repr_bytes);
 }
 
 class NodeAttrSetter : public AttrVisitor {

--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -32,6 +32,7 @@
 #include <tvm/ir/attrs.h>
 
 #include <string>
+#include <cctype>
 #include <map>
 
 #include "../support/base64.h"
@@ -44,6 +45,26 @@ inline std::string Type2String(const DataType& t) {
 
 inline DataType String2Type(std::string s) {
   return DataType(runtime::String2DLDataType(s));
+}
+
+inline std::string Base64Decode(std::string s) {
+  dmlc::MemoryStringStream mstrm(&s);
+  support::Base64InStream b64strm(&mstrm);
+  std::string output;
+  b64strm.InitPosition();
+  dmlc::Stream* strm = &b64strm;
+  strm->Read(&output);
+  return output;
+}
+
+inline std::string Base64Encode(std::string s) {
+  std::string blob;
+  dmlc::MemoryStringStream mstrm(&blob);
+  support::Base64OutStream b64strm(&mstrm);
+  dmlc::Stream* strm = &b64strm;
+  strm->Write(s);
+  b64strm.Finish();
+  return blob;
 }
 
 // indexer to index all the nodes
@@ -103,7 +124,10 @@ class NodeIndexer : public AttrVisitor {
         MakeIndex(const_cast<Object*>(kv.second.get()));
       }
     } else {
-      reflection_->VisitAttrs(node, this);
+      // if the node already have repr bytes, no need to visit Attrs.
+      if (!reflection_->GetReprBytes(node, nullptr)) {
+        reflection_->VisitAttrs(node, this);
+      }
     }
   }
 };
@@ -115,8 +139,8 @@ using AttrMap = std::map<std::string, std::string>;
 struct JSONNode {
   /*! \brief The type of key of the object. */
   std::string type_key;
-  /*! \brief The global key for global object. */
-  std::string global_key;
+  /*! \brief The str repr representation. */
+  std::string repr_bytes;
   /*! \brief the attributes */
   AttrMap attrs;
   /*! \brief keys of a map. */
@@ -127,8 +151,15 @@ struct JSONNode {
   void Save(dmlc::JSONWriter *writer) const {
     writer->BeginObject();
     writer->WriteObjectKeyValue("type_key", type_key);
-    if (global_key.size() != 0) {
-      writer->WriteObjectKeyValue("global_key", global_key);
+    if (repr_bytes.size() != 0) {
+      // choose to use str representation or base64, based on whether
+      // the byte representation is printable.
+      if (std::all_of(repr_bytes.begin(), repr_bytes.end(),
+                      [](char ch) { return std::isprint(ch); })) {
+        writer->WriteObjectKeyValue("repr_str", repr_bytes);
+      } else {
+        writer->WriteObjectKeyValue("repr_b64", Base64Encode(repr_bytes));
+      }
     }
     if (attrs.size() != 0) {
       writer->WriteObjectKeyValue("attrs", attrs);
@@ -145,15 +176,24 @@ struct JSONNode {
   void Load(dmlc::JSONReader *reader) {
     attrs.clear();
     data.clear();
-    global_key.clear();
+    repr_bytes.clear();
     type_key.clear();
+    std::string repr_b64, repr_str;
     dmlc::JSONObjectReadHelper helper;
     helper.DeclareOptionalField("type_key", &type_key);
-    helper.DeclareOptionalField("global_key", &global_key);
+    helper.DeclareOptionalField("repr_b64", &repr_b64);
+    helper.DeclareOptionalField("repr_str", &repr_str);
     helper.DeclareOptionalField("attrs", &attrs);
     helper.DeclareOptionalField("keys", &keys);
     helper.DeclareOptionalField("data", &data);
     helper.ReadAllFields(reader);
+
+    if (repr_str.size() != 0) {
+      CHECK_EQ(repr_b64.size(), 0U);
+      repr_bytes = std::move(repr_str);
+    } else if (repr_b64.size() != 0) {
+      repr_bytes = Base64Decode(repr_b64);
+    }
   }
 };
 
@@ -212,10 +252,8 @@ class JSONAttrGetter : public AttrVisitor {
       return;
     }
     node_->type_key = node->GetTypeKey();
-    node_->global_key = reflection_->GetGlobalKey(node);
-    // No need to recursively visit fields of global singleton
-    // They are registered via the environment.
-    if (node_->global_key.length() != 0) return;
+    // do not need to print additional things once we have repr bytes.
+    if (reflection_->GetReprBytes(node, &(node_->repr_bytes))) return;
 
     // populates the fields.
     node_->attrs.clear();
@@ -434,7 +472,7 @@ ObjectRef LoadJSON(std::string json_str) {
   for (const JSONNode& jnode : jgraph.nodes) {
     if (jnode.type_key.length() != 0) {
       ObjectPtr<Object> node =
-          reflection->CreateInitObject(jnode.type_key, jnode.global_key);
+          reflection->CreateInitObject(jnode.type_key, jnode.repr_bytes);
       nodes.emplace_back(node);
     } else {
       nodes.emplace_back(ObjectPtr<Object>());
@@ -447,9 +485,12 @@ ObjectRef LoadJSON(std::string json_str) {
 
   for (size_t i = 0; i < nodes.size(); ++i) {
     setter.node_ = &jgraph.nodes[i];
-    // do not need to recover content of global singleton object
-    // they are registered via the environment
-    if (setter.node_->global_key.length() == 0) {
+    // Skip the nodes that has an repr bytes representation.
+    // NOTE: the second condition is used to guard the case
+    // where the repr bytes itself is an empty string "".
+    if (setter.node_->repr_bytes.length() == 0 &&
+        nodes[i] != nullptr &&
+        !reflection->GetReprBytes(nodes[i].get(), nullptr)) {
       setter.Set(nodes[i].get());
     }
   }

--- a/tests/python/relay/test_json_compact.py
+++ b/tests/python/relay/test_json_compact.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import tvm
+from tvm import relay
 from tvm import te
 import json
 
@@ -108,6 +109,22 @@ def test_global_var():
     assert isinstance(tvar, tvm.ir.GlobalVar)
 
 
+def test_op():
+    nodes = [
+        {"type_key": ""},
+        {"type_key": "relay.Op",
+         "global_key": "nn.conv2d"}
+    ]
+    data = {
+        "root" : 1,
+        "nodes": nodes,
+        "attrs": {"tvm_version": "0.6.0"},
+        "b64ndarrays": [],
+    }
+    op = tvm.ir.load_json(json.dumps(data))
+    assert op == relay.op.get("nn.conv2d")
+
+
 def test_tir_var():
     nodes = [
         {"type_key": ""},
@@ -132,6 +149,7 @@ def test_tir_var():
 
 
 if __name__ == "__main__":
+    test_op()
     test_type_var()
     test_incomplete_type()
     test_func_tuple_type()

--- a/tests/python/unittest/test_node_reflection.py
+++ b/tests/python/unittest/test_node_reflection.py
@@ -89,7 +89,20 @@ def test_env_func():
     assert x.func(10) == 11
 
 
+def test_string():
+    # non printable str, need to store by b64
+    s1 = tvm.runtime.String("xy\x01z")
+    s2 = tvm.ir.load_json(tvm.ir.save_json(s1))
+    tvm.ir.assert_structural_equal(s1, s2)
+
+    # printable str, need to store by repr_str
+    s1 = tvm.runtime.String("xyz")
+    s2 = tvm.ir.load_json(tvm.ir.save_json(s1))
+    tvm.ir.assert_structural_equal(s1, s2)
+
+
 if __name__ == "__main__":
+    test_string()
     test_env_func()
     test_make_node()
     test_make_smap()


### PR DESCRIPTION
This PR refactors the serialization mechanism to support general
serialization of leaf objects into bytes.

The new feature superceded the original GetGlobalKey feature for singletons.
Added serialization support for runtime::String.

