### PR TITLE
[TFLite] Add config option to specify FlatBuffers location

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -154,6 +154,10 @@ set(USE_TFLITE OFF)
 # /path/to/tensorflow: tensorflow root path when use tflite library
 set(USE_TENSORFLOW_PATH none)
 
+# Required for full builds with TFLite. Not needed for runtime with TFLite.
+# /path/to/flatbuffers: flatbuffers root path when using tflite library
+set(USE_FLATBUFFERS_PATH none)
+
 # Possible values:
 # - OFF: disable tflite support for edgetpu
 # - /path/to/edgetpu: use specific path to edgetpu library

--- a/cmake/modules/contrib/TFLite.cmake
+++ b/cmake/modules/contrib/TFLite.cmake
@@ -17,7 +17,7 @@
 
 if(NOT USE_TFLITE STREQUAL "OFF")
   message(STATUS "Build with contrib.tflite")
-  if (USE_TENSORFLOW_PATH STREQUAL "none") 
+  if (USE_TENSORFLOW_PATH STREQUAL "none")
     set(USE_TENSORFLOW_PATH ${CMAKE_CURRENT_SOURCE_DIR}/tensorflow)
   endif()
 
@@ -40,5 +40,8 @@ if(NOT USE_TFLITE STREQUAL "OFF")
   find_library(TFLITE_CONTRIB_LIB libtensorflow-lite.a ${USE_TFLITE})
 
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${TFLITE_CONTRIB_LIB})
-  list(APPEND TVM_RUNTIME_LINKER_LIBS rt dl flatbuffers)
+
+  if (NOT USE_FLATBUFFERS_PATH STREQUAL "none")
+    include_directories(${USE_FLATBUFFERS_PATH}/include)
+  endif()
 endif()


### PR DESCRIPTION
Adds an option to `config.cmake`  for specifying the location of FlatBuffers when building with TFLite ON. 

This option _must_ be set when building full TVM with TFLite ON, but is not required to build just the runtime with TFLite ON. 