### PR TITLE
[TIR] Fix lower_warp_memory when there are >1 warp buffers

### DIFF
--- a/src/tir/transforms/lower_warp_memory.cc
+++ b/src/tir/transforms/lower_warp_memory.cc
@@ -377,12 +377,13 @@ class WarpMemoryRewriter : private StmtMutator {
 
  private:
   Stmt VisitStmt_(const AllocateNode* op) {
+    auto ret = StmtMutator::VisitStmt_(op);
+    op = ret.as<AllocateNode>();
     if (warp_buffer_.count(op->buffer_var.get())) {
       WarpAccessRewriter rewriter(warp_size_, &analyzer_);
-      return StmtMutator::VisitStmt_(rewriter.Rewrite(op).as<AllocateNode>());
-    } else {
-      return StmtMutator::VisitStmt_(op);
+      ret = rewriter.Rewrite(op);
     }
+    return ret;
   }
 
   Stmt VisitStmt_(const AttrStmtNode* op) {

--- a/src/tir/transforms/lower_warp_memory.cc
+++ b/src/tir/transforms/lower_warp_memory.cc
@@ -379,7 +379,7 @@ class WarpMemoryRewriter : private StmtMutator {
   Stmt VisitStmt_(const AllocateNode* op) {
     if (warp_buffer_.count(op->buffer_var.get())) {
       WarpAccessRewriter rewriter(warp_size_, &analyzer_);
-      return rewriter.Rewrite(op);
+      return StmtMutator::VisitStmt_(rewriter.Rewrite(op).as<AllocateNode>());
     } else {
       return StmtMutator::VisitStmt_(op);
     }


### PR DESCRIPTION
Fix #5366.

Changes:

1. Fixed the recursion. (Just look at the code)
2. Added a test.

Requesting for a review. @tqchen