### PR TITLE
Corrected TVM autotuning on GPU

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -615,7 +615,7 @@ def gpu_verify_pass(**kwargs):
     This pass will check memory usage and number of threads per block.
     """
     def verify_pass(f, *_):
-        valid = tvm.analysis.verify_gpu_code(f, kwargs)
+        valid = tvm.tir.analysis.verify_gpu_code(f, kwargs)
         if not valid:
             raise InstantiationError("Skipped because of invalid gpu kernel")
         return f


### PR DESCRIPTION
Added missing "tir" in tvm.tir.analysis.verify_gpu_code(f, kwargs) , which made the tuning on GPU (tested with RTX2080) fail.

Requesting a review from @eqy or @merrymercy