### PR TITLE
Link necessary libraries when building runtime for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,11 +146,35 @@ else(MSVC)
   if(BUILD_FOR_HEXAGON)
     message(STATUS "Building for Hexagon")
   endif()
+
+  # Detect if we're compiling for Android.
+  set(TEST_FOR_ANDROID_CXX
+      "#ifndef __ANDROID__"
+      "#error"
+      "#endif"
+      "int main() {}")
+  set(TEST_FOR_ANDROID_DIR
+      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp")
+  set(TEST_FOR_ANDROID_FILE "${TEST_FOR_ANDROID_DIR}/test_for_android.cc")
+  string(REPLACE ";" "\n" TEST_FOR_ANDROID_CXX_TEXT "${TEST_FOR_ANDROID_CXX}")
+  file(WRITE "${TEST_FOR_ANDROID_FILE}" "${TEST_FOR_ANDROID_CXX_TEXT}")
+  try_compile(BUILD_FOR_ANDROID "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}"
+              "${TEST_FOR_ANDROID_FILE}")
+  file(REMOVE "${TEST_FOR_ANDROID_FILE}")
+  if(BUILD_FOR_ANDROID)
+    message(STATUS "Building for Android")
+  endif()
 endif(MSVC)
 
 # Hexagon has dlopen built into QuRT (no need for static library).
 if(NOT BUILD_FOR_HEXAGON)
-  string(APPEND TVM_RUNTIME_LINKER_LIBS ${CMAKE_DL_LIBS})
+  list(APPEND TVM_RUNTIME_LINKER_LIBS ${CMAKE_DL_LIBS})
+endif()
+
+if(BUILD_FOR_ANDROID)
+  # EmuTLS on Android is in libgcc. Without it linked in, libtvm_runtime.so
+  # won't load on Android due to missing __emutls_XXX symbols.
+  list(APPEND TVM_RUNTIME_LINKER_LIBS "gcc")
 endif()
 
 # add source group

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -87,7 +87,11 @@ elseif(USE_HEXAGON_DEVICE STREQUAL "${PICK_HW}")
   include_directories(
       "${HEXAGON_SDK_ROOT}/libs/common/remote/ship/android_Release_aarch64")
   include_directories("${HEXAGON_TOOLCHAIN}/include/iss")
-  list(APPEND TVM_RUNTIME_LINKER_LIBS "-ldl")
+  list(APPEND TVM_RUNTIME_LINKER_LIBS "dl")
+  if(BUILD_FOR_ANDROID)
+    # Hexagon runtime uses __android_log_print, which is in liblog.
+    list(APPEND TVM_RUNTIME_LINKER_LIBS "log")
+  endif()
 endif()
 
 file(GLOB RUNTIME_HEXAGON_SRCS src/runtime/hexagon/*.cc)


### PR DESCRIPTION
- Link libgcc to enable use of thread-local storage (`ThreadLocalStore` requires emutls).
- Link liblog when building with Hexagon support.