### PR TITLE
[TIR] Enhance Substitute, python bindings for Substitute/PostOrderVisit

### DIFF
--- a/docs/api/python/tir.rst
+++ b/docs/api/python/tir.rst
@@ -38,3 +38,10 @@ tvm.tir.analysis
    :members:
    :imported-members:
    :autosummary:
+
+
+tvm.tir.stmt_functor
+--------------------
+.. automodule:: tvm.tir.stmt_functor
+   :members:
+   :autosummary:

--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -611,6 +611,10 @@ struct PackedFuncValueConverter<::tvm::runtime::String> {
   }
 };
 
+/*! \brief Helper to represent nullptr for optional. */
+struct NullOptType {
+};
+
 /*!
  * \brief Optional container that to represent to a Nullable variant of T.
  * \tparam T The original ObjectRef.
@@ -642,6 +646,8 @@ class Optional : public ObjectRef {
    * \param ptr
    */
   explicit Optional(ObjectPtr<Object> ptr) : ObjectRef(ptr) {}
+  /*! \brief Nullopt handling */
+  Optional(NullOptType) {}  // NOLINT(*)
   // nullptr handling.
   // disallow implicit conversion as 0 can be implicitly converted to nullptr_t
   explicit Optional(std::nullptr_t) {}
@@ -751,6 +757,7 @@ struct PackedFuncValueConverter<Optional<T>> {
 // expose the functions to the root namespace.
 using runtime::String;
 using runtime::Optional;
+constexpr runtime::NullOptType NullOpt{};
 }  // namespace tvm
 
 namespace std {

--- a/include/tvm/tir/ir_pass.h
+++ b/include/tvm/tir/ir_pass.h
@@ -82,40 +82,6 @@ bool ExprUseVar(const PrimExpr& e, const std::unordered_set<const VarNode*>& vse
 TVM_DLL Stmt ConvertSSA(Stmt stmt);
 
 /*!
- * \brief Substitute the var specified in key->var to be value.
- * \param stmt The source statement to be substituted
- * \param value_map The map of new values.
- * \return The converted form.
- */
-Stmt Substitute(Stmt stmt,
-                const std::unordered_map<const VarNode*, PrimExpr>& value_map);
-
-/*!
- * \brief Substitute the var specified in key->var to be value.
- * \param expr The source expression to be substituted
- * \param value_map The map of new values.
- * \return The converted expression.
- */
-PrimExpr Substitute(PrimExpr expr,
-                const std::unordered_map<const VarNode*, PrimExpr>& value_map);
-
-/*!
- * \brief Substitute the var specified in key->var to be value.
- * \param stmt The source statement to be substituted
- * \param value_map The map of new values.
- * \return The converted form.
- */
-Stmt Substitute(Stmt stmt, const Map<Var, PrimExpr>& value_map);
-
-/*!
- * \brief Substitute the var specified in key->var to be value.
- * \param expr The source expression to be substituted
- * \param value_map The map of new values.
- * \return The converted expression.
- */
-PrimExpr Substitute(PrimExpr expr, const Map<Var, PrimExpr>& value_map);
-
-/*!
  * \brief Verify if there is any argument bound to compact buffer.
  *
  * \param stmt The stmt to be verified.

--- a/python/tvm/te/hybrid/util.py
+++ b/python/tvm/te/hybrid/util.py
@@ -72,7 +72,7 @@ def _pruned_source(func):
 def replace_io(body, rmap):
     """Replacing tensors usage according to the dict given"""
     # pylint: disable=import-outside-toplevel
-    from tvm.tir import ir_pass
+    from tvm.tir import stmt_functor
 
     def replace(op):
         if isinstance(op, _stmt.Provide) and op.func in rmap.keys():
@@ -84,7 +84,7 @@ def replace_io(body, rmap):
                               _expr.Call.Halide, buf.op, buf.value_index)
         return None
 
-    return ir_pass.IRTransform(body, None, replace, ['Provide', 'Call'])
+    return stmt_functor.ir_transform(body, None, replace, ['Provide', 'Call'])
 
 
 def _is_tvm_arg_types(args):

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -48,3 +48,4 @@ from . import ir_builder
 from . import ir_pass
 from . import transform
 from . import analysis
+from . import stmt_functor

--- a/python/tvm/tir/stmt_functor.py
+++ b/python/tvm/tir/stmt_functor.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Statement functor utilities for IR transformations"""
+from . import _ffi_api
+
+
+def ir_transform(stmt, preorder, postorder, only_enable=None):
+    """Recursively visit and transform ir nodes in post DFS order.
+
+    Parameters
+    ----------
+    stmt : Stmt
+        The input to be transformed.
+
+    preorder: function
+        The function called in before recursive mutation
+        If preorder returns None, then the transform will proceed to recursive call.
+        If preorder returns a not None Stmt/Expr, the transformer will simply return it and
+        won't do further recursion.
+
+    postorder : function
+        The function called after recursive mutation.
+
+    only_enable : Optional[List[str]]
+        List of types that we only enable.
+
+    Returns
+    -------
+    result : Stmt
+        The result.
+    """
+    return _ffi_api.IRTransform(stmt, preorder, postorder, only_enable)
+
+
+def post_order_visit(stmt, fvisit):
+    """Recursively visit the ir in post DFS order node, apply fvisit
+       Each node is guaranteed to be visited only once.
+
+    Parameters
+    ----------
+    fvisit: function
+        The visitor function.
+    """
+    return _ffi_api.PostOrderVisit(stmt, fvisit)
+
+
+def substitute(node, vmap):
+    """ Substitute the var specified by vmap.
+
+    Parameters
+    ----------
+    node: ObjectRef
+        The input.
+
+    vmap : Dict[Var, PrimExpr]
+        The variable mapping.
+
+    Returns
+    -------
+    result : Stmt
+        The result.
+    """
+    return _ffi_api.Substitute(node, vmap)

--- a/src/te/autodiff/ad_util.cc
+++ b/src/te/autodiff/ad_util.cc
@@ -22,7 +22,7 @@
  * \brief Utility for tensor-level auto-differentiation.
  */
 #include <tvm/tir/expr.h>
-#include <tvm/tir/ir_pass.h>
+#include <tvm/tir/stmt_functor.h>
 #include <string>
 #include "ad_util.h"
 

--- a/src/te/operation/hybrid_op.cc
+++ b/src/te/operation/hybrid_op.cc
@@ -26,7 +26,6 @@
 #include <tvm/arith/analyzer.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/stmt_functor.h>
-#include <tvm/tir/ir_pass.h>
 #include <tvm/tir/analysis.h>
 #include <tvm/tir/op.h>
 #include <unordered_set>

--- a/src/te/operation/op_util.h
+++ b/src/te/operation/op_util.h
@@ -79,7 +79,7 @@ Stmt ReplaceTensor(Stmt stmt,
  * \param replace The replacement rule.
  */
 PrimExpr ReplaceTensor(PrimExpr expr,
-                   const std::unordered_map<Tensor, Tensor>& replace);
+                       const std::unordered_map<Tensor, Tensor>& replace);
 
 /*!
  * \brief Substitute the variables of stmt by value map.

--- a/src/te/operation/tensor_compute_op.cc
+++ b/src/te/operation/tensor_compute_op.cc
@@ -25,8 +25,9 @@
 #include <tvm/te/operation.h>
 #include <tvm/arith/analyzer.h>
 #include <tvm/tir/expr.h>
-#include <tvm/tir/ir_pass.h>
+#include <tvm/tir/stmt_functor.h>
 #include <unordered_set>
+
 #include "./op_util.h"
 #include "./compute_op.h"
 #include "../../arith/compute_expr.h"

--- a/src/tir/ir/data_layout.cc
+++ b/src/tir/ir/data_layout.cc
@@ -23,7 +23,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/data_layout.h>
-#include <tvm/tir/ir_pass.h>
+#include <tvm/tir/stmt_functor.h>
 #include <tvm/arith/analyzer.h>
 
 #include <cctype>

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -24,7 +24,7 @@
 #include <tvm/tir/expr.h>
 #include <tvm/tir/stmt.h>
 #include <tvm/tir/op.h>
-#include <tvm/tir/ir_pass.h>
+#include <tvm/tir/stmt_functor.h>
 #include <memory>
 #include <limits>
 #include "../pass/ir_util.h"
@@ -363,8 +363,8 @@ Array<PrimExpr> CommReducerNode::operator()(Array<PrimExpr> a, Array<PrimExpr> b
     value_map.Set(rhs[i], b[i]);
   }
   return UpdateArray(result, [&value_map] (const PrimExpr& e) {
-      return Substitute(e, value_map);
-    });
+    return Substitute(e, value_map);
+  });
 }
 
 TVM_REGISTER_GLOBAL("tir.CommReducer")

--- a/src/tir/pass/ffi_api.cc
+++ b/src/tir/pass/ffi_api.cc
@@ -32,26 +32,11 @@
 namespace tvm {
 namespace tir {
 
-TVM_REGISTER_GLOBAL("ir_pass.Substitute")
-.set_body([](TVMArgs args, TVMRetValue *ret) {
-    if (args[0].IsObjectRef<Stmt>()) {
-      *ret = Substitute(args[0].operator Stmt(), args[1].operator Map<Var, PrimExpr>());
-    } else {
-      *ret = Substitute(args[0].operator PrimExpr(), args[1].operator Map<Var, PrimExpr>());
-    }
-  });
+
 
 TVM_REGISTER_GLOBAL("ir_pass.ExprUseVar")
 .set_body([](TVMArgs args, TVMRetValue *ret) {
     *ret = ExprUseVar(args[0].operator PrimExpr(), args[1].operator Var());
-  });
-
-TVM_REGISTER_GLOBAL("ir_pass.PostOrderVisit")
-.set_body([](TVMArgs args, TVMRetValue *ret) {
-    PackedFunc f = args[1];
-    tir::PostOrderVisit(args[0], [f](const ObjectRef& n) {
-        f(n);
-      });
   });
 
 
@@ -63,7 +48,6 @@ TVM_REGISTER_GLOBAL("ir_pass.PostOrderVisit")
 
 REGISTER_PASS(ConvertSSA);
 REGISTER_PASS(VerifySSA);
-REGISTER_PASS(IRTransform);
 REGISTER_PASS(VerifyGPUCode);
 REGISTER_PASS(DecorateDeviceScope);
 REGISTER_PASS(VerifyCompactBuffer);

--- a/src/tir/pass/hoist_if_then_else.cc
+++ b/src/tir/pass/hoist_if_then_else.cc
@@ -159,7 +159,7 @@ Stmt update_for(const Stmt& parent_for_stmt, const Stmt& new_if_stmt) {
       }
     });
 
-  return IRTransform(parent_for_stmt, nullptr, replace_target_for, {"For"});
+  return IRTransform(parent_for_stmt, nullptr, replace_target_for, Array<String>{"For"});
 }
 
 // Remove IfThenElse node from a For node.
@@ -185,9 +185,9 @@ std::pair<Stmt, Stmt> RemoveIf(const Stmt& for_stmt, const Stmt& if_stmt) {
       }
     });
 
-  then_for = IRTransform(for_stmt, nullptr, replace_then_case, {"IfThenElse"});
+  then_for = IRTransform(for_stmt, nullptr, replace_then_case, Array<String>{"IfThenElse"});
   if (if_stmt.as<IfThenElseNode>()->else_case.defined()) {
-    else_for = IRTransform(for_stmt, nullptr, replace_else_case, {"IfThenElse"});
+    else_for = IRTransform(for_stmt, nullptr, replace_else_case, Array<String>{"IfThenElse"});
   }
 
   return std::make_pair(then_for, else_for);
@@ -408,7 +408,7 @@ Stmt IfThenElseHoist::PostOrderMutate(const Stmt& stmt) {
         *ret = new_for;
       }
     });
-  return IRTransform(stmt, nullptr, replace_top_for, {runtime::String("For")});
+  return IRTransform(stmt, nullptr, replace_top_for, Array<String>{"For"});
 }
 
 Stmt HoistIfThenElse(Stmt stmt) {

--- a/tests/python/unittest/test_target_codegen_cuda.py
+++ b/tests/python/unittest/test_target_codegen_cuda.py
@@ -201,7 +201,7 @@ def test_cuda_shuffle():
 
         def _transform(f, *_):
             return f.with_body(
-                tvm.tir.ir_pass.IRTransform(f.body, None, vectorizer, ['For']))
+                tvm.tir.stmt_functor.ir_transform(f.body, None, vectorizer, ['For']))
         return tvm.tir.transform.prim_func_pass(_transform, opt_level=0, name="MyVectorize")
 
     with tvm.target.build_config(add_lower_pass=[(1, MyVectorize())]):

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -685,7 +685,7 @@ def test_llvm_shuffle():
 
         def _transform(f, *_):
             return f.with_body(
-                tvm.tir.ir_pass.IRTransform(f.body, None, vectorizer, ['For']))
+                tvm.tir.stmt_functor.ir_transform(f.body, None, vectorizer, ['For']))
 
         return tvm.tir.transform.prim_func_pass(_transform, opt_level=0, name="my_vectorize")
 

--- a/tests/python/unittest/test_te_hybrid_script.py
+++ b/tests/python/unittest/test_te_hybrid_script.py
@@ -24,7 +24,7 @@ from tvm.te.hybrid.runtime import HYBRID_GLOBALS
 @pytest.mark.skip
 def run_and_check(func, args, var_dict={}, target='llvm', sch=None, outs=None):
     def tvm_val_2_py_val(val):
-        val = tvm.tir.ir_pass.Substitute(val, var_dict)
+        val = tvm.tir.stmt_functor.substitute(val, var_dict)
         val = tvm.arith.Analyzer().simplify(val)
         assert isinstance(val, (tvm.tir.IntImm,))
         return val.value

--- a/tests/python/unittest/test_te_schedule_bound_inference.py
+++ b/tests/python/unittest/test_te_schedule_bound_inference.py
@@ -148,8 +148,8 @@ def test_bound_fusesplit1():
             for k in range(1, 6):
                 vars = tvm.runtime.convert({split1: tvm.tir.const(i, "int32"), l: tvm.tir.const(j, "int32"), xo.var: tvm.tir.const(k, "int32")})
                 tvm.testing.assert_prim_expr_equal(
-                    tvm.tir.ir_pass.Substitute(bounds[A1.op.axis[0]].extent, vars),
-                    tvm.tir.ir_pass.Substitute(expected_extent, vars)
+                    tvm.tir.stmt_functor.substitute(bounds[A1.op.axis[0]].extent, vars),
+                    tvm.tir.stmt_functor.substitute(expected_extent, vars)
                 )
 
     tvm.testing.assert_prim_expr_equal(bounds[A1.op.axis[1]].extent, l)
@@ -170,10 +170,10 @@ def test_bound_fusesplit2():
     bounds = tvm.te.schedule.InferBound(s)
     assert isinstance(bounds, tvm.container.Map)
     vars = tvm.runtime.convert({xo.var: tvm.tir.const(5, "int32")})
-    tvm.testing.assert_prim_expr_equal(tvm.tir.ir_pass.Substitute(bounds[A1.op.axis[0]].min, vars), 2)
-    tvm.testing.assert_prim_expr_equal(tvm.tir.ir_pass.Substitute(bounds[A1.op.axis[1]].min, vars), 3)
-    tvm.testing.assert_prim_expr_equal(tvm.tir.ir_pass.Substitute(bounds[A1.op.axis[0]].extent, vars), 1)
-    tvm.testing.assert_prim_expr_equal(tvm.tir.ir_pass.Substitute(bounds[A1.op.axis[1]].extent, vars), 3)
+    tvm.testing.assert_prim_expr_equal(tvm.tir.stmt_functor.substitute(bounds[A1.op.axis[0]].min, vars), 2)
+    tvm.testing.assert_prim_expr_equal(tvm.tir.stmt_functor.substitute(bounds[A1.op.axis[1]].min, vars), 3)
+    tvm.testing.assert_prim_expr_equal(tvm.tir.stmt_functor.substitute(bounds[A1.op.axis[0]].extent, vars), 1)
+    tvm.testing.assert_prim_expr_equal(tvm.tir.stmt_functor.substitute(bounds[A1.op.axis[1]].extent, vars), 3)
 
 
 def test_bound_warp():

--- a/tests/python/unittest/test_te_schedule_ops.py
+++ b/tests/python/unittest/test_te_schedule_ops.py
@@ -155,7 +155,7 @@ def test_inline_mixed():
     def check(x):
         if isinstance(x, tvm.tir.Call):
             assert x.func != A2
-    tvm.tir.ir_pass.PostOrderVisit(s[C].op.body[0], check)
+    tvm.tir.stmt_functor.post_order_visit(s[C].op.body[0], check)
 
 
 def test_scan_inline1():
@@ -517,7 +517,7 @@ def test_local_stage_predicate():
 
     def collect_visit(stmt, f):
         ret = []
-        tvm.tir.ir_pass.PostOrderVisit(stmt, lambda x: ret.append(f(x)))
+        tvm.tir.stmt_functor.post_order_visit(stmt, lambda x: ret.append(f(x)))
         return ret
     # local vs. threadIdx
     s = schedule(tx, "local")
@@ -563,7 +563,7 @@ def test_local_stage_predicate2():
 
     def collect_visit(stmt, f):
         ret = []
-        tvm.tir.ir_pass.PostOrderVisit(stmt, lambda x: ret.append(f(x)))
+        tvm.tir.stmt_functor.post_order_visit(stmt, lambda x: ret.append(f(x)))
         return ret
 
     def visit_stmt(op):

--- a/tests/python/unittest/test_te_tensor.py
+++ b/tests/python/unittest/test_te_tensor.py
@@ -264,7 +264,7 @@ def test_tuple_with_different_deps():
            x.func == B1.op and x.value_index == 1:
             ret.append(x)
     ret = []
-    tvm.tir.ir_pass.PostOrderVisit(stmt, get_B1_realize)
+    tvm.tir.stmt_functor.post_order_visit(stmt, get_B1_realize)
 
     assert stmt.node == C.op and len(ret) == 1
 

--- a/tests/python/unittest/test_tir_pass_hoist_if.py
+++ b/tests/python/unittest/test_tir_pass_hoist_if.py
@@ -32,7 +32,7 @@ def verify_structure(stmt, expected_struct):
         key = op
         if isinstance(op, tvm.tir.IfThenElse):
             global var_list
-            tvm.tir.ir_pass.PostOrderVisit(op.condition, _extract_vars)
+            tvm.tir.stmt_functor.post_order_visit(op.condition, _extract_vars)
             val = [(op.then_case, op.else_case), ("IfThenElse", tuple(var_list))]
             var_list.clear()
         elif isinstance(op, tvm.tir.For):
@@ -43,7 +43,7 @@ def verify_structure(stmt, expected_struct):
             return
         node_dict[key] = val
 
-    tvm.tir.ir_pass.PostOrderVisit(stmt, _visit)
+    tvm.tir.stmt_functor.post_order_visit(stmt, _visit)
     for key, val in node_dict.items():
         struct[val[1]] = tuple(node_dict[child][1] if child in node_dict
                                else None for child in val[0])

--- a/tests/python/unittest/test_tir_pass_ir_transform.py
+++ b/tests/python/unittest/test_tir_pass_ir_transform.py
@@ -37,7 +37,7 @@ def test_ir_transform():
         if op.name == "TestA":
             return tvm.tir.call_extern("int32", "TestB", op.args[0] + 1)
         return op
-    body = tvm.tir.ir_pass.IRTransform(body, preorder, postorder, ["Call"])
+    body = tvm.tir.stmt_functor.ir_transform(body, preorder, postorder, ["Call"])
     stmt_list = tvm.tir.stmt_list(body.body.body)
     assert stmt_list[0].value.args[0].name == "TestB"
     assert stmt_list[1].value.value == 0

--- a/tests/python/unittest/test_tir_transform_inject_double_buffer.py
+++ b/tests/python/unittest/test_tir_transform_inject_double_buffer.py
@@ -54,7 +54,7 @@ def test_double_buffer():
     def count_sync(op):
         if isinstance(op, tvm.tir.Call) and op.name == "tvm_storage_sync":
             count[0] += 1
-    tvm.tir.ir_pass.PostOrderVisit(f.body, count_sync)
+    tvm.tir.stmt_functor.post_order_visit(f.body, count_sync)
     assert count[0] == 4
 
 

--- a/tests/python/unittest/test_tir_transform_instrument_bound_checkers.py
+++ b/tests/python/unittest/test_tir_transform_instrument_bound_checkers.py
@@ -21,7 +21,7 @@ import numpy as np
 
 def collect_visit(stmt, f):
     ret = []
-    tvm.tir.ir_pass.PostOrderVisit(stmt, lambda x: ret.append(f(x)))
+    tvm.tir.stmt_functor.post_order_visit(stmt, lambda x: ret.append(f(x)))
     return ret
 
 

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -20,7 +20,7 @@ import numpy
 
 def collect_visit(stmt, f):
     ret = []
-    tvm.tir.ir_pass.PostOrderVisit(stmt, lambda x : ret.append(f(x)))
+    tvm.tir.stmt_functor.post_order_visit(stmt, lambda x : ret.append(f(x)))
     return ret
 
 

--- a/tests/python/unittest/test_tir_transform_storage_flatten.py
+++ b/tests/python/unittest/test_tir_transform_storage_flatten.py
@@ -123,7 +123,7 @@ def test_flatten_double_buffer():
     def count_sync(op):
         if isinstance(op, tvm.tir.Call) and op.name == "tvm_storage_sync":
             count[0] += 1
-    tvm.tir.ir_pass.PostOrderVisit(f.body, count_sync)
+    tvm.tir.stmt_functor.post_order_visit(f.body, count_sync)
     assert count[0] == 4
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_transform_storage_rewrite.py
+++ b/tests/python/unittest/test_tir_transform_storage_rewrite.py
@@ -45,7 +45,7 @@ def test_storage_share():
     def verify(n):
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
     assert num_alloc[0] == 1
 
 def register_mem(scope_tb, max_bits):
@@ -84,7 +84,7 @@ def test_alloc_seq():
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
             assert n.extents[0].value == 200
-    tvm.tir.ir_pass.PostOrderVisit(body, verify)
+    tvm.tir.stmt_functor.post_order_visit(body, verify)
     assert num_alloc[0] == 1
 
 def test_alloc_different_dtypes():
@@ -139,7 +139,7 @@ def test_alloc_different_dtypes():
         mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], body))
         body = tvm.tir.transform.StorageRewrite()(mod)["main"].body
 
-        tvm.tir.ir_pass.PostOrderVisit(body, verify)
+        tvm.tir.stmt_functor.post_order_visit(body, verify)
 
     length = 1024
     dtype_list = ["float16", "int32", "uint16", "int8"]
@@ -181,7 +181,7 @@ def test_inplace_rule():
     def verify(n):
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
     assert num_alloc[0] == 2
 
 
@@ -214,7 +214,7 @@ def test_storage_combine():
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
             assert (n.extents[0].value == 16)
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
     assert num_alloc[0] == 1
 
 
@@ -250,7 +250,7 @@ def test_storage_share_gpu():
         if isinstance(n, tvm.tir.AttrStmt):
             if n.attr_key == "storage_scope":
                 alloc_stats[n.value.value] += 1
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
     assert alloc_stats["global"] == 2
     assert alloc_stats["shared"] == num_stage
 
@@ -318,7 +318,7 @@ def test_inplace_rule2(scope_tb = "local_TB2", max_bits = 1024 * 1024 * 1024):
     def verify(n):
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
     assert num_alloc[0] == 2
 
 def test_exceed_mem():
@@ -407,7 +407,7 @@ def test_inplace_rule3():
     def verify(n):
         if isinstance(n, tvm.tir.Allocate):
             assert n.extents[0].value == 70
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
 
 def test_alloc_seq_type():
     ib = tvm.tir.ir_builder.create()
@@ -437,7 +437,7 @@ def test_alloc_seq_type():
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
             assert n.extents[0].value == 500
-    tvm.tir.ir_pass.PostOrderVisit(body, verify)
+    tvm.tir.stmt_functor.post_order_visit(body, verify)
     assert num_alloc[0] == 1
 
 def test_alloc_seq_type2():
@@ -469,7 +469,7 @@ def test_alloc_seq_type2():
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
             assert n.extents[0].value == 200
-    tvm.tir.ir_pass.PostOrderVisit(body, verify)
+    tvm.tir.stmt_functor.post_order_visit(body, verify)
     assert num_alloc[0] == 1
 
 
@@ -502,7 +502,7 @@ def test_reuse_small_buffer():
         if isinstance(n, tvm.tir.Allocate):
             num_alloc[0] += 1
             assert n.extents[0].value == 800
-    tvm.tir.ir_pass.PostOrderVisit(body, verify)
+    tvm.tir.stmt_functor.post_order_visit(body, verify)
     assert num_alloc[0] == 1
 
 def test_replace_dataflow():
@@ -540,7 +540,7 @@ def test_large_input():
     def verify(n):
         if isinstance(n, tvm.tir.Allocate):
             assert n.extents[0].value == 268435456
-    tvm.tir.ir_pass.PostOrderVisit(stmt, verify)
+    tvm.tir.stmt_functor.post_order_visit(stmt, verify)
 
 
 if __name__ == "__main__":

--- a/tutorials/dev/low_level_custom_pass.py
+++ b/tutorials/dev/low_level_custom_pass.py
@@ -70,7 +70,7 @@ print(ir)
 #
 # IR Visitor
 # ~~~~~~~~~~
-# We can use ``tvm.tir.ir_pass.PostOrderVisit(stmt, func)`` to gather information from the Halide IR.
+# We can use ``tvm.tir.stmt_functor.post_order_visit(stmt, func)`` to gather information from the Halide IR.
 # ``func`` is a function callback. This function will be called before exiting the current IR node,
 # i.e. post-order visit. Then we leverage side effects to store the result of IR visit, because the
 # return value of ``func`` will be ignored.
@@ -111,7 +111,7 @@ def vectorize8(op):
         extent = op.extent.value
         name = op.loop_var.name
         lo, li = te.var(name + '.outer'), te.var(name + '.inner')
-        body = tvm.tir.ir_pass.Substitute(op.body, {op.loop_var: lo * 8 + li})
+        body = tvm.tir.stmt_functor.substitute(op.body, {op.loop_var: lo * 8 + li})
         body = tvm.tir.For(li, 0, 8, tvm.tir.For.Vectorized, 0, body)
         body = tvm.tir.For(lo, 0, extent // 8, tvm.tir.For.Serial, 0, body)
         return body
@@ -121,7 +121,7 @@ def vectorize8(op):
 def vectorize(f, mod, ctx):
     global loops
 
-    tvm.tir.ir_pass.PostOrderVisit(f.body, find_width8)
+    tvm.tir.stmt_functor.post_order_visit(f.body, find_width8)
 
     if not loops:
         return sf
@@ -129,7 +129,7 @@ def vectorize(f, mod, ctx):
     # The last list arugment indicates what kinds of nodes will be transformed.
     # Thus, in this case only `For` nodes will call `vectorize8`
     return f.with_body(
-        tvm.tir.ir_pass.IRTransform(f.body, None, vectorize8, ['For']))
+        tvm.tir.stmt_functor.ir_transform(f.body, None, vectorize8, ['For']))
 
 
 #####################################################################
@@ -161,8 +161,8 @@ with tvm.target.build_config(add_lower_pass=[(1, vectorize)]) as cfg:
 # Quick View
 # ----------
 # This tutorial gives a quick view of writing a customized IR transformation pass:
-# - Use ``tvm.tir.ir_pass.PostOrderVisit`` to gather information on each IR nodes.
-# - Use ``tvm.tir.ir_pass.IRTransform`` to transform IR nodes.
+# - Use ``tvm.tir.stmt_functor.post_order_visit`` to gather information on each IR nodes.
+# - Use ``tvm.tir.stmt_functor.ir_transform`` to transform IR nodes.
 # - Wrap up two above to write an IR-transformation function.
 # - Use ``tvm.target.build_config`` to put this function to TVM lowering pass
 #


### PR DESCRIPTION
Substitute now takes a std::function to customize more replacing behaviors.

Co-authored-by: Siyuan Feng <hzfengsy@sjtu.edu.cn>


