### PR TITLE
[Rust] Fixes for wasm32 target

### DIFF
--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -29,11 +29,5 @@ curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default
 . $CARGO_HOME/env
 rustup component add rustfmt
 
-# install wasmtime
-export WASMTIME_HOME=/opt/wasmtime
-curl https://wasmtime.dev/install.sh -sSf | bash
-export PATH="${WASMTIME_HOME}/bin:${PATH}"
-rustup target add wasm32-wasi
-
 # make rust usable by all users
 chmod -R a+w /opt/rust

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 	"runtime",
 	"runtime/tests/test_tvm_basic",
 	"runtime/tests/test_tvm_dso",
+	"runtime/tests/test_wasm32",
 	"runtime/tests/test_nn",
 	"frontend",
 	"frontend/tests/basics",

--- a/rust/common/build.rs
+++ b/rust/common/build.rs
@@ -51,6 +51,7 @@ fn main() {
         .layout_tests(false)
         .derive_partialeq(true)
         .derive_eq(true)
+        .derive_default(true)
         .generate()
         .expect("unable to generate bindings")
         .write_to_file(PathBuf::from("src/c_runtime_api.rs"))

--- a/rust/common/src/array.rs
+++ b/rust/common/src/array.rs
@@ -133,6 +133,7 @@ macro_rules! impl_dltensor_from_ndarray {
                     shape: arr.shape().as_ptr() as *const i64 as *mut i64,
                     strides: arr.strides().as_ptr() as *const isize as *mut i64,
                     byte_offset: 0,
+                    ..Default::default()
                 }
             }
         }

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -31,8 +31,13 @@ pub mod ffi {
 
     include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/c_runtime_api.rs"));
 
-    pub type BackendPackedCFunc =
-        extern "C" fn(args: *const TVMValue, type_codes: *const c_int, num_args: c_int) -> c_int;
+    pub type BackendPackedCFunc = extern "C" fn(
+        args: *const TVMValue,
+        type_codes: *const c_int,
+        num_args: c_int,
+        out_ret_value: *mut TVMValue,
+        out_ret_tcode: *mut u32,
+    ) -> c_int;
 }
 
 pub mod array;

--- a/rust/runtime/src/array.rs
+++ b/rust/runtime/src/array.rs
@@ -297,6 +297,7 @@ impl<'a> Tensor<'a> {
                 self.strides.as_ref().unwrap().as_ptr()
             } as *mut i64,
             byte_offset: 0,
+            ..Default::default()
         }
     }
 }

--- a/rust/runtime/src/graph.rs
+++ b/rust/runtime/src/graph.rs
@@ -382,7 +382,18 @@ named! {
 // Converts a bytes to String.
 named! {
     name<String>,
-    map_res!(length_data!(le_u64), |b: &[u8]| String::from_utf8(b.to_vec()))
+    do_parse!(
+        len_l: le_u32 >>
+        len_h: le_u32 >>
+        data: take!(len_l) >>
+        (
+            if len_h == 0 {
+                String::from_utf8(data.to_vec()).unwrap()
+            } else {
+                panic!("Too long string")
+            }
+        )
+    )
 }
 
 // Parses a TVMContext

--- a/rust/runtime/src/module/mod.rs
+++ b/rust/runtime/src/module/mod.rs
@@ -44,9 +44,17 @@ fn wrap_backend_packed_func(func_name: String, func: BackendPackedCFunc) -> Box<
                 (val, code as i32)
             })
             .unzip();
