### PR TITLE
[Refactor] Add memoized expr translator for use by backend codegen

### DIFF
--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -21,29 +21,31 @@
  * \file relay/backend/compile_engine.cc
  * \brief Internal compialtion engine.
  */
+#include "compile_engine.h"
+
+#include <topi/tags.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/ir/type_functor.h>
-#include <tvm/te/schedule.h>
-#include <tvm/te/operation.h>
-#include <tvm/te/schedule_pass.h>
-#include <tvm/runtime/registry.h>
-#include <tvm/runtime/container.h>
-#include <tvm/relay/attrs/device_copy.h>
 #include <tvm/relay/analysis.h>
+#include <tvm/relay/attrs/device_copy.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/op.h>
 #include <tvm/relay/op_attr_types.h>
-#include <tvm/driver/driver_api.h>
+#include <tvm/runtime/container.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/te/operation.h>
+#include <tvm/te/schedule.h>
+#include <tvm/te/schedule_pass.h>
 
-#include <topi/tags.h>
-#include <utility>
+#include <functional>
 #include <limits>
 #include <mutex>
-#include <functional>
-#include <vector>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "compile_engine.h"
+#include "utils.h"
 
 namespace tvm {
 namespace relay {
@@ -111,8 +113,7 @@ Array<IndexExpr> GetShape(const Array<IndexExpr>& shape) {
 
 // The getter to get schedule from compile engine.
 // Get schedule from functor.
-class ScheduleGetter :
-      public ExprFunctor<Array<te::Tensor>(const Expr&)> {
+class ScheduleGetter : public backend::MemoizedExprTranslator<Array<te::Tensor>> {
  public:
   explicit ScheduleGetter(Target target)
       : target_(target), device_copy_op_(Op::Get("device_copy")) {}
@@ -177,17 +178,6 @@ class ScheduleGetter :
     }
     cache_node->schedule = std::move(schedule);
     return CachedFunc(cache_node);
-  }
-
-  Array<te::Tensor> VisitExpr(const Expr& expr) {
-    auto it = memo_.find(expr);
-    if (it != memo_.end()) {
-      return it->second;
-    } else {
-      Array<te::Tensor> res = ExprFunctor::VisitExpr(expr);
-      memo_[expr] = res;
-      return res;
-    }
   }
 
   Array<te::Tensor> VisitExpr_(const VarNode* op) final {
@@ -327,7 +317,6 @@ class ScheduleGetter :
   int master_op_pattern_{0};
   OpImplementation master_implementation_;
   std::ostringstream readable_name_stream_;
-  std::unordered_map<Expr, Array<te::Tensor>, ObjectHash, ObjectEqual> memo_;
   Array<te::Operation> scalars_;
   // Cache device copy op for equivalence checking to reduce registry lookup
   // overhead for each invocation of call node when retrieving schedules.
@@ -335,7 +324,7 @@ class ScheduleGetter :
 };
 
 // Creates shape function from functor.
-class MakeShapeFunc : public ExprFunctor<Array<te::Tensor>(const Expr&)> {
+class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> {
  public:
   MakeShapeFunc() {}
 
@@ -422,19 +411,14 @@ class MakeShapeFunc : public ExprFunctor<Array<te::Tensor>(const Expr&)> {
     return std::make_pair(schedule, cfunc);
   }
 
-  Array<te::Tensor> VisitExpr(const Expr& expr) {
-    auto it = memo_.find(expr);
-    if (it != memo_.end()) {
-      return it->second;
-    } else {
-      Array<te::Tensor> res = ExprFunctor::VisitExpr(expr);
-      if (expr.as<VarNode>() == nullptr) {
-        // Do not memoize vars because shape functions could use either the data
-        // or the shape of a var each time.
-        memo_[expr] = res;
-      }
-      return res;
+  Array<te::Tensor> VisitExpr(const Expr& expr) final {
+    if (expr.as<VarNode>()) {
+      // Do not memoize vars because shape functions could use either the data
+      // or the shape of a var each time.
+      return ExprFunctor::VisitExpr(expr);
     }
+    // For other case, do memoized visit
+    return backend::MemoizedExprTranslator<Array<te::Tensor>>::VisitExpr(expr);
   }
 
   Array<te::Tensor> VisitExpr_(const VarNode* var_node) final {
@@ -577,8 +561,6 @@ class MakeShapeFunc : public ExprFunctor<Array<te::Tensor>(const Expr&)> {
   std::unordered_map<Expr, Array<te::Tensor>, ObjectHash, ObjectEqual> param_data_;
   /*! \brief Map from parameter to list of shape placeholder */
   std::unordered_map<Expr, Array<te::Tensor>, ObjectHash, ObjectEqual> param_shapes_;
-  /*! \brief Memoized visit result */
-  std::unordered_map<Expr, Array<te::Tensor>, ObjectHash, ObjectEqual> memo_;
   /*! \brief Stack of data dependencies for shape function */
   std::vector<bool> data_dependants_;
   /*! \brief Scalars used in the shape function */

--- a/src/relay/backend/contrib/codegen_c/codegen.cc
+++ b/src/relay/backend/contrib/codegen_c/codegen.cc
@@ -40,17 +40,9 @@ using namespace backend;
  * purpose. Only several binary options are covered. Users
  * may need to extend them to cover more operators.
  */
-class CodegenC : public ExprFunctor<std::vector<Output>(const Expr&)>,
-                 public CodegenCBase {
+class CodegenC : public MemoizedExprTranslator<std::vector<Output>>, public CodegenCBase {
  public:
   explicit CodegenC(const std::string& id) { this->ext_func_id_ = id; }
-
-  std::vector<Output> VisitExpr(const Expr& expr) final {
-    if (visited_.count(expr)) return visited_.at(expr);
-    std::vector<Output> output = ExprFunctor::VisitExpr(expr);
-    visited_[expr] = output;
-    return output;
-  }
 
   std::vector<Output> VisitExprDefault_(const Object* op) final {
     LOG(FATAL) << "C codegen doesn't support: " << op->GetTypeKey();
@@ -208,8 +200,6 @@ class CodegenC : public ExprFunctor<std::vector<Output>(const Expr&)>,
   std::vector<std::string> func_decl_;
   /*! \brief The declaration statements of buffers. */
   std::vector<std::string> buf_decl_;
-  /*! \brief The name and index pairs for output. */
-  std::unordered_map<Expr, std::vector<Output>, ObjectHash, ObjectEqual> visited_;
 };
 
 class CSourceCodegen : public CSourceModuleCodegenBase {

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -128,17 +128,9 @@ std::vector<std::string> Add(const CallNode* call) {
 
 // TODO(@zhiics, @comaniac): This is a basic implementation. We should implement
 // all utilities and make a base class for users to implement.
-class CodegenDNNL : public ExprFunctor<std::vector<Output>(const Expr&)>,
-                    public CodegenCBase {
+class CodegenDNNL : public MemoizedExprTranslator<std::vector<Output>>, public CodegenCBase {
  public:
   explicit CodegenDNNL(const std::string& id) { this->ext_func_id_ = id; }
-
-  std::vector<Output> VisitExpr(const Expr& expr) final {
-    if (visited_.count(expr)) return visited_.at(expr);
-    std::vector<Output> output = ExprFunctor::VisitExpr(expr);
-    visited_[expr] = output;
-    return output;
-  }
 
   std::vector<Output> VisitExprDefault_(const Object* op) final {
     LOG(FATAL) << "DNNL codegen doesn't support: " << op->GetTypeKey();
@@ -343,8 +335,6 @@ class CodegenDNNL : public ExprFunctor<std::vector<Output>(const Expr&)>,
   std::vector<std::string> ext_func_body;
   /*! \brief The declaration of intermeidate buffers. */
   std::vector<std::string> buf_decl_;
-  /*! \brief The cached expressions. */
-  std::unordered_map<Expr, std::vector<Output>, ObjectHash, ObjectEqual> visited_;
 };
 
 /*!

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -244,11 +244,6 @@ class Interpreter :
     return VisitExpr(expr);
   }
 
-  ObjectRef VisitExpr(const Expr& expr) final {
-    auto ret = ExprFunctor<ObjectRef(const Expr& n)>::VisitExpr(expr);
-    return ret;
-  }
-
   ObjectRef VisitExpr_(const VarNode* var_node) final {
     return Lookup(GetRef<Var>(var_node));
   }


### PR DESCRIPTION
Related discussion: https://discuss.tvm.ai/t/missing-memoization-in-exprfunctor/6334

The rationale is two fold:
* Clean up existing code that has duplicated memo logic and unnecessary `VisitExpr(const Expr& n)` override
* More importantly, to remove the cognitive load of having to do memoization by external codegen implementers. Most likely any external codegen needs some memoization. It would be better to take care of this in the Relay side once for all, so that there would be no chance of forgetting to do memoization and having a bad time (which happened to me). 

please review @tqchen @zhiics 