### PR TITLE
[RUNTIME][CRT] scalar's ndim is 0

### DIFF
--- a/src/runtime/crt/ndarray.c
+++ b/src/runtime/crt/ndarray.c
@@ -68,15 +68,15 @@ int TVMNDArray_Load(TVMNDArray * ret, const char ** strm) {
   ctx = ((DLContext*)*strm)[0]; *strm += sizeof(ctx);  // NOLINT(*)
   ndim = ((uint32_t*)*strm)[0]; *strm += sizeof(ndim);  // NOLINT(*)
   dtype = ((DLDataType*)*strm)[0]; *strm += sizeof(dtype);  // NOLINT(*)
-  if ((ndim <= 0) || (ndim > TVM_CRT_MAX_NDIM)) {
-    fprintf(stderr, "Invalid ndim=%d: expected to be 1 ~ %d.\n", ndim, TVM_CRT_MAX_NDIM);
+  if ((ndim < 0) || (ndim > TVM_CRT_MAX_NDIM)) {
+    fprintf(stderr, "Invalid ndim=%d: expected to be 0 ~ %d.\n", ndim, TVM_CRT_MAX_NDIM);
     status = -1;
   }
   if (ctx.device_type != kDLCPU) {
     fprintf(stderr, "Invalid DLTensor context: can only save as CPU tensor\n");
     status = -1;
   }
-  int64_t shape[TVM_CRT_MAX_NDIM];
+  int64_t shape[TVM_CRT_MAX_NDIM] = {0};
   uint32_t idx;
   if (ndim != 0) {
     for (idx = 0; idx < ndim; idx++) {


### PR DESCRIPTION
If a DLTensor is scalar, its ndim is 0 indeed. It's not a error. and google's mobilenet v1 quantize model 's params contains scalar, when I build it with tvm/apps/bundle_deploy, CRT report ndim == 0.

The model's address is 
https://storage.googleapis.com/download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz


I init shape array because it is only inited when ndim != 0, if ndim == 0, it contains rubbish data.