### PR TITLE
[TOPI-ARM] Do not alter layout if layout is NHWC

### DIFF
--- a/topi/python/topi/arm_cpu/conv2d_alter_op.py
+++ b/topi/python/topi/arm_cpu/conv2d_alter_op.py
@@ -59,6 +59,10 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
     data, kernel = tinfos
     out_dtype = out_type.dtype
 
+    # We only perform layout alteration for NCHW data layout.
+    if data_layout == "NHWC":
+        return None
+
     # Extract data types
     data_tensor, kernel_tensor = tinfos
     data_dtype = data_tensor.dtype


### PR DESCRIPTION
@icemelon9 I think we missed this piece while working on op strategy.

Currently, anybody running NHWC conv on ARM results in a compilation failure - also reported at https://discuss.tvm.ai/t/issue-in-alter-conv2d-layout-for-arm-cpu/6383

There might be a way to improve the NHWC ARM schedule and use alter_op_layout to alter kernel layout, but it needs work. @jackwish @FrozenGene Can you take a look? Meanwhile, we can push this PR to suppress the error.