### PR TITLE
[uTVM] Reset target and wait for runtime initialization on connect.

### DIFF
--- a/src/runtime/micro/openocd_low_level_device.cc
+++ b/src/runtime/micro/openocd_low_level_device.cc
@@ -20,8 +20,8 @@
 /*!
  * \file openocd_low_level_device.cc
  */
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 
 #include "micro_common.h"
 #include "low_level_device.h"
@@ -46,7 +46,10 @@ class OpenOCDLowLevelDevice final : public LowLevelDevice {
     port_ = port;
 
     socket_.Connect(tvm::support::SockAddr(server_addr_.c_str(), port_));
-    socket_.cmd_builder() << "halt 0";
+    socket_.cmd_builder() << "reset run";
+    socket_.SendCommand();
+
+    socket_.cmd_builder() << "halt 500";
     socket_.SendCommand();
   }
 


### PR DESCRIPTION
 * This ensures a clean runtime environment for tuning and evaluating
   tasks.
 * This patch assumes that the code flashed to target executes the ARM
   BKPT or RISC-V EBREAK instructions after startup.

see mbed runtime for an example of on-device code meant to work with this patch:
https://github.com/areusch/utvm-mbed-runtime