### PR TITLE
[RELAY][Convert Layout] Specify additional layouts in convert layout pass

### DIFF
--- a/docs/dev/convert_layout.rst
+++ b/docs/dev/convert_layout.rst
@@ -247,8 +247,10 @@ In order to specify the layouts to convert to, we create a mapping of heavily-la
 The example above only considers data layout, the kernel layout is automatically converted to one that is supported by TVM. If we wish to also convert to a specific kernel layout this can be done like so:
 
 .. code-block:: python
+
     desired_layouts = {'nn.conv2d': ['NCHW', 'HWIO']}
     pass = relay.transform.ConvertLayout(desired_layouts)
+
 
 If we wish to select the default choice for a specific layout then the layout should be declared as "default". In the first example, the kernel layout is implicitly defined as "default".
 

--- a/docs/dev/convert_layout.rst
+++ b/docs/dev/convert_layout.rst
@@ -258,7 +258,7 @@ The example above only considers data layout because the kernel layout is automa
 
 The ordering of layouts is defined by the implementation of `register_convert_op_layout("OPNAME")`, you can refer to the docstring which should explicitly state the expected layout. In the example above its [data_layout, kernel_layout].
 
-If we wish to select the default choice for a specific layout then the layout should be declared as "default". For nn.conv2d the following two statements are equivalent: `{'nn.conv2d': ['NCHW', 'default']} == {'nn.conv2d': ['NCHW', 'HWIO']}` since the default kernel layout in TVM is HWIO. In the first example, the kernel layout is implicitly defined as "default". The example below shows how this can be used:
+If we wish to select the default choice for a specific layout then the layout should be declared as "default". For nn.conv2d the following two statements are equivalent: `{'nn.conv2d': ['NHWC', 'default']} == {'nn.conv2d': ['NHWC', 'HWIO']}` since the default kernel layout in TVM is HWIO for NHWC. In the first example, the kernel layout is implicitly defined as "default". The example below shows how this can be used:
 
 .. code-block:: python
 

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -153,11 +153,13 @@ using FTVMAlterOpLayout =
  * \param tinfos An array of placeholders, use for getting the inferred shape
  *               and dtype of the inputs.
  * \param desired_layout The desired layout.
+ * \param additional_layouts Specify additional layouts, e.g. kernel_layout.
  * \return new_expr The modified expression.
  */
 using FTVMConvertOpLayout = runtime::TypedPackedFunc<Expr(
     const Attrs& attrs, const Array<Expr>& args, const Array<te::Tensor>& tinfos,
-    const std::string& desired_layout)>;
+    const std::string& desired_layout,
+       const Map<std::string, ObjectRef>& additional_layouts)>;
 /*!
  * \brief Legalizes an expression with another expression. This function will be
  *  invoked in Legalize pass. It is a target-dependent pass.

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -152,14 +152,14 @@ using FTVMAlterOpLayout =
  * \param inputs The input symbols of the original node.
  * \param tinfos An array of placeholders, use for getting the inferred shape
  *               and dtype of the inputs.
- * \param desired_layout The desired layout.
- * \param additional_layouts Specify additional layouts, e.g. kernel_layout.
+ * \param desired_layouts Specify an array of desired layouts for each input.
+ *                        For example a conv2d op: Array("NHWC", "OHWI"), this
+ *                        specifies the desired layout for data then kernel.
  * \return new_expr The modified expression.
  */
 using FTVMConvertOpLayout = runtime::TypedPackedFunc<Expr(
     const Attrs& attrs, const Array<Expr>& args, const Array<te::Tensor>& tinfos,
-    const std::string& desired_layout,
-       const Map<std::string, ObjectRef>& additional_layouts)>;
+    const Array<String>& desired_layouts)>;
 /*!
  * \brief Legalizes an expression with another expression. This function will be
  *  invoked in Legalize pass. It is a target-dependent pass.

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -281,14 +281,12 @@ TVM_DLL Pass AlterOpLayout();
  * layouts for conv2d ops for now. Most of the other operators try to adapt to their input layout
  * using the InferCorrectLayout infrastructure.
  *
- * \param desired_layout The desired layout.
- * \param additional_layouts Specify additional layouts for inputs other than
- *    data e.g. 'kernel_layout' to specify a kernel layout.
+ * \param desired_layouts Specify mapping of op_name to array of desired layouts for each input.
+ *                        For example: Map("nn.conv2d", Array("NHWC", "OHWI")),
+ *                        this specifies the desired layout for data then kernel for nn.conv2d.
  * \return The pass.
  */
