### PR TITLE
[Topi, ARM] Disbale Winograd for quantized tensors.

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -69,11 +69,12 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                 # check if winograd algorithm is applicable
                 _, _, kh, kw = get_const_tuple(kernel.shape)
                 pt, pl, pb, pr = topi.nn.get_pad_tuple(padding, (kh, kw))
-                is_dtype_fp32 = data.dtype == "float32" and kernel.dtype == "float32"
-                is_winograd_applicable = kh == 3 and kw == 3 and \
+                is_winograd_applicable = "float" in data.dtype and \
+                                         "float" in kernel.dtype and \
+                                         kh == 3 and kw == 3 and \
                                          stride_h == 1 and stride_w == 1 and \
                                          dilation_h == 1 and dilation_w == 1
-                if is_dtype_fp32 and is_winograd_applicable:
+                if is_winograd_applicable:
                     strategy.add_implementation(
                         wrap_compute_conv2d(topi.arm_cpu.conv2d_nchw_winograd),
                         wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nchw_winograd),

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -59,16 +59,21 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                     wrap_compute_conv2d(topi.arm_cpu.conv2d_nchw_spatial_pack),
                     wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nchw_spatial_pack),
                     name="conv2d_nchw_spatial_pack.arm_cpu")
+
                 # Intel x86 conv2d schedule.
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.x86.conv2d_nchw),
                     wrap_topi_schedule(topi.x86.schedule_conv2d_nchw),
                     name="conv2d_nchw.x86")
+
                 # check if winograd algorithm is applicable
                 _, _, kh, kw = get_const_tuple(kernel.shape)
                 pt, pl, pb, pr = topi.nn.get_pad_tuple(padding, (kh, kw))
-                if kh == 3 and kw == 3 and stride_h == 1 and stride_w == 1 and \
-                    dilation_h == 1 and dilation_w == 1:
+                is_dtype_fp32 = data.dtype == "float32" and kernel.dtype == "float32"
+                is_winograd_applicable = kh == 3 and kw == 3 and \
+                                         stride_h == 1 and stride_w == 1 and \
+                                         dilation_h == 1 and dilation_w == 1
+                if is_dtype_fp32 and is_winograd_applicable:
                     strategy.add_implementation(
                         wrap_compute_conv2d(topi.arm_cpu.conv2d_nchw_winograd),
                         wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nchw_winograd),


### PR DESCRIPTION
Winograd Conv2D on integer tensors lead to bad accuracy. I think this is due to underlying maths that needs floating point multiplication or high precision computation. Enabling it only for FP32 tensors.

@masahi @FrozenGene @zhen-jia @u99127 

Without winograd, the TOP 5 labels for few images with class 0 label is 
~~~
1 [  0 389 391 758 394]
2 [390 394  48 103   0]
3 [  0 389 241 240  28]
4 [133 124 132 131 554]
5 [  0 389 390 939 391]
6 [  0 389  37 997 241]
7 [  0 758 389 391 696]
8 [  0 389 838 930 393]
9 [  0 389   1 395 758]
10 [  0 391 758 389 921]
11 [  0 389   1 391 395]
12 [  0 241 955 944 240]
13 [  0 389   5 393  57]
14 [758 391 346 268 395]
15 [  0 389   1 838 393]
16 [  0 389 241 838  28]
17 [  0 389   1 395  37]
~~~


With winograd, the TOP 5 labels for few images with class 0 label is 
~~~
1 [904 818 828 556 648]
2 [904 632 482 270 556]
3 [904 556 270 632 650]
4 [904 828 650 556 383]
5 [904 632 270 556 482]
6 [904 650 828 556 270]
7 [904 818 650 270 249]
8 [904 632 818  60 482]
9 [904 632 828 556 270]
10 [904 818 556 650 270]
11 [904 632 482 556 270]
12 [904 828 632 482 270]
13 [904 632 818 270 556]
14 [904 828 650 818 556]
15 [904 632 482  60 818]
~~~
Essentially, accuracy goes down to 0%
