### PR TITLE
Changes to cpp_rpc to make it work on Android (+ Hexagon offloading)

### DIFF
--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -67,7 +67,12 @@ namespace {
 namespace tvm {
 namespace runtime {
 RPCEnv::RPCEnv() {
-  base_ = "./rpc";
+  char cwd[PATH_MAX];
+  if (char *rc = getcwd(cwd, sizeof(cwd))) {
+    base_ = std::string(cwd) + "/rpc";
+  } else {
+    base_ = "./rpc";
+  }
   mkdir(base_.c_str(), 0777);
   TVM_REGISTER_GLOBAL("tvm.rpc.server.workpath").set_body([](TVMArgs args, TVMRetValue* rv) {
     static RPCEnv env;

--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -67,12 +67,17 @@ namespace {
 namespace tvm {
 namespace runtime {
 RPCEnv::RPCEnv() {
+#ifndef _WIN32
   char cwd[PATH_MAX];
   if (char *rc = getcwd(cwd, sizeof(cwd))) {
     base_ = std::string(cwd) + "/rpc";
   } else {
     base_ = "./rpc";
   }
+#else
+  base_ = "./rpc";
+#endif
+
   mkdir(base_.c_str(), 0777);
   TVM_REGISTER_GLOBAL("tvm.rpc.server.workpath").set_body([](TVMArgs args, TVMRetValue* rv) {
     static RPCEnv env;


### PR DESCRIPTION
- Implement `getNextString` to break up ~~`std::string`~~`stringstream` into words. Operator `>>` on `stringstream` just doesn't work on Android.
- `string::find_last_of` doesn't look for the last substring, but the last character from a given string.
- Use `SIGTERM` to terminate processes (this isn't necessary, but using `SIGKILL` is not a good practice).
- Convert `./rpc` to a full path. When a module is uploaded and offloaded to Hexagon, the `dlopen` on Hexagon needs an absolute path (or a path without directories).