### PR TITLE
[relay][topi] Add operation relay.nn.dilate() which calls topi.nn.dilate()

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -442,7 +442,6 @@ struct Conv2DTransposeAttrs : public tvm::AttrsNode<Conv2DTransposeAttrs> {
   }
 };
 
-////
 /*! \brief Attributes used in dilate operator */
 struct DilateAttrs : public tvm::AttrsNode<DilateAttrs> {
   Array<IndexExpr> strides;
@@ -452,7 +451,6 @@ struct DilateAttrs : public tvm::AttrsNode<DilateAttrs> {
       .describe("Dilation stride on each dimension, 1 means no dilation.");
   }
 };
-////
 
 /*! \brief Attributes used in 1D transposed convolution operator */
 struct Conv1DTransposeAttrs : public tvm::AttrsNode<Conv1DTransposeAttrs> {

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -442,6 +442,18 @@ struct Conv2DTransposeAttrs : public tvm::AttrsNode<Conv2DTransposeAttrs> {
   }
 };
 
+////
+/*! \brief Attributes used in dilate operator */
+struct DilateAttrs : public tvm::AttrsNode<DilateAttrs> {
+  Array<IndexExpr> strides;
+
+  TVM_DECLARE_ATTRS(DilateAttrs, "relay.attrs.DilateAttrs") {
+    TVM_ATTR_FIELD(strides).set_default(Array<IndexExpr>({1, 1}))
+      .describe("Dilation stride on each dimension, 1 means no dilation.");
+  }
+};
+////
+
 /*! \brief Attributes used in 1D transposed convolution operator */
 struct Conv1DTransposeAttrs : public tvm::AttrsNode<Conv1DTransposeAttrs> {
   IndexExpr channels;

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -464,7 +464,7 @@ def compute_dilate(attrs, inputs, out_dtype):
     return [topi.nn.dilate(inputs[0], attrs.strides)]
 
 reg.register_broadcast_schedule("nn.dilate")
-reg.register_pattern("nn.dilate", OpPattern.OPAQUE)
+reg.register_pattern("nn.dilate", OpPattern.INJECTIVE)
 
 
 # cross_entropy_with_logits

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -458,6 +458,15 @@ reg.register_reduce_schedule("nn.cross_entropy")
 reg.register_pattern("nn.cross_entropy", OpPattern.OPAQUE)
 
 
+# dilate
+@reg.register_compute("nn.dilate")
+def compute_dilate(attrs, inputs, out_dtype):
+    return [topi.nn.dilate(inputs[0], attrs.strides)]
+
+reg.register_broadcast_schedule("nn.dilate")
+reg.register_pattern("nn.dilate", OpPattern.OPAQUE)
+
+
 # cross_entropy_with_logits
 @reg.register_compute("nn.cross_entropy_with_logits")
 def compute_cross_entropy_with_logits(attrs, inputs, out_dtype):
@@ -652,6 +661,21 @@ def pad_shape_func(attrs, inputs, _):
     for pair in attrs.pad_width:
         pad_width.append(get_const_tuple(pair))
     return [_pad_shape_func(inputs[0], convert(pad_width))]
+
+@script
+def _dilate_shape_func(data_shape, strides):
+    out = output_tensor((data_shape.shape[0],), "int64")
+    for i in const_range(out.shape[0]):
+        out[i] = (data_shape[i] - 1) * strides[i] + 1
+
+    return out
+
+@reg.register_shape_func("nn.dilate", False)
+def dilate_shape_func(attrs, inputs, _):
+    """
+    Shape function for dilate op.
+    """
+    return [_dilate_shape_func(inputs[0], convert(attrs.strides))]
 
 reg.register_shape_func("nn.bias_add", False, elemwise_shape_func)
 reg.register_shape_func("nn.softmax", False, elemwise_shape_func)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1347,6 +1347,25 @@ def pad(data,
     return _make.pad(data, pad_width, pad_value, pad_mode)
 
 
+def dilate(data, strides):
+    """Dilate data with zeros.
+
+    Parameters
+    ----------
+    data : tvm.relay.Expr
+        n-D, can be any layout.
+
+    strides : <tuple of n <int>
+        Dilation stride on each dimension, 1 means no dilation.
+
+    Returns
+    -------
+    Output : tvm.relay.Expr
+        The computed result
+    """
+    return _make.dilate(data, strides)
+
+
 def mirror_pad(data,
                pad_width,
                mode="SYMMETRIC"):

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1355,7 +1355,7 @@ def dilate(data, strides):
     data : tvm.relay.Expr
         n-D, can be any layout.
 
-    strides : <tuple of n <int>
+    strides : <tuple of <int>
         Dilation stride on each dimension, 1 means no dilation.
 
     Returns

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -350,6 +350,11 @@ class Conv2DTransposeAttrs(Attrs):
     """Attributes used in Transposed Conv2D operators"""
 
 
+@tvm._ffi.register_object("relay.attrs.DilateAttrs")
+class DilateAttrs(Attrs):
+    """Attributes used in dilate operators"""
+
+
 @tvm._ffi.register_object("relay.attrs.SubPixelAttrs")
 class SubPixelAttrs(Attrs):
     """Attributes used in depth to space and space to depth operators"""

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -961,6 +961,56 @@ Do log on the data - do not accept logits.
 .add_type_rel("CrossEntropy", CrossEntropyRel);
 
 
+/////
+// relay.nn.dilate
+TVM_REGISTER_NODE_TYPE(DilateAttrs);
+
+bool DilateRel(const Array<Type>& types,
+                    int num_inputs,
+                    const Attrs& attrs,
+                    const TypeReporter& reporter) {
+  CHECK_EQ(types.size(), 2);
+  const auto* x = types[0].as<TensorTypeNode>();
+  const DilateAttrs* param = attrs.as<DilateAttrs>();
+  if (x == nullptr) return false;
+  CHECK_EQ(x->shape.size(), param->strides.size());
+
+  std::vector<IndexExpr> oshape;
+  for (size_t i = 0; i < param->strides.size(); ++i) {
+    if (!x->shape[i].as<tir::AnyNode>()) {
+      oshape.push_back((x->shape[i] - 1) * param->strides[i] + 1);
+    } else {
+      oshape.push_back(x->shape[i]);
+    }
+  }
+
+  reporter->Assign(types[1], TensorType(Array<IndexExpr>(oshape), x->dtype));
+  return true;
+}
+
+// Positional relay function to create dilate operator used by frontend FFI.
+Expr MakeDilate(Expr data, Array<IndexExpr> strides) {
+  auto attrs = make_object<DilateAttrs>();
+  attrs->strides = std::move(strides);
+  static const Op& op = Op::Get("nn.dilate");
+  return Call(op, {data}, Attrs(attrs), {});
+}
+
+
+TVM_REGISTER_GLOBAL("relay.op.nn._make.dilate")
+.set_body_typed(MakeDilate);
+
+
+RELAY_REGISTER_OP("nn.dilate")
+.describe(R"code(
+Dilate data with zeros.
+)code" TVM_ADD_FILELINE)
+.set_num_inputs(1)
+.add_argument("x", "1D Tensor", "Data to dilate.")
+.set_support_level(10)
+.add_type_rel("Dilate", DilateRel);
+/////
+
 // Positional relay function to create cross_entropy_with_logits operator used by frontend FFI.
 Expr MakeCrossEntropyWithLogits(Expr predictions, Expr targets) {
   static const Op& op = Op::Get("nn.cross_entropy_with_logits");

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -961,14 +961,13 @@ Do log on the data - do not accept logits.
 .add_type_rel("CrossEntropy", CrossEntropyRel);
 
 
-/////
 // relay.nn.dilate
 TVM_REGISTER_NODE_TYPE(DilateAttrs);
 
 bool DilateRel(const Array<Type>& types,
-                    int num_inputs,
-                    const Attrs& attrs,
-                    const TypeReporter& reporter) {
+               int num_inputs,
+               const Attrs& attrs,
+               const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 2);
   const auto* x = types[0].as<TensorTypeNode>();
   const DilateAttrs* param = attrs.as<DilateAttrs>();
@@ -1009,7 +1008,6 @@ Dilate data with zeros.
 .add_argument("x", "1D Tensor", "Data to dilate.")
 .set_support_level(10)
 .add_type_rel("Dilate", DilateRel);
-/////
 
 // Positional relay function to create cross_entropy_with_logits operator used by frontend FFI.
 Expr MakeCrossEntropyWithLogits(Expr predictions, Expr targets) {


### PR DESCRIPTION
Hi! I made this PR to add operation `dilate` into relay.

My main goal is to be able to implement a complete version of `conv2d_transpose` in relay which supports all values for groups, dilations, output padding and strides (code based on Theano mplementation: https://github.com/Theano/Theano/blob/master/theano/tensor/nnet/abstract_conv.py#L2927 ). I needed operation `dilation` to do that:

```python
from tvm import relay


def conv2d_transpose(
    input_shape, kern_shape, strides, padding, dilation, output_padding, groups
):
    h_out = (
        (input_shape[2] - 1) * strides[0]
        - 2 * padding[0]
        + dilation[0] * (kern_shape[2] - 1)
        + output_padding[0]
        + 1
    )
    w_out = (
        (input_shape[3] - 1) * strides[1]
        - 2 * padding[1]
        + dilation[1] * (kern_shape[3] - 1)
        + output_padding[1]
        + 1
    )

    data = relay.var("data", shape=input_shape)
    weight = relay.var("weight", shape=kern_shape)
    data_dilated = relay.nn.dilate(data, (1, 1) + strides)
    data_padded = relay.nn.pad(
        data_dilated,
        ((0, 0), (0, 0), (0, output_padding[0]), (0, output_padding[1]),),
    )

    # Pre-process kernel,
    # from (m0, m1, m2, m3) to (m1 * g, m0 // g, m2, m3).
    mshp0 = kern_shape[0] // groups
    c_out = kern_shape[1] * groups
    kern = relay.reshape(weight, (groups, mshp0) + kern_shape[1:])
    # => (g, m0 // g, m1, m2, m3)
    kern = relay.op.transpose(kern, axes=(1, 0, 2, 3, 4))
    # => (m0 // g, g, m1, m2, m3)
    kern = relay.reshape(kern, (mshp0, c_out, kern_shape[-2], kern_shape[-1]))
    # => (m0 // g, m1 * g, m2, m3)
    kern = relay.op.transpose(kern, (1, 0, 2, 3))
    # => (m1 * g, m0 // g, m2, m3)
    # Kernel 2 latest dimensions must be flipped
    kern = relay.op.transform.reverse(kern, 2)
    kern = relay.op.transform.reverse(kern, 3)
    # End pre-processing kernel.

    img = relay.nn.conv2d(
        data_padded,
        kern,
        groups=groups,
        channels=c_out,
        padding=[(kern_shape[2 + i] - 1) * dilation[i] for i in range(2)],
        dilation=dilation,
    )

    if any(p != 0 for p in padding):
        img = relay.op.transform.strided_slice(
            data=img,
            begin=[0, 0, padding[0], padding[1]],
            end=[None, None, h_out + padding[0], w_out + padding[1],],
        )

    f = relay.Function([data, weight], img)
    return f

```