### PR TITLE
[KERAS]Minimum & AlphaDropout op support

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -186,8 +186,11 @@ def _convert_merge(inexpr, keras_layer, _):
     elif merge_type == 'Subtract':
         assert len(inexpr) == 2, "Subtract merge takes 2 inputs."
         ret = _op.subtract(ret, inexpr[1])
-    elif merge_type in ['Add', 'Multiply', 'Maximum']:
-        op_map = {'Add': _op.add, 'Multiply': _op.multiply, 'Maximum': _op.maximum}
+    elif merge_type in ['Add', 'Multiply', 'Minimum', 'Maximum']:
+        op_map = {'Add': _op.add,
+                  'Multiply': _op.multiply,
+                  'Minimum': _op.minimum,
+                  'Maximum': _op.maximum}
         for i in range(1, len(inexpr)):
             ret = op_map[merge_type](ret, inexpr[i])
     elif merge_type == 'Average':
@@ -902,6 +905,7 @@ _convert_map = {
     # 'TimeDistributed'        : _default_skip,
 
     'Average'                  : _convert_merge,
+    'Minimum'                  : _convert_merge,
     'Maximum'                  : _convert_merge,
     'Dot'                      : _convert_merge,
     'Permute'                  : _convert_permute,
@@ -910,6 +914,7 @@ _convert_map = {
 
     'InputLayer'               : _default_skip,
     'Dropout'                  : _default_skip,
+    'AlphaDropout'             : _default_skip,
     'SpatialDropout2D'         : _default_skip,
     'SpatialDropout1D'         : _default_skip,
     'GaussianDropout'          : _default_skip,

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -125,6 +125,7 @@ class TestKeras:
                     keras.layers.Subtract(),
                     keras.layers.Multiply(),
                     keras.layers.Maximum(),
+                    keras.layers.Minimum(),
                     keras.layers.Average(),
                     keras.layers.Concatenate()]
         for merge_func in merge_funcs:


### PR DESCRIPTION
Added support for merge operator `Minimum` and `AlphaDropout` in Keras frontend. 
@FrozenGene please help to review this PR and merge. Thanks.