### PR TITLE
[REFACTOR][IR] Remove PrimExpr from String

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -108,12 +108,6 @@ class PrimExpr : public BaseExpr {
    */
   TVM_DLL PrimExpr(float value);  // NOLINT(*)
 
-  /*!
-   * \brief construct from runtime String.
-   * \param value The value to be constructed.
-   */
-  TVM_DLL PrimExpr(runtime::String value);  // NOLINT(*)
-
   /*! \return the data type of this expression. */
   DataType dtype() const {
     return static_cast<const PrimExprNode*>(get())->dtype;

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -40,9 +40,6 @@ PrimExpr::PrimExpr(int32_t value)
 PrimExpr::PrimExpr(float value)
     : PrimExpr(FloatImm(DataType::Float(32), value)) {}
 
-PrimExpr::PrimExpr(runtime::String value)
-    : PrimExpr(tir::StringImmNode::make(value)) {}
-
 PrimExpr PrimExpr::FromObject_(ObjectRef ref) {
   using runtime::ObjectTypeChecker;
   if (auto* ptr = ref.as<tir::IterVarNode>()) {

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -137,7 +137,7 @@ Target CreateTarget(const std::string& target_name,
   } else if (target_name == "hybrid") {
     t->device_type = kDLCPU;
   } else if (target_name == "hexagon") {
-    t->keys_array.push_back(runtime::String("hexagon"));
+    t->keys_array.push_back("hexagon");
     t->device_type = kDLHexagon;
   } else {
     LOG(ERROR) << "Unknown target name " << target_name;

--- a/topi/include/topi/contrib/cublas.h
+++ b/topi/include/topi/contrib/cublas.h
@@ -53,7 +53,7 @@ inline Tensor cublas_matmul(const Tensor& lhs,
     { { n, m } }, { lhs->dtype }, { lhs, rhs },
     [&](Array<Buffer> ins, Array<Buffer> outs) {
       return call_packed({
-        runtime::String("tvm.contrib.cublas.matmul"),
+        StringImmNode::make("tvm.contrib.cublas.matmul"),
         pack_buffer(ins[0]),
         pack_buffer(ins[1]),
         pack_buffer(outs[0]),
@@ -85,7 +85,7 @@ inline Tensor cublas_batch_matmul(const Tensor& lhs,
     { { b, n, m } }, { lhs->dtype }, { lhs, rhs },
     [&](Array<Buffer> ins, Array<Buffer> outs) {
       return call_packed({
-        runtime::String("tvm.contrib.cublas.batch_matmul"),
+        StringImmNode::make("tvm.contrib.cublas.batch_matmul"),
         pack_buffer(ins[0]),
         pack_buffer(ins[1]),
         pack_buffer(outs[0]),

--- a/topi/include/topi/contrib/rocblas.h
+++ b/topi/include/topi/contrib/rocblas.h
@@ -52,7 +52,7 @@ inline Tensor rocblas_matmul(const Tensor& lhs,
     { { n, m } }, { lhs->dtype }, { lhs, rhs },
     [&](Array<Buffer> ins, Array<Buffer> outs) {
       return call_packed({
-        runtime::String("tvm.contrib.rocblas.matmul"),
+        StringImmNode::make("tvm.contrib.rocblas.matmul"),
         pack_buffer(ins[0]),
         pack_buffer(ins[1]),
         pack_buffer(outs[0]),


### PR DESCRIPTION
Followup of #5250 

Actually only one node now is left that would use string. We can remove the constructor of PrimExpr from runtime String now.

@tqchen 