### PR TITLE
[Runtime] Enable set_output in GraphRuntime

### DIFF
--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -133,6 +133,7 @@ class GraphModule(object):
         self.module = module
         self._set_input = module["set_input"]
         self._run = module["run"]
+        self._set_output = module["set_output"]
         self._get_output = module["get_output"]
         self._get_input = module["get_input"]
         self._get_num_outputs = module["get_num_outputs"]
@@ -162,6 +163,19 @@ class GraphModule(object):
             keys.sort(key=lambda x: -np.prod(params[x].shape))
             for k in keys:
                 self._get_input(k).copyfrom(params[k])
+
+    def set_output(self, index, out):
+        """Set index-th output to out
+
+        Parameters
+        ----------
+        index : int
+            The output index
+
+        out : NDArray
+            The output array container
+        """
+        return self._set_output(index, out)
 
     def run(self, **input_dict):
         """Run forward execution of the graph

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -149,6 +149,8 @@ void GraphRuntime::SetOutput(int index, DLTensor* data_out) {
   }
 
   const_cast<DLTensor*>(old_t)->data = data_out->data;
+  const_cast<DLTensor*>(old_t)->strides = data_out->strides;
+  const_cast<DLTensor*>(old_t)->byte_offset = data_out->byte_offset;
 }
 /*!
  * \brief Get the number of outputs

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -67,7 +67,7 @@ struct TVMOpParam {
  */
 class TVM_DLL GraphRuntime : public ModuleNode {
   struct OpArgs {
-    std::vector<DLTensor> args;
+    std::vector<DLTensor*> args;
     std::vector<TVMValue> arg_values;
     std::vector<int> arg_tcodes;
     std::vector<int64_t> shape_data;
@@ -384,7 +384,7 @@ class TVM_DLL GraphRuntime : public ModuleNode {
    * \return The created executor.
    */
   std::pair<std::function<void()>, std::shared_ptr<OpArgs> > CreateTVMOp(
-      const TVMOpParam& attrs, const std::vector<DLTensor>& args,
+      const TVMOpParam& attrs, const std::vector<DLTensor*>& args,
       size_t num_inputs);
   // Get node entry index.
   uint32_t entry_id(uint32_t nid, uint32_t index) const {

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -124,6 +124,12 @@ class TVM_DLL GraphRuntime : public ModuleNode {
    */
   void SetInputZeroCopy(int index, DLTensor* data_ref);
   /*!
+   * \brief set index-th output to the graph
+   * \param index The output index.
+   * \param data_ref The output data that is written.
+   */
+  void SetOutput(int index, DLTensor* data_out);
+  /*!
    * \brief Get the number of outputs
    *
    * \return The number of outputs from graph.

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -159,6 +159,15 @@ TEST(Relay, BuildModule) {
   for (int i = 0; i < 6; ++i) {
     CHECK_LT(fabs(pY3[i] - (i + (i + 3) + (i + 4))), 1e-4);
   }
+  // attach an output and run it again
+  auto D = tvm::runtime::NDArray::Empty({2, 3}, {kDLFloat, 32, 1}, {kDLCPU, 0});
+  auto pD = (float*)D.ToDLPack()->dl_tensor.data;
+  auto set_output_f = run_mod.GetFunction("set_output", false);
+  set_output_f(0, &D.ToDLPack()->dl_tensor);
+  run_f();
+  for (int i = 0; i < 6; ++i) {
+    CHECK_LT(fabs(pD[i] - (i + (i + 3) + (i + 4))), 1e-4);
+  }
 }
 
 int main(int argc, char ** argv) {


### PR DESCRIPTION
set_output is enabled to redirect the output, with unnecessary copies saved. It can be regarded as the output version of set_input_zero_copy.
