### PR TITLE
[CRT]fix to reduce RAM size during loading model

### DIFF
--- a/src/runtime/crt/graph_runtime.c
+++ b/src/runtime/crt/graph_runtime.c
@@ -672,7 +672,6 @@ void TVMGraphRuntime_SetupStorage(TVMGraphRuntime * runtime) {
       pool_entry_count = sid + 1;
     }
     pool_entry[sid].size = MAX(pool_entry[sid].size, bytes);
-    pool_entry[sid].bits = MAX(pool_entry[sid].bits, t.bits);
     pool_entry[sid].device_type = device_type;
   }
 
@@ -683,23 +682,8 @@ void TVMGraphRuntime_SetupStorage(TVMGraphRuntime * runtime) {
     TVMGraphRuntimePoolEntry pit = pool_entry[idx];
     int64_t shape[TVM_CRT_MAX_NDIM] = {0, };
     TVMContext ctx = runtime->ctxs[0];
-    DLDataType dtype;
-    if (pit.bits == 8) {
-      dtype.code = kDLInt;
-      dtype.bits = 8;
-      dtype.lanes = 1;
-      shape[0] = pit.size;
-    }  else if (pit.bits == 16) {
-      dtype.code = kDLInt;
-      dtype.bits = 16;
-      dtype.lanes = 1;
-      shape[0] = (pit.size + 1) / 2;
-    }  else {
-      dtype.code = kDLFloat;
-      dtype.bits = 32;
-      dtype.lanes = 1;
-      shape[0] = (pit.size + 3) / 4;
-    }
+    DLDataType dtype = {kDLFloat, 32, 1};
+    shape[0] = (pit.size + 3) / 4;
     runtime->storage_pool[runtime->storage_pool_count] = TVMNDArray_Empty(1, shape, dtype, ctx);
     CHECK_NE(runtime->storage_pool[runtime->storage_pool_count].dl_tensor.data, 0,
              "fail to create storage_pool with idx=%d\n", idx);
@@ -831,10 +815,10 @@ void TVMGraphRuntime_Init(TVMGraphRuntime * runtime, const char * graph_json,
                           const TVMModule * module, const TVMContext * ctxs) {
   JSONReader reader = JSONReader_Create(graph_json);
   runtime->Load(runtime, &reader);
+  JSONReader_Release(&reader);
   runtime->ctxs[0] = ctxs[0];
   runtime->SetupStorage(runtime);
   runtime->SetupOpExecs(runtime);
-  JSONReader_Release(&reader);
 }
 
 TVMGraphRuntime * TVMGraphRuntimeCreate(const char * sym_json,

--- a/src/runtime/crt/graph_runtime.h
+++ b/src/runtime/crt/graph_runtime.h
@@ -43,6 +43,7 @@ typedef struct TVMOpParam {
 typedef struct TVMGraphRuntimePoolEntry {
   size_t size;
   int device_type;
+  int bits;
 } TVMGraphRuntimePoolEntry;
 
 // Node entry

--- a/src/runtime/crt/graph_runtime.h
+++ b/src/runtime/crt/graph_runtime.h
@@ -43,7 +43,6 @@ typedef struct TVMOpParam {
 typedef struct TVMGraphRuntimePoolEntry {
   size_t size;
   int device_type;
-  int bits;
 } TVMGraphRuntimePoolEntry;
 
 // Node entry


### PR DESCRIPTION
Free the graph_json immediately after loading the graph to runtime. This will help in saving some RAM for low memory devices.

@liangfu @tmoreau89 Please help to review this code.