### PR TITLE
[Hexagon] Change "scalar" and "stack" in IDL from "inrout" to "in"

### DIFF
--- a/src/runtime/hexagon/target/fastrpc/include/tvm_remote.idl
+++ b/src/runtime/hexagon/target/fastrpc/include/tvm_remote.idl
@@ -34,8 +34,8 @@ interface tvm_remote : remote_handle64 {
                    rout handle_t sym_ptr);
    long kernel(in handle_t mod,
                in handle_t symbol,
-               inrout sequence <long> scalar,
-               inrout sequence <long> stack,
+               in sequence <long> scalar,
+               in sequence <long> stack,
                in sequence<buffer> scalar_in_octet,
                rout sequence<buffer> scalar_out_octet,
                in sequence<buffer> stack_in_octet,

--- a/src/runtime/hexagon/target/fastrpc/include/tvm_remote_nd.idl
+++ b/src/runtime/hexagon/target/fastrpc/include/tvm_remote_nd.idl
@@ -36,8 +36,8 @@ interface tvm_remote_nd {
                    rout handle_t sym_ptr);
    long kernel(in handle_t mod,
                in handle_t symbol,
-               inrout sequence <long> scalar,
-               inrout sequence <long> stack,
+               in sequence <long> scalar,
+               in sequence <long> stack,
                in sequence<buffer> scalar_in_octet,
                rout sequence<buffer> scalar_out_octet,
                in sequence<buffer> stack_in_octet,

--- a/src/runtime/hexagon/target/fastrpc/src/tvm_remote_imp.cc
+++ b/src/runtime/hexagon/target/fastrpc/src/tvm_remote_imp.cc
@@ -165,8 +165,8 @@ int tvm_remote_get_symbol(remote_handle64 handle, tvm_remote_handle_t lib,
  */
 int tvm_remote_kernel(
     remote_handle64 handle, tvm_remote_handle_t lib,
-    tvm_remote_handle_t symbol, int* scalar, int scalar_len, int* stack,
-    int stack_len, const tvm_remote_buffer* scalar_in_octet,
+    tvm_remote_handle_t symbol, const int* scalar, int scalar_len,
+    const int* stack, int stack_len, const tvm_remote_buffer* scalar_in_octet,
     int scalar_in_octet_len, tvm_remote_buffer* scalar_out_octet,
     int scalar_out_octet_len, const tvm_remote_buffer* stack_in_octet,
     int stack_in_octet_len, tvm_remote_buffer* stack_out_octet,

--- a/src/runtime/hexagon/target/fastrpc/src/tvm_remote_nd_imp.cc
+++ b/src/runtime/hexagon/target/fastrpc/src/tvm_remote_nd_imp.cc
@@ -262,8 +262,8 @@ static void print_msg_call(const msg_call& mc) {
  * only. They are not used for procesing.
  */
 int tvm_remote_nd_kernel(
-    tvm_remote_nd_handle_t lib, tvm_remote_nd_handle_t symbol, int* scalar,
-    int scalar_len, int* stack, int stack_len,
+    tvm_remote_nd_handle_t lib, tvm_remote_nd_handle_t symbol,
+    const int* scalar, int scalar_len, const int* stack, int stack_len,
     const tvm_remote_nd_buffer* scalar_in_octet, int scalar_in_octet_len,
     tvm_remote_nd_buffer* scalar_out_octet, int scalar_out_octet_len,
     const tvm_remote_nd_buffer* stack_in_octet, int stack_in_octet_len,


### PR DESCRIPTION
This changes the `scalar` and `stack` parameters to `kernel` to be input parameters only, as suggested by @FrozenGene .
