### PR TITLE
[PYTHON] Enhance with_attr API, cleanup MakeAPILegacy in testcases

### DIFF
--- a/python/tvm/relay/function.py
+++ b/python/tvm/relay/function.py
@@ -65,22 +65,3 @@ class Function(BaseFunc):
             Arguments.
         """
         return Call(self, args, None, None)
-
-    def with_attr(self, attr_key, attr_value):
-        """Create a new copy of the function and update the attribute
-
-        Parameters
-        ----------
-        attr_key : str
-            The attribute key to use.
-
-        attr_value : Object
-            The new attribute value.
-
-        Returns
-        -------
-        func : Function
-            A new copy of the function
-        """
-        return _ffi_api.FunctionWithAttr(
-            self, attr_key, convert(attr_value))

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -168,41 +168,4 @@ def check_numerical_grads(function, input_values, grad_values, function_value=No
                      x_name, grad.shape, dist, max_diff, avg_diff)
 
 
-def MakeAPILegacy(stmt, name, args, num_unpacked_args, noalias):
-    """Legacy adapter to build a Module from statement.
-
-    Used for migrating existing test cases only.
-
-    Parameters
-    ----------
-    stmt: Stmt
-        The input statement.
-
-    name: str
-        The name of the funciton.
-
-    args: list of Buffer or Vars
-        The function arguments
-
-    num_unpacked_args: int
-        Number of unpacked arguments.
-
-    nolias: bool
-        Whether allow noalias.
-
-    Returns
-    -------
-    mod : IRModule
-        The created IRModule.
-    """
-    assert num_unpacked_args == 0
-    f = tvm.tir.PrimFunc(args, stmt).with_attr(
-        "global_symbol", tvm.runtime.String(name))
-    f = f.with_attr("tir.is_entry_func", True)
-    if noalias:
-        f = f.with_attr("tir.noalias", True)
-    mod = tvm.IRModule({name: f})
-    return mod
-
-
 tvm._ffi._init_api("testing", __name__)

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -67,22 +67,3 @@ class PrimFunc(BaseFunc):
 
         self.__init_handle_by_constructor__(
             _ffi_api.PrimFunc, param_list, body, ret_type, buffer_map, attrs)
-
-    def with_attr(self, attr_key, attr_value):
-        """Create a new copy of the function and update the attribute
-
-        Parameters
-        ----------
-        attr_key : str
-            The attribute key to use.
-
-        attr_value : Object
-            The new attribute value.
-
-        Returns
-        -------
-        func : Function
-            A new copy of the function
-        """
-        return _ffi_api.PrimFuncWithAttr(
-            self, attr_key, tvm.runtime.convert(attr_value))

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -362,13 +362,19 @@ IRModule IRModule::FromExpr(
   const tvm::Map<GlobalTypeVar, TypeData>& type_definitions) {
   auto mod = IRModule(global_funcs, type_definitions);
   BaseFunc func;
+  std::string gv_name = "main";
+
   if (auto* func_node = expr.as<BaseFuncNode>()) {
     func = GetRef<BaseFunc>(func_node);
+    if (auto opt = func->GetAttr<String>(tvm::attr::kGlobalSymbol)) {
+      gv_name = opt.value();
+    }
+
   } else {
     func = relay::Function(relay::FreeVars(expr), expr, Type(),
                            relay::FreeTypeVars(expr, mod), {});
   }
-  auto main_gv = GlobalVar("main");
+  auto main_gv = GlobalVar(gv_name);
   mod->Add(main_gv, func);
   return mod;
 }

--- a/src/relay/ir/function.cc
+++ b/src/relay/ir/function.cc
@@ -74,11 +74,5 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
             << node->attrs << ")";
 });
 
-TVM_REGISTER_GLOBAL("relay.ir.FunctionWithAttr")
-.set_body_typed(
-    [](Function func, std::string name, ObjectRef ref) {
-      return WithAttr(std::move(func), name, ref);
-    });
-
 }  // namespace relay
 }  // namespace tvm

--- a/src/tir/ir/function.cc
+++ b/src/tir/ir/function.cc
@@ -84,11 +84,5 @@ TVM_REGISTER_GLOBAL("tir.PrimFunc")
   return PrimFunc(params, body, ret_type, buffer_map, attrs);
 });
 
-
-TVM_REGISTER_GLOBAL("tir.PrimFuncWithAttr")
-.set_body_typed([](PrimFunc func, std::string name, ObjectRef ref) {
-  return WithAttr(std::move(func), name, ref);
-});
-
 }  // namespace tir
 }  // namespace tvm

--- a/tests/python/unittest/test_runtime_extension.py
+++ b/tests/python/unittest/test_runtime_extension.py
@@ -39,7 +39,8 @@ def test_dltensor_compatible():
         A[i + 1] = A[i] + 1
     stmt = ib.get()
 
-    mod = tvm.testing.MakeAPILegacy(stmt, "arange", [Ab], 0, True)
+    mod = tvm.IRModule.from_expr(
+        tvm.tir.PrimFunc([Ab], stmt).with_attr("global_symbol", "arange"))
     f = tvm.build(mod, target="stackvm")
     a = tvm.nd.array(np.zeros(10, dtype=dtype))
     aview = MyTensorView(a)

--- a/tests/python/unittest/test_runtime_module_load.py
+++ b/tests/python/unittest/test_runtime_module_load.py
@@ -57,8 +57,11 @@ def test_dso_module_load():
             tvm.tir.Store(Ab.data,
                            tvm.tir.Load(dtype, Ab.data, i) + 1,
                            i + 1))
-        m = tvm.testing.MakeAPILegacy(stmt, "ramp", [Ab], 0, True)
-        m = tvm.driver.build(m, target="llvm")
+        mod = tvm.IRModule.from_expr(
+            tvm.tir.PrimFunc([Ab], stmt).with_attr(
+                "global_symbol", "main")
+        )
+        m = tvm.driver.build(mod, target="llvm")
         for name in names:
             m.save(name)
 

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -36,8 +36,11 @@ def test_llvm_intrin():
             "int32", "prefetch", args, tvm.tir.Call.Intrinsic, None, 0)))
     body = ib.get()
 
-    func = tvm.testing.MakeAPILegacy(body, "prefetch", [A], 0, True)
-    fcode = tvm.build(func, None, "llvm")
+    mod = tvm.IRModule.from_expr(
+        tvm.tir.PrimFunc([A], body).with_attr(
+            "global_symbol", "prefetch")
+    )
+    fcode = tvm.build(mod, None, "llvm")
 
 
 def test_llvm_overloaded_intrin():
@@ -111,8 +114,9 @@ def test_llvm_lookup_intrin():
     x = tvm.tir.call_llvm_intrin("uint8x8", "llvm.ctpop.v8i8", tvm.tir.const(1, 'uint32'), A[z])
     ib.emit(x)
     body = ib.get()
-    func = tvm.testing.MakeAPILegacy(body, "ctpop", [A], 0, True)
-    fcode = tvm.build(func, None, "llvm")
+    mod = tvm.IRModule.from_expr(
+        tvm.tir.PrimFunc([A], body).with_attr("global_symbol", "main"))
+    fcode = tvm.build(mod, None, "llvm")
 
 
 def test_llvm_large_uintimm():

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -277,7 +277,7 @@ def test_prim_func():
     assert func.buffer_map[func.params[2]].same_as(b)
 
     assert len(func.buffer_map) == 1
-    f2 = func.with_attr("calling_conv", 1)
+    f2 = func.with_attr({"calling_conv": 1, "tir.noalias": True})
     assert f2.attrs["calling_conv"].value == 1
     assert func.attrs is None
 

--- a/tests/python/unittest/test_tir_pass_storage_flatten.py
+++ b/tests/python/unittest/test_tir_pass_storage_flatten.py
@@ -92,7 +92,9 @@ def test_flatten_double_buffer():
     stmt = tvm.tir.ir_pass.Simplify(stmt)
     assert isinstance(stmt.body.body, tvm.tir.Allocate)
     assert stmt.body.body.extents[0].value == 2
-    mod = tvm.testing.MakeAPILegacy(stmt, "db", [A.asobject(), C.asobject()], 0, True)
+
+    mod = tvm.IRModule.from_expr(
+        tvm.tir.PrimFunc([A, C], stmt).with_attr("global_symbol", "db"))
     f = tvm.tir.transform.ThreadSync("shared")(mod)["db"]
 
     count = [0]

--- a/tests/python/unittest/test_tir_transform_lower_warp_memory.py
+++ b/tests/python/unittest/test_tir_transform_lower_warp_memory.py
@@ -43,7 +43,7 @@ def test_lower_warp_memory_local_scope():
     mod = tvm.tir.transform.Apply(lambda f: f.with_attr("target", cuda_target))(mod)
     fdevice = tvm.tir.transform.SplitHostDevice()(mod)["f_kernel0"]
     mod = tvm.IRModule.from_expr(fdevice)
-    fdevice = tvm.tir.transform.LowerWarpMemory()(mod)["main"]
+    fdevice = tvm.tir.transform.LowerWarpMemory()(mod)["f_kernel0"]
     assert(fdevice.body.body.value.value == "local")
     assert(fdevice.body.body.body.extents[0].value == 2)
 

--- a/tests/python/unittest/test_tir_transform_make_packed_api.py
+++ b/tests/python/unittest/test_tir_transform_make_packed_api.py
@@ -35,11 +35,11 @@ def test_makeapi():
     stmt = tvm.tir.ir_pass.StorageFlatten(stmt, {A: Ab, B:Bb, C:Cb}, 64)
 
     num_unpacked_args = 2
-    f = tvm.tir.PrimFunc([n, Ab, Bb, Cb], stmt)
-    f = f.with_attr("global_symbol", "myadd")
-    f = f.with_attr("target", tvm.target.create("llvm"))
-
-    mod = tvm.IRModule.from_expr(f)
+    mod = tvm.IRModule.from_expr(
+        tvm.tir.PrimFunc([n, Ab, Bb, Cb], stmt).with_attr({
+            "global_symbol": "main",
+            "target": tvm.target.create("llvm")
+        }))
     f = tvm.tir.transform.MakePackedAPI(num_unpacked_args)(mod)["main"]
     assert(len(f.params) == 7)
 


### PR DESCRIPTION
Related update: IRModule::FromExpr now respect the global_symbol attribute if it is available.