### PR TITLE
[RPC] Improve RPCServer AsyncIO support.

### DIFF
--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -206,8 +206,6 @@ class RPCEndpoint {
   std::string name_;
   // The remote key
   std::string remote_key_;
-  // AsyncIO
-  bool ayncio_;
 };
 
 /*!

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -206,6 +206,8 @@ class RPCEndpoint {
   std::string name_;
   // The remote key
   std::string remote_key_;
+  // AsyncIO
+  bool ayncio_;
 };
 
 /*!

--- a/src/runtime/rpc/rpc_local_session.h
+++ b/src/runtime/rpc/rpc_local_session.h
@@ -28,6 +28,7 @@
 #include <tvm/runtime/device_api.h>
 #include <functional>
 #include <string>
+#include <utility>
 #include "rpc_session.h"
 
 namespace tvm {
@@ -40,13 +41,13 @@ namespace runtime {
 class LocalSession : public RPCSession {
  public:
   // function overrides
-  PackedFuncHandle GetFunction(const std::string& name) final;
+  PackedFuncHandle GetFunction(const std::string& name) override;
 
   void CallFunc(PackedFuncHandle func,
                 const TVMValue* arg_values,
                 const int* arg_type_codes,
                 int num_args,
-                const FEncodeReturn& fencode_return) final;
+                const FEncodeReturn& fencode_return) override;
 
   void CopyToRemote(void* from,
                     size_t from_offset,
@@ -54,7 +55,7 @@ class LocalSession : public RPCSession {
                     size_t to_offset,
                     size_t nbytes,
                     TVMContext ctx_to,
-                    DLDataType type_hint) final;
+                    DLDataType type_hint) override;
 
   void CopyFromRemote(void* from,
                       size_t from_offset,
@@ -62,23 +63,23 @@ class LocalSession : public RPCSession {
                       size_t to_offset,
                       size_t nbytes,
                       TVMContext ctx_from,
-                      DLDataType type_hint) final;
+                      DLDataType type_hint) override;
 
-  void FreeHandle(void* handle, int type_code) final;
+  void FreeHandle(void* handle, int type_code) override;
 
-  DeviceAPI* GetDeviceAPI(TVMContext ctx, bool allow_missing = false) final;
+  DeviceAPI* GetDeviceAPI(TVMContext ctx, bool allow_missing = false) override;
 
-  bool IsLocalSession() const final {
+  bool IsLocalSession() const override {
     return true;
   }
 
  protected:
   /*!
-   * \brief Internal implementation of GetFunction.
-   * \param name The name of the function.
-   * \return The corresponding PackedFunc.
+   * \brief internal encode return fucntion.
+   * \param rv The return value.
+   * \param encode_return The encoding function.
    */
