### PR TITLE
[CI] Include local Docker images as source for layers 

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -67,6 +67,7 @@ fi
 if [[ "$1" == "--cache-from" ]]; then
     shift 1
     cached_image="$1"
+    CI_DOCKER_BUILD_EXTRA_PARAMS+=("--cache-from tvm.$CONTAINER_TYPE")
     CI_DOCKER_BUILD_EXTRA_PARAMS+=("--cache-from $cached_image")
     shift 1
 fi


### PR DESCRIPTION
The `--cache-from` argument can be used on `buld.sh` to speed up the Docker image (re)build process, by pointing to a remote image to be used as cache for Docker layers.

This patch does a bit of an improvement, including also the current version of the local image in the cache, in case you want o used cached images. In case there is no local image, it is ok, Docker knows how to deal with it.

cc @tqchen