### PR TITLE
[Fontend][Pytorch] Fix translation of transpose when axis argument is as a list

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -923,7 +923,7 @@ def _transpose(prelude):
             axes[src] = dst
             axes[dst] = src
         else:
-            axes = inputs[1]
+            axes = _infer_shape(inputs[1], prelude.mod)
         return _op.transform.transpose(data, axes)
     return _impl
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -767,9 +767,14 @@ def test_forward_transpose():
         def forward(self, *args):
             return args[0].transpose(-2, -1)
 
+    class Transpose3(Module):
+        def forward(self, *args):
+            return args[0].permute(0,2,3,1)
+
     input_data = torch.rand(input_shape).float()
     verify_model(Transpose1().float().eval(), input_data=input_data)
     verify_model(Transpose2().float().eval(), input_data=input_data)
+    verify_model(Transpose3().float().eval(), input_data=input_data)
 
 def test_forward_size():
     torch.set_grad_enabled(False)


### PR DESCRIPTION
Symptoms
```
Traceback (most recent call last):
  File "test_forward.py", line 1646, in <module>
    test_forward_transpose()
  File "test_forward.py", line 755, in test_forward_transpose
    verify_model(Transpose3().float().eval(), input_data=input_data)
  File "test_forward.py", line 175, in verify_model
    custom_convert_map)
  File "/home/nnez/devel/public-tvm/python/tvm/relay/frontend/pytorch.py", line 2117, in from_pytorch
    outputs, ret_name, convert_map, prelude)
  File "/home/nnez/devel/public-tvm/python/tvm/relay/frontend/pytorch.py", line 2031, in convert_operators
    relay_out = relay_op(inputs, _get_input_types(op_node))
  File "/home/nnez/devel/public-tvm/python/tvm/relay/frontend/pytorch.py", line 780, in _impl
    return _op.transform.transpose(data, axes)
  File "/home/nnez/devel/public-tvm/python/tvm/relay/op/transform.py", line 125, in transpose
    axes = list(axes)
```

This happens because of the current implementation of `prim::ListConstruct` translates a list of integer into `relay.Var` with the list encoded as the shape of it.