### PR TITLE
[NDArray] Set NDArray::Container.shape_ in NDArray::FromDLPack

### DIFF
--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -208,6 +208,10 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
   // fill up content.
   data->manager_ctx = tensor;
   data->dl_tensor = tensor->dl_tensor;
+  // update shape_
+  data->shape_.resize(data->dl_tensor.ndim);
+  data->shape_.assign(data->dl_tensor.shape, data->dl_tensor.shape + data->dl_tensor.ndim);
+  data->dl_tensor.shape = data->shape_.data();
   return NDArray(GetObjectPtr<Object>(data));
 }
 


### PR DESCRIPTION
In some cases, the shape info in DLTensor.shape might not be dynamically allocated and may cease to exist after passing the DLTensor to NDArray. We can avoid this problem by setting NDArray::Container.shape_ at construction time and assign it back to DLTensor.shape.