-        let exit_code = func(values.as_ptr(), type_codes.as_ptr(), values.len() as i32);
+        let ret: TVMRetValue = TVMRetValue::default();
+        let (mut ret_val, mut ret_type_code) = ret.to_tvm_value();
+        let exit_code = func(
+            values.as_ptr(),
+            type_codes.as_ptr(),
+            values.len() as i32,
+            &mut ret_val,
+            &mut ret_type_code,
+        );
         if exit_code == 0 {
-            Ok(TVMRetValue::default())
+            Ok(TVMRetValue::from_tvm_value(ret_val, ret_type_code))
         } else {
             Err(tvm_common::errors::FuncCallError::get_with_context(
                 func_name.clone(),

--- a/rust/runtime/tests/test_wasm32/.cargo/config
+++ b/rust/runtime/tests/test_wasm32/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/rust/runtime/tests/test_wasm32/Cargo.toml
+++ b/rust/runtime/tests/test_wasm32/Cargo.toml
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,24 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
-set -o pipefail
+[package]
+name = "test-wasm32"
+version = "0.0.0"
+license = "Apache-2.0"
+authors = ["TVM Contributors"]
 
-apt-get update && apt-get install -y --no-install-recommends curl
-
-export RUSTUP_HOME=/opt/rust
-export CARGO_HOME=/opt/rust
-# this rustc is one supported by the installed version of rust-sgx-sdk
-curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain stable
-. $CARGO_HOME/env
-rustup component add rustfmt
-
-# install wasmtime
-export WASMTIME_HOME=/opt/wasmtime
-curl https://wasmtime.dev/install.sh -sSf | bash
-export PATH="${WASMTIME_HOME}/bin:${PATH}"
-rustup target add wasm32-wasi
-
-# make rust usable by all users
-chmod -R a+w /opt/rust
+[dependencies]
+ndarray="0.12"
+tvm-runtime = { path = "../../" }

--- a/rust/runtime/tests/test_wasm32/build.rs
+++ b/rust/runtime/tests/test_wasm32/build.rs
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::{path::PathBuf, process::Command};
+
+fn main() {
+    let mut out_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    out_dir.push("lib");
+
+    if !out_dir.is_dir() {
+        std::fs::create_dir(&out_dir).unwrap();
+    }
+
+    let obj_file = out_dir.join("test.o");
+    let lib_file = out_dir.join("libtest_wasm32.a");
+
+    let output = Command::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/build_test_lib.py"
+    ))
+    .arg(&out_dir)
+    .output()
+    .expect("Failed to execute command");
+    assert!(
+        obj_file.exists(),
+        "Could not build tvm lib: {}",
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .trim()
+            .split("\n")
+            .last()
+            .unwrap_or("")
+    );
+
+    let ar = option_env!("LLVM_AR").unwrap_or("llvm-ar-8");
+    let output = Command::new(ar)
+        .arg("rcs")
+        .arg(&lib_file)
+        .arg(&obj_file)
+        .output()
+        .expect("Failed to execute command");
+    assert!(
+        lib_file.exists(),
+        "Could not create archive: {}",
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .trim()
+            .split("\n")
+            .last()
+            .unwrap_or("")
+    );
+
+    println!("cargo:rustc-link-lib=static=test_wasm32");
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+}

--- a/rust/runtime/tests/test_wasm32/src/main.rs
+++ b/rust/runtime/tests/test_wasm32/src/main.rs
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+extern "C" {
+    static __tvm_module_ctx: i32;
+}
+
+#[no_mangle]
+unsafe fn __get_tvm_module_ctx() -> i32 {
+    // Refer a symbol in the libtest_wasm32.a to make sure that the link of the
+    // library is not optimized out.
+    __tvm_module_ctx
+}
+
+extern crate ndarray;
+#[macro_use]
+extern crate tvm_runtime;
+
+use ndarray::Array;
+use tvm_runtime::{DLTensor, Module as _, SystemLibModule};
+
+fn main() {
+    // try static
+    let mut a = Array::from_vec(vec![1f32, 2., 3., 4.]);
+    let mut b = Array::from_vec(vec![1f32, 0., 1., 0.]);
+    let mut c = Array::from_vec(vec![0f32; 4]);
+    let e = Array::from_vec(vec![2f32, 2., 4., 4.]);
+    let mut a_dl: DLTensor = (&mut a).into();
+    let mut b_dl: DLTensor = (&mut b).into();
+    let mut c_dl: DLTensor = (&mut c).into();
+
+    let syslib = SystemLibModule::default();
+    let add = syslib
+        .get_function("default_function")
+        .expect("main function not found");
+    call_packed!(add, &mut a_dl, &mut b_dl, &mut c_dl).unwrap();
+    assert!(c.all_close(&e, 1e-8f32));
+}

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -103,7 +103,8 @@ ALLOW_SPECIFIC_FILE = {
     "KEYS",
     "DISCLAIMER",
     "Jenkinsfile",
-    # sgx config
+    # cargo config
+    "rust/runtime/tests/test_wasm32/.cargo/config",
     "apps/sgx/.cargo/config",
     # html for demo purposes
     "tests/webgl/test_static_webgl_library.html",

--- a/tests/scripts/task_rust.sh
+++ b/tests/scripts/task_rust.sh
@@ -54,6 +54,12 @@ cd tests/test_tvm_dso
 cargo run
 cd -
 
+# run wasm32 test
+cd tests/test_wasm32
+cargo build
+wasmtime $RUST_DIR/target/wasm32-wasi/debug/test-wasm32.wasm
+cd -
+
 # run nn graph test
 cd tests/test_nn
 cargo run

--- a/tests/scripts/task_rust.sh
+++ b/tests/scripts/task_rust.sh
@@ -54,11 +54,11 @@ cd tests/test_tvm_dso
 cargo run
 cd -
 
-# run wasm32 test
-cd tests/test_wasm32
-cargo build
-wasmtime $RUST_DIR/target/wasm32-wasi/debug/test-wasm32.wasm
-cd -
+# # run wasm32 test
+# cd tests/test_wasm32
+# cargo build
+# wasmtime $RUST_DIR/target/wasm32-wasi/debug/test-wasm32.wasm
+# cd -
 
 # run nn graph test
 cd tests/test_nn


### PR DESCRIPTION
This PR fixes warnings and errors when targeting wasm32.
- Update the BackendPackedCFunc signature which was changed in #4637.
- Use derive_default() for bindgen to handle the generated padding field.
- Add workaround for nom::length_data, which doesn't allow u64 on 32-bit architecture.
- Terminate the thread safely instead of panic when crossbeam-channel is closed.
- Remove unused import warnings.

@jroesch @nhynes @ehsanmok @tqchen Please help to review.