### PR TITLE
[COMMUNITY] @liangfu -> committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ We do encourage everyone to work anything they are interested in.
 
 - [Aditya Atluri](https://github.com/adityaatluri): @adityaatluri - rocm
 - [Tianqi Chen](https://github.com/tqchen) (PPMC): @tqchen - topi, compiler, relay, docs
+- [Liangfu Chen](https://github.com/liangfu): @liangfu - vta, chisel, intel FPGA, c runtime
 - [Wei Chen](https://github.com/wweic): @wweic - runtime, relay, vm
 - [Zhi Chen](https://github.com/zhiics): @zhiics - relay, quantization, pass manager
 - [Yuwei Hu](https://github.com/Huyuwei): @Huyuwei - topi, frontends


### PR DESCRIPTION
Please join us to welcome @liangfu as a committer. He has helped maintain much of the Chisel codebase for VTA and notably has brought support to Intel FPGAs. More recently he contributed by adding a MISRA-C compliant lightweight runtime for micro-controllers. He also built early support for sparse operations in CSR form.

Commits:
https://github.com/apache/incubator-tvm/commits?author=liangfu

Code Review:
https://github.com/apache/incubator-tvm/pulls?utf8=%E2%9C%93&q=reviewed-by%3Aliangfu

Community:
https://discuss.tvm.ai/u/liangfu/summary