-TVM_DLL Pass ConvertLayout(const std::string& desired_layout,
-                           const Map<std::string, ObjectRef>&
-                               additional_layouts = Map<std::string, ObjectRef>());
+TVM_DLL Pass ConvertLayout(const Map<std::string, Array<String>>& desired_layouts);
 
 /*!
  * \brief Legalizes an expr with another expression.

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -282,9 +282,13 @@ TVM_DLL Pass AlterOpLayout();
  * using the InferCorrectLayout infrastructure.
  *
  * \param desired_layout The desired layout.
+ * \param additional_layouts Specify additional layouts for inputs other than
+ *    data e.g. 'kernel_layout' to specify a kernel layout.
  * \return The pass.
  */
-TVM_DLL Pass ConvertLayout(const std::string& desired_layout);
+TVM_DLL Pass ConvertLayout(const std::string& desired_layout,
+                           const Map<std::string, ObjectRef>&
+                               additional_layouts = Map<std::string, ObjectRef>());
 
 /*!
  * \brief Legalizes an expr with another expression.

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -142,15 +142,14 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
     from tvm import relay
     data, weight = inputs
     new_attrs = dict(attrs)
-    desired_data_layout = str(desired_layouts[0])
+    assert len(desired_layouts) == 2, "A desired layout is expected for both of nn.conv2d's inputs"
+    desired_data_layout, desired_kernel_layout = map(str, desired_layouts)
     assert desired_data_layout != "default", "Data layout cannot be default"
     new_attrs['data_layout'] = desired_data_layout
 
-    if len(desired_layouts) > 1:
-        desired_kernel_layout = str(desired_layouts[1])
-        if desired_kernel_layout != "default":
-            new_attrs['kernel_layout'] = desired_kernel_layout
-            return relay.nn.conv2d(data, weight, **new_attrs)
+    if desired_kernel_layout != "default":
+        new_attrs['kernel_layout'] = desired_kernel_layout
+        return relay.nn.conv2d(data, weight, **new_attrs)
 
     # Handle default kernel layouts
     if desired_data_layout == 'NCHW':
@@ -164,8 +163,8 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
         else:
             new_attrs['kernel_layout'] = 'HWIO'
         return relay.nn.conv2d(data, weight, **new_attrs)
-    assert "Layout %s is not yet supported." % (desired_data_layout)
-    return None
+
+    raise ValueError("Layout %s is not yet supported." % desired_data_layout)
 
 
 # conv2d_transpose
@@ -227,15 +226,14 @@ def convert_conv3d(attrs, inputs, tinfos, desired_layouts):
     from tvm import relay
     data, weight = inputs
     new_attrs = dict(attrs)
-    desired_data_layout = str(desired_layouts[0])
+    assert len(desired_layouts) == 2, "A desired layout is expected for both of nn.conv3d's inputs"
+    desired_data_layout, desired_kernel_layout = map(str, desired_layouts)
     assert desired_data_layout != "default", "Data layout cannot be default"
     new_attrs['data_layout'] = desired_data_layout
 
-    if len(desired_layouts) > 1:
-        desired_kernel_layout = str(desired_layouts[1])
-        if desired_kernel_layout != "default":
-            new_attrs['kernel_layout'] = desired_kernel_layout
-            return relay.nn.conv3d(data, weight, **new_attrs)
+    if desired_kernel_layout != "default":
+        new_attrs['kernel_layout'] = desired_kernel_layout
+        return relay.nn.conv3d(data, weight, **new_attrs)
 
     # Handle default kernel layouts
     if desired_data_layout == 'NCDHW':
@@ -244,8 +242,9 @@ def convert_conv3d(attrs, inputs, tinfos, desired_layouts):
     elif desired_data_layout == "NDHWC":
         new_attrs['kernel_layout'] = 'DHWIO'
         return relay.nn.conv3d(data, weight, **new_attrs)
-    assert "Layout %s is not yet supported" % desired_data_layout
-    return None
+
+    raise ValueError("Layout %s is not yet supported" % desired_data_layout)
+
 
 # conv3d_winograd related operators
 reg.register_strategy("nn.contrib_conv3d_winograd_without_weight_transform",

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -164,8 +164,7 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
         else:
             new_attrs['kernel_layout'] = 'HWIO'
         return relay.nn.conv2d(data, weight, **new_attrs)
-    else:
-        assert "Layout %s is not yet supported." % (desired_data_layout)
+    assert "Layout %s is not yet supported." % (desired_data_layout)
     return None
 
 
@@ -245,8 +244,7 @@ def convert_conv3d(attrs, inputs, tinfos, desired_layouts):
     elif desired_data_layout == "NDHWC":
         new_attrs['kernel_layout'] = 'DHWIO'
         return relay.nn.conv3d(data, weight, **new_attrs)
-    else:
-        assert "Layout %s is not yet supported" % desired_data_layout
+    assert "Layout %s is not yet supported" % desired_data_layout
     return None
 
 # conv3d_winograd related operators

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -131,7 +131,7 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
         List of input and output types
     desired_layouts : list of layout strings
         List of layouts defining our desired
-        layout for the data and kernel inputs.
+        layout for the data and kernel inputs respectively.
 
     Returns
     -------
@@ -142,9 +142,9 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
     from tvm import relay
     data, weight = inputs
     new_attrs = dict(attrs)
-    desired_layout = str(desired_layouts[0])
-    assert desired_layout != "default", "Data layout cannot be default"
-    new_attrs['data_layout'] = desired_layout
+    desired_data_layout = str(desired_layouts[0])
+    assert desired_data_layout != "default", "Data layout cannot be default"
+    new_attrs['data_layout'] = desired_data_layout
 
     if len(desired_layouts) > 1:
         desired_kernel_layout = str(desired_layouts[1])
@@ -153,10 +153,10 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
             return relay.nn.conv2d(data, weight, **new_attrs)
 
     # Handle default kernel layouts
-    if desired_layout == 'NCHW':
+    if desired_data_layout == 'NCHW':
         new_attrs['kernel_layout'] = 'OIHW'
         return relay.nn.conv2d(data, weight, **new_attrs)
-    elif desired_layout == 'NHWC':
+    elif desired_data_layout == 'NHWC':
         # Check for depthwise convolution.
         if is_depthwise_conv2d(data.shape, attrs['data_layout'], weight.shape,
                                attrs['kernel_layout'], attrs['groups']):
@@ -165,7 +165,7 @@ def convert_conv2d(attrs, inputs, tinfos, desired_layouts):
             new_attrs['kernel_layout'] = 'HWIO'
         return relay.nn.conv2d(data, weight, **new_attrs)
     else:
-        assert "Layout %s is not yet supported." % (desired_layout)
+        assert "Layout %s is not yet supported." % (desired_data_layout)
     return None
 
 
@@ -217,7 +217,7 @@ def convert_conv3d(attrs, inputs, tinfos, desired_layouts):
         List of input and output types
     desired_layouts : list of layout strings
         List of layouts defining our desired
-        layout for the data and kernel inputs.
+        layout for the data and kernel inputs respectively.
 
     Returns
     -------
@@ -228,9 +228,9 @@ def convert_conv3d(attrs, inputs, tinfos, desired_layouts):
     from tvm import relay
     data, weight = inputs
     new_attrs = dict(attrs)
-    desired_layout = str(desired_layouts[0])
-    assert desired_layout != "default", "Data layout cannot be default"
-    new_attrs['data_layout'] = desired_layout
+    desired_data_layout = str(desired_layouts[0])
+    assert desired_data_layout != "default", "Data layout cannot be default"
+    new_attrs['data_layout'] = desired_data_layout
 
     if len(desired_layouts) > 1:
         desired_kernel_layout = str(desired_layouts[1])
@@ -239,14 +239,14 @@ def convert_conv3d(attrs, inputs, tinfos, desired_layouts):
             return relay.nn.conv3d(data, weight, **new_attrs)
 
     # Handle default kernel layouts
-    if desired_layout == 'NCDHW':
+    if desired_data_layout == 'NCDHW':
         new_attrs['kernel_layout'] = 'OIDHW'
         return relay.nn.conv3d(data, weight, **new_attrs)
-    elif desired_layout == "NDHWC":
+    elif desired_data_layout == "NDHWC":
         new_attrs['kernel_layout'] = 'DHWIO'
         return relay.nn.conv3d(data, weight, **new_attrs)
     else:
-        assert "Layout %s is not yet supported" % desired_layout
+        assert "Layout %s is not yet supported" % desired_data_layout
     return None
 
 # conv3d_winograd related operators

--- a/python/tvm/relay/qnn/op/layout_conversions.py
+++ b/python/tvm/relay/qnn/op/layout_conversions.py
@@ -45,6 +45,7 @@ def convert_qnn_conv2d(attrs, inputs, tinfos, desired_layouts):
     # pylint: disable=import-outside-toplevel
     from tvm import relay
     desired_data_layout = str(desired_layouts[0])
+    assert desired_data_layout != "default", "Data layout cannot be default"
 
     if desired_data_layout == 'NCHW':
         new_attrs = dict(attrs)
@@ -60,6 +61,5 @@ def convert_qnn_conv2d(attrs, inputs, tinfos, desired_layouts):
             new_attrs['kernel_layout'] = 'OIHW'
 
         return relay.qnn.op.conv2d(*inputs, **new_attrs)
-    else:
-        assert "Layout %s is not yet supported" % desired_data_layout
-        return None
+    assert "Layout %s is not yet supported" % desired_data_layout
+    return None

--- a/python/tvm/relay/qnn/op/layout_conversions.py
+++ b/python/tvm/relay/qnn/op/layout_conversions.py
@@ -22,7 +22,7 @@ from tvm.relay.op import op as reg
 
 
 @reg.register_convert_op_layout("qnn.conv2d")
-def convert_qnn_conv2d(attrs, inputs, tinfos, desired_layout):
+def convert_qnn_conv2d(attrs, inputs, tinfos, desired_layout, additional_layouts):
     """Convert Layout pass registration for QNN conv2d op.
 
     Parameters
@@ -35,6 +35,8 @@ def convert_qnn_conv2d(attrs, inputs, tinfos, desired_layout):
         List of input and output types
     desired_layout : str
         The desired layout
+    additional_layouts : tvm.ir.StrMap
+        Additional layouts (e.g. kernel layout).
 
     Returns
     -------

--- a/python/tvm/relay/qnn/op/layout_conversions.py
+++ b/python/tvm/relay/qnn/op/layout_conversions.py
@@ -44,22 +44,18 @@ def convert_qnn_conv2d(attrs, inputs, tinfos, desired_layouts):
     """
     # pylint: disable=import-outside-toplevel
     from tvm import relay
-    desired_data_layout = str(desired_layouts[0])
+    assert len(desired_layouts) == 2, "A desired layout is expected for both of qnn.conv2d's inputs"
+    desired_data_layout, desired_kernel_layout = map(str, desired_layouts)
     assert desired_data_layout != "default", "Data layout cannot be default"
 
+    new_attrs = dict(attrs)
+    new_attrs['data_layout'] = desired_data_layout
+
     if desired_data_layout == 'NCHW':
-        new_attrs = dict(attrs)
-        new_attrs['data_layout'] = desired_data_layout
-
-        desired_kernel_layout = "default"
-        if len(desired_layouts) > 1:
-            desired_kernel_layout = str(desired_layouts[1])
-
         if desired_kernel_layout != "default":
             new_attrs['kernel_layout'] = desired_kernel_layout
         else:
             new_attrs['kernel_layout'] = 'OIHW'
-
         return relay.qnn.op.conv2d(*inputs, **new_attrs)
-    assert "Layout %s is not yet supported" % desired_data_layout
-    return None
+
+    raise ValueError('Layout %s is not yet supported' % desired_data_layout)

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -324,7 +324,7 @@ def AlterOpLayout():
     return _ffi_api.AlterOpLayout()
 
 
-def ConvertLayout(desired_layout):
+def ConvertLayout(desired_layout, additional_layouts=None):
     """ Given a dest layout, this pass transforms the expr such that most of the ops input data
     layout is changed to the dest layout. In ideal situation, there are only 2 layout transforms,
     one at the start and one at the end.
@@ -343,13 +343,15 @@ def ConvertLayout(desired_layout):
     ----------
     desired_layout : str
       The desired layout for the transformed expr.
+    additional_layouts : dict (optional)
+      Specify additional layouts for the transformed expr. E.g. {"kernel_layout": "OHWI"}
 
     Returns
     -------
     pass: FunctionPass
       The pass.
     """
-    return _ffi_api.ConvertLayout(desired_layout)
+    return _ffi_api.ConvertLayout(desired_layout, tvm.runtime.convert(additional_layouts))
 
 
 def Legalize(legalize_map_attr_name="FTVMLegalize"):

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -324,7 +324,7 @@ def AlterOpLayout():
     return _ffi_api.AlterOpLayout()
 
 
-def ConvertLayout(layouts):
+def ConvertLayout(desired_layouts):
     """ Given a dest layout, this pass transforms the expr such that most of the ops input data
     layout is changed to the dest layout. In ideal situation, there are only 2 layout transforms,
     one at the start and one at the end.
@@ -341,7 +341,7 @@ def ConvertLayout(layouts):
 
     Parameters
     ----------
-    layouts : map of op_name to list of layouts
+    desired_layouts : map of op_name to list of layouts
         Specify a mapping of operator names to a list of layouts to convert to, in the order
         defined by the operator. An example for nn.conv2d could be: {"nn.conv2d", ["NHWC", "OHWI]},
         where the first item in the list specifies the data layout and the second specifies the
@@ -352,7 +352,7 @@ def ConvertLayout(layouts):
     pass: FunctionPass
       The pass.
     """
-    return _ffi_api.ConvertLayout(layouts)
+    return _ffi_api.ConvertLayout(desired_layouts)
 
 
 def Legalize(legalize_map_attr_name="FTVMLegalize"):

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -324,7 +324,7 @@ def AlterOpLayout():
     return _ffi_api.AlterOpLayout()
 
 
-def ConvertLayout(desired_layout, additional_layouts=None):
+def ConvertLayout(layouts):
     """ Given a dest layout, this pass transforms the expr such that most of the ops input data
     layout is changed to the dest layout. In ideal situation, there are only 2 layout transforms,
     one at the start and one at the end.
@@ -341,17 +341,18 @@ def ConvertLayout(desired_layout, additional_layouts=None):
 
     Parameters
     ----------
-    desired_layout : str
-      The desired layout for the transformed expr.
-    additional_layouts : dict (optional)
-      Specify additional layouts for the transformed expr. E.g. {"kernel_layout": "OHWI"}
+    layouts : map of op_name to list of layouts
+        Specify a mapping of operator names to a list of layouts to convert to, in the order
+        defined by the operator. An example for nn.conv2d could be: {"nn.conv2d", ["NHWC", "OHWI]},
+        where the first item in the list specifies the data layout and the second specifies the
+        kernel layout.
 
     Returns
     -------
     pass: FunctionPass
       The pass.
     """
-    return _ffi_api.ConvertLayout(desired_layout, tvm.runtime.convert(additional_layouts))
+    return _ffi_api.ConvertLayout(layouts)
 
 
 def Legalize(legalize_map_attr_name="FTVMLegalize"):

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -498,6 +498,9 @@ class StringImm(ConstExpr):
             return self.value != other.value
         return self.value != other
 
+    def __str__(self):
+        return self.value
+
 
 @tvm._ffi.register_object
 class Cast(PrimExprWithOp):

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -498,9 +498,6 @@ class StringImm(ConstExpr):
             return self.value != other.value
         return self.value != other
 
-    def __str__(self):
-        return self.value
-
 
 @tvm._ffi.register_object
 class Cast(PrimExprWithOp):

--- a/src/relay/transforms/convert_layout.cc
+++ b/src/relay/transforms/convert_layout.cc
@@ -51,9 +51,9 @@ class ConvertTransformMemorizerNode : public TransformMemorizerNode {
  public:
   /*!
    * \brief Initializes the desired_layout.
- * \param desired_layouts Specify mapping of op_name to array of desired layouts for each input.
- *                        For example: Map("nn.conv2d", Array("NHWC", "OHWI")),
- *                        this specifies the desired layout for data then kernel for nn.conv2d.
+   * \param desired_layouts Specify mapping of op_name to array of desired layouts for each input.
+   *                        For example: Map("nn.conv2d", Array("NHWC", "OHWI")),
+   *                        this specifies the desired layout for data then kernel for nn.conv2d.
    */
   explicit ConvertTransformMemorizerNode(Map<std::string, Array<String>> desired_layouts)
       : desired_layouts_(std::move(desired_layouts)) {}

