### PR TITLE
[VTA] Fix VTA compile issue

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -108,6 +108,7 @@ elseif(PYTHON)
     endforeach()
     if(${VTA_TARGET} STREQUAL "pynq" OR
        ${VTA_TARGET} STREQUAL "ultra96")
+      target_include_directories(vta PUBLIC ${VTA_HW_PATH}/include)
       target_link_libraries(vta ${__cma_lib})
     elseif(${VTA_TARGET} STREQUAL "de10nano")  # DE10-Nano rules
      #target_compile_definitions(vta PUBLIC VTA_MAX_XFER=2097152) # (1<<21)

--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -89,7 +89,7 @@ elseif(PYTHON)
 
   # VTA FPGA driver sources
   if(USE_VTA_FPGA)
-    file(GLOB FPGA_RUNTIME_SRCS ${VTA_HW_PATH}/src/*.cc)
+    file(GLOB FPGA_RUNTIME_SRCS vta/runtime/*.cc)
     # Rules for Zynq-class FPGAs with pynq OS support (see pynq.io)
     if(${VTA_TARGET} STREQUAL "pynq" OR
        ${VTA_TARGET} STREQUAL "ultra96")


### PR DESCRIPTION
Issue1:
When doing vta compile in xilinx FPGA, the pynqdriver.cc report can
not find <vta/driver.h>

Issue2:
Run vta on pynq board , libvta.so load failed.

solution:
fixed VTA.make logic issue
@tmoreau89  @liangfu , could you help to have a review , thanks.
