### PR TITLE
POC refactor tflite frontend 

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -112,7 +112,8 @@ def convert_wrapper(name,
                     # Assumes single output tensor
                     output_tensor = op_converter.get_output_tensors(op)[0]
                     if not output_tensor.qnn_params:
-                        out = op_converter.convert_fused_activation_function(out, fused_activation_fn)
+                        out = op_converter.\
+                            convert_fused_activation_function(out, fused_activation_fn)
                     else:
                         raise tvm.error.OpNotImplemented(
                             'TFLite quantized {} operator\

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -553,7 +553,7 @@ class OperatorConverter(object):
     @convert_wrapper("L2_NORMALIZATION", num_inputs=1, num_outputs=1,
                      options_class_str='L2NormOptions', quantized_check=True,
                      do_fuse_activation=True)
-    def convert_l2_normalization(self, op, input_tensors=[], output_tensors=[], options=None):
+    def convert_l2_normalization(self, op, input_tensors=None, output_tensors=None, options=None):
         """Convert TFLite L2_NORMALIZATION """
         input_tensor = input_tensors[0]
         in_expr = self.get_tensor_expr(input_tensor)


### PR DESCRIPTION
While working on TFLite Frontend ops, It was observed that most of the common code can be refactored to a single place.
For example below are few redundant things:
- Input and Output tensor checks
- Getting operator options
- Getting Relay expressions for input tensors
- Quantized check
- Fusing activation functions

This PR is a POC to refactor tflite frontend. It adds a decorator which does all the things mentioned above. Currently, this PR demos the decorator for one operator only. I would like to hear opinions from the community about this approach and then once we decide on an approach/design we can refactor all the operators.

This change will allow new developers to quickly add new operators. Plus it will help reviewers also as new devs like me can not make obvious mistakes. :-)




