### PR TITLE
[BYOC] Bind constant tuples in graph partitioner

### DIFF
--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -1155,8 +1155,8 @@ def test_duplicate_merge_and_tuplegetitem():
     partitioned = seq(mod)
     assert tvm.ir.structural_equal(partitioned, ref_mod, map_free_vars=True)
 
-def test_constant_partitioning():
-    @reg.register("qnn.concatenate", "target.const_test")
+def test_constant_tuples():
+    @reg.register("qnn.concatenate", "target.const_tuples")
     def add(attrs, args):  # pylint: disable=unused-variable
         return True
 
@@ -1179,13 +1179,13 @@ def test_constant_partitioning():
         return mod
 
     seq = tvm.transform.Sequential([
-        transform.AnnotateTarget("const_test"),
+        transform.AnnotateTarget("const_tuples"),
         transform.MergeCompilerRegions(),
         transform.PartitionGraph(),
     ])
 
     partitioned = seq(create_graph())
-    concat = partitioned["const_test_0"].body
+    concat = partitioned["const_tuples_0"].body
     assert type(concat.args[1]) == relay.Tuple
     assert type(concat.args[2]) == relay.Tuple
     assert type(concat.args[3]) == relay.Constant
@@ -1207,4 +1207,4 @@ if __name__ == "__main__":
     test_multiple_use_of_an_output()
     test_duplicate_outputs()
     test_duplicate_merge_and_tuplegetitem()
-    test_constant_partitioning()
+    test_constant_tuples()

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -1155,6 +1155,42 @@ def test_duplicate_merge_and_tuplegetitem():
     partitioned = seq(mod)
     assert tvm.ir.structural_equal(partitioned, ref_mod, map_free_vars=True)
 
+def test_constant_partitioning():
+    @reg.register("qnn.concatenate", "target.const_test")
+    def add(attrs, args):  # pylint: disable=unused-variable
+        return True
+
+    def create_graph():
+        a = relay.var('a', shape=(10, 10), dtype="uint8")
+        b = relay.var('b', shape=(10, 10), dtype="uint8")
+        a1 = relay.abs(a)
+
+        zeroi = relay.const(1, "int32")
+        zerof = relay.const(0, "float32")
+        con = relay.qnn.op.concatenate((a1, b),
+                                       input_scales=(zerof, zerof),
+                                       input_zero_points=(zeroi, zeroi),
+                                       output_scale=zerof,
+                                       output_zero_point=zeroi,
+                                       axis=1)
+
+        f = relay.Function([a, b], con)
+        mod = tvm.IRModule.from_expr(f)
+        return mod
+
+    seq = tvm.transform.Sequential([
+        transform.AnnotateTarget("const_test"),
+        transform.MergeCompilerRegions(),
+        transform.PartitionGraph(),
+    ])
+
+    partitioned = seq(create_graph())
+    concat = partitioned["const_test_0"].body
+    assert type(concat.args[1]) == relay.Tuple
+    assert type(concat.args[2]) == relay.Tuple
+    assert type(concat.args[3]) == relay.Constant
+    assert type(concat.args[4]) == relay.Constant
+
 if __name__ == "__main__":
     test_multi_node_compiler()
     test_extern_ccompiler_single_op()
@@ -1171,3 +1207,4 @@ if __name__ == "__main__":
     test_multiple_use_of_an_output()
     test_duplicate_outputs()
     test_duplicate_merge_and_tuplegetitem()
+    test_constant_partitioning()


### PR DESCRIPTION
Constant tuples were not being propagated into partitions making it impossible to codegen functions like concatenate. This extends the constant binding that happens in PartitionGraph to also include constant tuples.

This is an alternative solution to the one presented in this PR: [5409](https://github.com/apache/incubator-tvm/pull/5409).