### PR TITLE
[CI] Fix build.sh to propagate --network=host to the docker build command

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -60,6 +60,7 @@ fi
 
 if [[ "$1" == "--net=host" ]]; then
     CI_DOCKER_EXTRA_PARAMS+=('--net=host')
+    CI_DOCKER_BUILD_EXTRA_PARAMS+=("--network=host")
     shift 1
 fi
 


### PR DESCRIPTION
This fixes a small issue that, when passing `--net=host` to build.sh, it needs to be also sent as --network=host to "docker build", so that both `build` and `run` will use the same network configuration.

Originally, this parameter was being sent only to `docker run`.

cc @tqchen 