--- a/src/relay/transforms/convert_layout.cc
+++ b/src/relay/transforms/convert_layout.cc
@@ -51,18 +51,15 @@ class ConvertTransformMemorizerNode : public TransformMemorizerNode {
  public:
   /*!
    * \brief Initializes the desired_layout.
-   * \param desired_layout The desired layout.
-   * \param additional_layouts Specify additional layouts for operators
-   *    with additional inputs e.g. kernel_layout = OHWI.
+ * \param desired_layouts Specify mapping of op_name to array of desired layouts for each input.
+ *                        For example: Map("nn.conv2d", Array("NHWC", "OHWI")),
+ *                        this specifies the desired layout for data then kernel for nn.conv2d.
    */
-  explicit ConvertTransformMemorizerNode(const std::string& desired_layout,
-                                         const Map<std::string, ObjectRef>& additional_layouts)
-      : desired_layout_(desired_layout), additional_layouts_(additional_layouts) {}
+  explicit ConvertTransformMemorizerNode(Map<std::string, Array<String>> desired_layouts)
+      : desired_layouts_(std::move(desired_layouts)) {}
 
-  /*! \brief The desired layout for the Convert Layout pass */
-  std::string desired_layout_;
-  /*! \brief The desired kernel layout for the Convert Layout pass */
-  Map<std::string, ObjectRef> additional_layouts_;
+  /*! \brief A mapping of op_name to array of desired layouts for each input. */
+  Map<std::string, Array<String>> desired_layouts_;
 };
 
 /*!
@@ -96,9 +93,14 @@ class ConvertTransformMemorizer : public TransformMemorizer {
         auto ttype = expr->type_as<TensorTypeNode>();
         tinfos.push_back(tvm::te::placeholder(ttype->shape, ttype->dtype));
       }
+
+      auto desired_layouts = operator->()->desired_layouts_;
+      if (desired_layouts.find(op->name) == desired_layouts.end()) {
+        LOG(FATAL) << "Desired layout(s) not specified for op: " << op->name;
+      }
+      Array<String> op_desired_layouts = desired_layouts.at(op->name);
       Expr altered_value =
-          fconvert_layout[op](ref_call->attrs, new_args, tinfos,
-              operator->()->desired_layout_, operator->()->additional_layouts_);
+          fconvert_layout[op](ref_call->attrs, new_args, tinfos, op_desired_layouts);
       if (altered_value.defined()) {
         new_e = altered_value;
         modified = true;
@@ -121,10 +123,9 @@ class ConvertTransformMemorizer : public TransformMemorizer {
  * 1. The altered op should have the same number of arguments as the previous one.
  * 2. Do not support nested tuple arguments.
  */