-  virtual PackedFunc GetFunctionInternal(const std::string& name);
+  void EncodeReturn(TVMRetValue rv, const FEncodeReturn& encode_return);
 };
 
 }  // namespace runtime

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -30,6 +30,93 @@
 namespace tvm {
 namespace runtime {
 
+bool RPCSession::IsAsync() const {
+  return false;
+}
+
+void RPCSession::SendException(FAsyncCallback callback, const char* msg) {
+  TVMValue value;
+  value.v_str = msg;
+  int32_t tcode = kTVMStr;
+  callback(RPCCode::kException, TVMArgs(&value, &tcode, 1));
+}
+
+void RPCSession::AsyncCallFunc(PackedFuncHandle func,
+                               const TVMValue* arg_values,
+                               const int* arg_type_codes,
+                               int num_args,
+                               FAsyncCallback callback) {
+  try {
+    this->CallFunc(func, arg_values, arg_type_codes, num_args,
+                   [&callback](TVMArgs args) {
+                     callback(RPCCode::kReturn, args);
+                   });
+  } catch (const std::runtime_error& e) {
+    this->SendException(callback, e.what());
+  }
+}
+
+
+void RPCSession::AsyncCopyToRemote(void* local_from,
+                                   size_t local_from_offset,
+                                   void* remote_to,
+                                   size_t remote_to_offset,
+                                   size_t nbytes,
+                                   TVMContext remote_ctx_to,
+                                   DLDataType type_hint,
+                                   RPCSession::FAsyncCallback callback) {
+  TVMValue value;
+  int32_t tcode = kTVMNullptr;
+  value.v_handle = nullptr;
+
+  try {
+    this->CopyToRemote(local_from, local_from_offset,
+                       remote_to, remote_to_offset,
+                       nbytes, remote_ctx_to, type_hint);
+    callback(RPCCode::kReturn, TVMArgs(&value, &tcode, 1));
+  } catch (const std::runtime_error& e) {
+    this->SendException(callback, e.what());
+  }
+}
+
+void RPCSession::AsyncCopyFromRemote(void* remote_from,
+                                     size_t remote_from_offset,
+                                     void* local_to,
+                                     size_t local_to_offset,
+                                     size_t nbytes,
+                                     TVMContext remote_ctx_from,
+                                     DLDataType type_hint,
+                                     RPCSession::FAsyncCallback callback) {
+  TVMValue value;
+  int32_t tcode = kTVMNullptr;
+  value.v_handle = nullptr;
+
+  try {
+    this->CopyFromRemote(remote_from, remote_from_offset,
+                         local_to, local_to_offset,
+                         nbytes, remote_ctx_from, type_hint);
+    callback(RPCCode::kReturn, TVMArgs(&value, &tcode, 1));
+  } catch (const std::runtime_error& e) {
+    this->SendException(callback, e.what());
+  }
+}
+
+void RPCSession::AsyncStreamWait(TVMContext ctx,
+                                 TVMStreamHandle stream,
+                                 RPCSession::FAsyncCallback callback) {
+  TVMValue value;
+  int32_t tcode = kTVMNullptr;
+  value.v_handle = nullptr;
+
+  try {
+    this->GetDeviceAPI(ctx)->StreamSync(ctx, stream);
+    callback(RPCCode::kReturn, TVMArgs(&value, &tcode, 1));
+  } catch (const std::runtime_error& e) {
+    this->SendException(callback, e.what());
+  }
+}
+
+
 class RPCSessTable {
  public:
   static constexpr int kMaxRPCSession = 32;

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include "rpc_protocol.h"
 
 namespace tvm {
 namespace runtime {
@@ -58,7 +59,6 @@ class RPCSession {
    * \brief Callback to send an encoded return values via encode_args.
    *
    * \param encode_args The arguments that we can encode the return values into.
-   * \param ret_tcode The actual remote type code of the return value.
    *
    * Encoding convention (as list of arguments):
    * - str/float/int/byte: [tcode: int, value: TVMValue] value follows PackedFunc convention.
@@ -68,6 +68,14 @@ class RPCSession {
    *            nd_handle can be used for deletion.
    */
   using FEncodeReturn = std::function<void(TVMArgs encoded_args)>;
+
+  /*!
+   * \brief Callback to send an encoded return values via encode_args.
+   *
+   * \param status The return status, can be RPCCode::kReturn or RPCCode::kException.
+   * \param encode_args The arguments that we can encode the return values into.
+   */
+  using FAsyncCallback = std::function<void(RPCCode status, TVMArgs encoded_args)>;
 
   /*! \brief Destructor.*/
   virtual ~RPCSession() {}
@@ -189,6 +197,98 @@ class RPCSession {
    */
   virtual bool IsLocalSession() const = 0;
 
+  // Asynchrous variant of API
+  // These APIs are used by the RPC server to allow sessions that
+  // have special implementations for the async functions.
+  //
+  // In the async APIs, an exception is returned by the passing
+  // async_error=true, encode_args=[error_msg].
+
+  /*!
+   * \brief Whether the session is async.
+   *
+   * If the session is not async, its Aync implementations
+   * simply calls into the their synchronize counterparts,
+   * and the callback is guaranteed to be called before the async function finishes.
+   *
+   * \return the async state.
+   *
+   * \note We can only use async session in an Event driven RPC server.
+   */
+  virtual bool IsAsync() const;
+
+  /*!
+   * \brief Asynchrously call func.
+   * \param func The function handle.
+   * \param arg_values The argument values.
+   * \param arg_type_codes the type codes of the argument.
+   * \param num_args Number of arguments.
+   *
+   * \param callback The callback to pass the return value or exception.
+   */
+  virtual void AsyncCallFunc(PackedFuncHandle func,
+                             const TVMValue* arg_values,
+                             const int* arg_type_codes,
+                             int num_args,
+                             FAsyncCallback callback);
+
+  /*!
+   * \brief Asynchrous version of CopyToRemote.
+   *
+   * \param local_from The source host data.
+   * \param local_from_offset The byte offeset in the from.
+   * \param remote_to The target array.
+   * \param remote_to_offset The byte offset in the to.
+   * \param nbytes The size of the memory in bytes.
+   * \param remote_ctx_to The target context.
+   * \param type_hint Hint of content data type.
+   *
+   * \param on_complete The callback to signal copy complete.
+   * \note All the allocated memory in local_from, and remote_to
+   *       must stay alive until on_compelete is called.
+   */
+  virtual void AsyncCopyToRemote(void* local_from,
+                                 size_t local_from_offset,
+                                 void* remote_to,
+                                 size_t remote_to_offset,
+                                 size_t nbytes,
+                                 TVMContext remote_ctx_to,
+                                 DLDataType type_hint,
+                                 FAsyncCallback on_complete);
+
+  /*!
+   * \brief Asynchrous version of CopyFromRemote.
+   *
+   * \param local_from The source host data.
+   * \param local_from_offset The byte offeset in the from.
+   * \param remote_to The target array.
+   * \param remote_to_offset The byte offset in the to.
+   * \param nbytes The size of the memory in bytes.
+   * \param remote_ctx_to The target context.
+   * \param type_hint Hint of content data type.
+   *
+   * \param on_complete The callback to signal copy complete.
+   * \note All the allocated memory in remote_from, and local_to
+   *       must stay alive until on_compelete is called.
+   */
+  virtual void AsyncCopyFromRemote(void* remote_from,
+                                   size_t remote_from_offset,
+                                   void* local_to,
+                                   size_t local_to_offset,
+                                   size_t nbytes,
+                                   TVMContext remote_ctx_from,
+                                   DLDataType type_hint,
+                                   FAsyncCallback on_complete);
+  /*!
+   * \brief Asynchrously wait for all events in ctx, stream compeletes.
+   * \param ctx The device context.
+   * \param stream The stream to wait on.
+   * \param on_complete The callback to signal copy complete.
+   */
+  virtual void AsyncStreamWait(TVMContext ctx,
+                               TVMStreamHandle stream,
+                               FAsyncCallback on_compelte);
+
   /*!
    * \return The session table index of the session.
    */
@@ -202,6 +302,13 @@ class RPCSession {
    * \return The shared_ptr to the session, can be nullptr.
    */
   static std::shared_ptr<RPCSession> Get(int table_index);
+
+ protected:
+  /*!
+   * \brief Send an exception to the callback.
+   * \param msg The exception message.
+   */
+  void SendException(FAsyncCallback callback, const char* msg);
 
  private:
   /*! \brief index of this session in RPC session table */

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -259,12 +259,12 @@ class RPCSession {
   /*!
    * \brief Asynchrous version of CopyFromRemote.
    *
-   * \param local_from The source host data.
-   * \param local_from_offset The byte offeset in the from.
-   * \param remote_to The target array.
-   * \param remote_to_offset The byte offset in the to.
+   * \param remote_from The source host data.
+   * \param remote_from_offset The byte offeset in the from.
+   * \param to The target array.
+   * \param to_offset The byte offset in the to.
    * \param nbytes The size of the memory in bytes.
-   * \param remote_ctx_to The target context.
+   * \param remote_ctx_from The source context in the remote.
    * \param type_hint Hint of content data type.
    *
    * \param on_complete The callback to signal copy complete.


### PR DESCRIPTION
When the RPCServer is in the async IO mode, it is possible for the server
to directly serve async function that may return its value via a callback in the future.
This mode is particular useful to the web environment, where blocking is not an option.

This PR introduces the Async support to the RPCSession, allowing the AsyncIO driven servers
to serve the async functions. These functions will still be presented as synchronized version
on the client side.

Followup PR will refactor the web runtime to make use of this feature.
