### PR TITLE
[BYOC][FIX] Fix typo in "default"

### DIFF
--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -63,7 +63,7 @@ class AnnotateTargetWrapper : public ExprMutator {
     std::string ref_target = "";
     Array<Expr> compiler_ends;
     for (auto arg : args) {
-      std::string arg_target = "defualt";
+      std::string arg_target = "default";
       const CallNode* call = arg.as<CallNode>();
 
       if (call && call->op == compiler_begin_op) {


### PR DESCRIPTION
Default annotations were incorrectly being named 'defualt' which results in them not being removed in PartitionGraph.