### PR TITLE
[QNN] Support CallNode inputs in qnn.concatenate

### DIFF
--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -180,9 +180,9 @@ def concatenate(data,
         The concatenated quantized tensor.
     """
 
-    if type(data) in (list, tuple):
+    if isinstance(data, list)  or isinstance(data, tuple):
         data = Tuple(data)
-    if type(data) == TupleWrapper:
+    if isinstance(data, TupleWrapper):
         data = data.tuple_value
     if not isinstance(axis, int):
         raise ValueError("For now, we only support integer axis")

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -182,7 +182,7 @@ def concatenate(data,
 
     if isinstance(data, (list, tuple)):
         data = Tuple(data)
-    if isinstance(data, TupleWrapper):
+    elif isinstance(data, TupleWrapper):
         data = data.tuple_value
     if not isinstance(axis, int):
         raise ValueError("For now, we only support integer axis")

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -18,7 +18,7 @@
 """QNN dialect operators."""
 
 from __future__ import absolute_import as _abs
-from tvm.relay.expr import Tuple
+from tvm.relay.expr import Tuple, TupleWrapper
 from tvm.relay.op.nn.util import get_pad_tuple2d
 from . import _make
 
@@ -156,7 +156,7 @@ def concatenate(data,
 
     Parameters
     ----------
-    data : Union(List[relay.Expr], Tuple[relay.Expr])
+    data : Union(List[relay.Expr], Tuple[relay.Expr], TupleWrapper[relay.Expr])
         The list of quantized tensors.
 
     input_scales : List[relay.Expr]
@@ -180,15 +180,16 @@ def concatenate(data,
         The concatenated quantized tensor.
     """
 
-    data = list(data)
-    if not data:
-        raise ValueError("relay.concatenate requires data to be non-empty.")
+    if type(data) in (list, tuple):
+        data = Tuple(data)
+    if type(data) == TupleWrapper:
+        data = data.tuple_value
     if not isinstance(axis, int):
         raise ValueError("For now, we only support integer axis")
     input_scales = list(input_scales)
     input_zero_points = list(input_zero_points)
 
-    return _make.concatenate(Tuple(data),
+    return _make.concatenate(data,
                              Tuple(input_scales),
                              Tuple(input_zero_points),
                              output_scale,

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -180,7 +180,7 @@ def concatenate(data,
         The concatenated quantized tensor.
     """
 
-    if isinstance(data, list)  or isinstance(data, tuple):
+    if isinstance(data, (list, tuple)):
         data = Tuple(data)
     if isinstance(data, TupleWrapper):
         data = data.tuple_value

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -154,7 +154,7 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
     tuple_exprs = data.as<TupleNode>()->fields;
   }
   // if the data is a CallNode, use TupleGetItems
-  if (data->IsInstance<CallNode>()) {
+  else if (data->IsInstance<CallNode>()) {
     auto call = Downcast<Call>(data);
     for (size_t i=0; i < tuple_type->fields.size(); i++) {
       tuple_exprs.push_back(TupleGetItem(call, i));

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -154,7 +154,7 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
     tuple_exprs = data.as<TupleNode>()->fields;
   } else if (data->IsInstance<CallNode>()) {  // if the data is a CallNode, use TupleGetItems
     auto call = Downcast<Call>(data);
-    for (size_t i=0; i < tuple_type->fields.size(); i++) {
+    for (size_t i = 0; i < tuple_type->fields.size(); i++) {
       tuple_exprs.push_back(TupleGetItem(call, i));
     }
   }

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -156,7 +156,7 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   // if the data is a CallNode, use TupleGetItems
   if (data->IsInstance<CallNode>()) {
     auto call = Downcast<Call>(data);
-    for (size_t i=0;i<tuple_type->fields.size();i++) {
+    for (size_t i=0; i < tuple_type->fields.size(); i++) {
       tuple_exprs.push_back(TupleGetItem(call, i));
     }
   }

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -152,7 +152,7 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   Array<Expr> tuple_exprs;
   if (data->IsInstance<TupleNode>()) {
     tuple_exprs = data.as<TupleNode>()->fields;
-  } else if (data->IsInstance<CallNode>()) { // if the data is a CallNode, use TupleGetItems
+  } else if (data->IsInstance<CallNode>()) {  // if the data is a CallNode, use TupleGetItems
     auto call = Downcast<Call>(data);
     for (size_t i=0; i < tuple_type->fields.size(); i++) {
       tuple_exprs.push_back(TupleGetItem(call, i));

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -152,9 +152,7 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   Array<Expr> tuple_exprs;
   if (data->IsInstance<TupleNode>()) {
     tuple_exprs = data.as<TupleNode>()->fields;
-  }
-  // if the data is a CallNode, use TupleGetItems
-  else if (data->IsInstance<CallNode>()) {
+  } else if (data->IsInstance<CallNode>()) { // if the data is a CallNode, use TupleGetItems
     auto call = Downcast<Call>(data);
     for (size_t i=0; i < tuple_type->fields.size(); i++) {
       tuple_exprs.push_back(TupleGetItem(call, i));

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -149,8 +149,18 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   // If the output qnn params do not match the input qnn params, we can call requantize on the input
   // expr first, followed by a concatenate on the requantized input exprs.
 
-  auto tuple_data = data.as<TupleNode>();
-  CHECK(tuple_data != nullptr);
+  Array<Expr> tuple_exprs;
+  if (data->IsInstance<TupleNode>()) {
+    tuple_exprs = data.as<TupleNode>()->fields;
+  }
+  // if the data is a CallNode, use TupleGetItems
+  if (data->IsInstance<CallNode>()) {
+    auto call = Downcast<Call>(data);
+    for (size_t i=0;i<tuple_type->fields.size();i++) {
+      tuple_exprs.push_back(TupleGetItem(call, i));
+    }
+  }
+  CHECK(!tuple_exprs.empty());
 
   auto tuple_input_scales = input_scales.as<TupleNode>();
   CHECK(tuple_input_scales != nullptr);
@@ -160,7 +170,7 @@ Expr ConcatenateQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
 
   int idx = 0;
   Array<Expr> requantized_exprs;
-  for (auto quantized_expr : tuple_data->fields) {
+  for (auto quantized_expr : tuple_exprs) {
     // Get the input scale for the idx quantized input tensor.
     auto input_scale = tuple_input_scales->fields[idx];
 


### PR DESCRIPTION
Currently, qnn.concatenate assumes that its 1st arg (data) is a TupleNode. This may not necessarily be true if the input is a CallNode which returns a value of tuple-type. This patch handles the CallNode case by inserting TupleGetItemNodes.