### PR TITLE
[RFC] Make tflite frontend more data driven / improve errors.

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -2220,8 +2220,10 @@ class OperatorConverter(object):
         padding = deconv_options.Padding()
         stride_h = deconv_options.StrideH()
         stride_w = deconv_options.StrideW()
-        assert padding in (Padding.VALID, Padding.SAME), \
-            'Padding format {} is not supported for operator TRANSPOSE_CONV'.format(padding)
+
+        if padding not in (Padding.VALID, Padding.SAME):
+            raise tvm.error.OpAttributeUnImplemented('Padding format {} is not supported'\
+                                                     'for operator TRANSPOSE_CONV'.format(padding))
 
         # Data
         in_expr = self.get_expr(input_tensor.tensor_idx)


### PR DESCRIPTION
This is a draft PR and only for discussion but not for merging as is.

These are a couple of commits that show a proof of concept about how we could restructure and improve the tflite frontend. I've lightly tested these by compiling a couple of tflite models to give me some confidence that they work.  If this looks reasonable I'm happy to pull things out into separate individual pull requests that could allow us to migrate to this with newer operators that get added and refactor the existing operators in a piecemeal fashion with time and availability of folks.

The first commit tries to make the tflite operator table more data driven, the observation being that the common case is that of input and output operands being subject to an equality check that we can commonize into the top level. This means we can reduce the number of individual checks in every helper function and thus making it simpler for our developers to add new operators.

The second commit here shows another aspect of the tflite frontend which is the use of asserts instead of using tvm.error . If we have a set of errors that can be raised by the various frontends attached to tvm, we should use them more efficiently. 

Thanks,
Ramana

@tqchen , @anijain2305 , @FrozenGene - comments / reviews would be welcome.