-Expr ConvertLayout(const Expr& expr, const std::string& desired_layout,
-                   const Map<std::string, ObjectRef>& additional_layouts) {
+Expr ConvertLayout(const Expr& expr, const Map<std::string, Array<String>>& desired_layouts) {
   ConvertTransformMemorizer transformMemorizer(
-      make_object<ConvertTransformMemorizerNode>(desired_layout, additional_layouts));
+      make_object<ConvertTransformMemorizerNode>(desired_layouts));
   auto fcontext = [&](const Call& call) -> ObjectRef { return transformMemorizer; };
 
   return ForwardRewrite(expr, LayoutRewriter<ConvertTransformMemorizer>, fcontext);
@@ -134,12 +135,10 @@ Expr ConvertLayout(const Expr& expr, const std::string& desired_layout,
 
 namespace transform {
 
-Pass ConvertLayout(const std::string& desired_layout,
-                   const Map<std::string, ObjectRef>& additional_layouts) {
+Pass ConvertLayout(const Map<std::string, Array<String>>& desired_layouts) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(relay::convert_op_layout::ConvertLayout(f, desired_layout,
-            additional_layouts));
+        return Downcast<Function>(relay::convert_op_layout::ConvertLayout(f, desired_layouts));
       };
   return CreateFunctionPass(pass_func, 3, "ConvertLayout", {"InferType", "CanonicalizeOps"});
 }

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -49,7 +49,7 @@ def test_no_convert_layout():
         return before()
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -84,7 +84,7 @@ def test_conv_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -129,7 +129,7 @@ def test_conv_bias_pool_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -177,7 +177,7 @@ def test_conv_concat_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -232,7 +232,7 @@ def test_dual_path_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -256,7 +256,7 @@ def test_bn_convert_layout():
         return relay.Function(analysis.free_vars(y), y)
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
 
     # Check that there is only 1 NHWC to NCHW transform.
     has_lt = list()
@@ -312,7 +312,7 @@ def test_resnet_convert_layout():
         return relay.Function(analysis.free_vars(y), y)
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -344,7 +344,7 @@ def test_scalar_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -392,7 +392,7 @@ def test_conv_bn_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -448,7 +448,7 @@ def test_qnn_conv_requantize_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -526,7 +526,7 @@ def test_qnn_conv_concat_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -606,7 +606,7 @@ def test_qnn_conv_add_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW']}))
+    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW', 'default']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -672,6 +672,71 @@ def test_default_keyword():
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
 
 
+def test_different_ops_convert_layout():
+    """ Check convert layout correctly supports converting the layout of
+    different ops in the same graph.
+    """
+    def before():
+        x = relay.var("x", shape=(1, 64, 56, 56))
+        weight1 = relay.var("weight1", shape=(64, 3, 3, 64))
+        weight2 = relay.var("weight2", shape=(64, 3, 3, 64), dtype='int8')
+        out = relay.nn.conv2d(x, weight1,
+                              channels=64,
+                              kernel_size=(3, 3),
+                              padding=(1, 1),
+                              data_layout='NCHW',
+                              kernel_layout='OHWI')
+        out = relay.cast(out, 'int8')
+        out = relay.qnn.op.conv2d(out, weight2,
+                                  relay.const(1, 'int32'),
+                                  relay.const(1, 'int32'),
+                                  relay.const(1, 'float32'),
+                                  relay.const(1, 'float32'),
+                                  channels=64,
+                                  kernel_size=(3, 3),
+                                  padding=(1, 1),
+                                  data_layout='NCHW',
+                                  kernel_layout='OHWI')
+        out = relay.Function(analysis.free_vars(out), out)
+        return out
+
+    def expected():
+        x = relay.var("x", shape=(1, 64, 56, 56))
+        weight1 = relay.var("weight1", shape=(64, 3, 3, 64))
+        weight2 = relay.var("weight2", shape=(64, 3, 3, 64), dtype='int8')
+        x = relay.layout_transform(x, 'NCHW', 'NHWC')
+        weight1 = relay.layout_transform(weight1, 'OHWI', 'HWIO')
+        out = relay.nn.conv2d(x, weight1,
+                              channels=64,
+                              kernel_size=(3, 3),
+                              padding=(1, 1),
+                              data_layout='NHWC',
+                              kernel_layout='HWIO')
+        out = relay.cast(out, 'int8')
+        out = relay.layout_transform(out, 'NHWC', 'NCHW')
+        weight2 = relay.layout_transform(weight2, 'OHWI', 'OIHW')
+        out = relay.qnn.op.conv2d(out, weight2,
+                                  relay.const(1, 'int32'),
+                                  relay.const(1, 'int32'),
+                                  relay.const(1, 'float32'),
+                                  relay.const(1, 'float32'),
+                                  channels=64,
+                                  kernel_size=(3, 3),
+                                  padding=(1, 1),
+                                  data_layout='NCHW',
+                                  kernel_layout='OIHW')
+        out = relay.Function(analysis.free_vars(out), out)
+        return out
+
+    a = before()
+    desired_layouts = {'nn.conv2d': ['NHWC', 'HWIO'],
+                       'qnn.conv2d': ['NCHW', 'OIHW']}
+    a = run_opt_pass(a, transform.ConvertLayout(desired_layouts))
+    b = run_opt_pass(expected(), transform.InferType())
+
+    assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
+
+
 if __name__ == "__main__":
     test_no_convert_layout()
     test_conv_convert_layout()
@@ -687,3 +752,4 @@ if __name__ == "__main__":
     test_qnn_conv_add_convert_layout()
     test_conv_convert_kernel_layout()
     test_default_keyword()
+    test_different_ops_convert_layout()

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -49,7 +49,7 @@ def test_no_convert_layout():
         return before()
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -84,7 +84,7 @@ def test_conv_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -129,7 +129,7 @@ def test_conv_bias_pool_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -177,7 +177,7 @@ def test_conv_concat_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -232,7 +232,7 @@ def test_dual_path_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -256,7 +256,7 @@ def test_bn_convert_layout():
         return relay.Function(analysis.free_vars(y), y)
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
 
     # Check that there is only 1 NHWC to NCHW transform.
     has_lt = list()
@@ -312,7 +312,7 @@ def test_resnet_convert_layout():
         return relay.Function(analysis.free_vars(y), y)
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -344,7 +344,7 @@ def test_scalar_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -392,7 +392,7 @@ def test_conv_bn_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -448,7 +448,7 @@ def test_qnn_conv_requantize_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -526,7 +526,7 @@ def test_qnn_conv_concat_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -606,13 +606,13 @@ def test_qnn_conv_add_convert_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NCHW'))
+    a = run_opt_pass(a, transform.ConvertLayout({'qnn.conv2d': ['NCHW']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
 
 
-def test_conv_additional_layout():
+def test_conv_convert_kernel_layout():
     """ Check that convolution kernel layout is correctly transformed. """
     def before():
         x = relay.var("x", shape=(1, 56, 56, 64))
@@ -636,7 +636,7 @@ def test_conv_additional_layout():
         return y
 
     a = before()
-    a = run_opt_pass(a, transform.ConvertLayout('NHWC', {'kernel_layout': 'OHWI'}))
+    a = run_opt_pass(a, transform.ConvertLayout({'nn.conv2d': ['NHWC', 'OHWI']}))
     b = run_opt_pass(expected(), transform.InferType())
 
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
@@ -655,4 +655,4 @@ if __name__ == "__main__":
     test_qnn_conv_requantize_convert_layout()
     test_qnn_conv_concat_convert_layout()
     test_qnn_conv_add_convert_layout()
-    test_conv_additional_layout()
+    test_conv_convert_kernel_layout()


### PR DESCRIPTION
* This patch means that you can specify an additional layout, rather than using the layout chosen by default during conversion.
* This is specifically useful for external codegen when a 3rd party library needs to target a specific kernel layout for example.
