### PR TITLE
[WEB][RUNTIME] WebGPU support

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -83,6 +83,7 @@ typedef enum {
   kOpenGL = 11,
   kDLMicroDev = 13,
   kDLHexagon = 14,
+  kDLWebGPU = 15
   // AddExtraTVMType which is not in DLPack here
 } TVMDeviceExtType;
 

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -226,6 +226,7 @@ inline const char* DeviceName(int type) {
     case kDLROCM: return "rocm";
     case kOpenGL: return "opengl";
     case kDLExtDev: return "ext_dev";
+    case kDLWebGPU: return "webgpu";
     case kDLMicroDev: return "micro_dev";
     case kDLHexagon: return "hexagon";
     default: LOG(FATAL) << "unknown type =" << type; return "Unknown";

--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -90,6 +90,7 @@ def find_lib_path(name=None, search_path=None, optional=False):
 
     if os.path.isdir(source_dir):
         dll_path.append(os.path.join(source_dir, "web", "dist", "wasm"))
+        dll_path.append(os.path.join(source_dir, "web", "dist"))
 
     dll_path = [os.path.realpath(x) for x in dll_path]
     if search_path is not None:

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -147,6 +147,7 @@ class TVMContext(ctypes.Structure):
         12: 'ext_dev',
         13: 'micro_dev',
         14: 'hexagon',
+        15: 'webgpu'
     }
     STR2MASK = {
         'llvm': 1,
@@ -169,6 +170,7 @@ class TVMContext(ctypes.Structure):
         'ext_dev': 12,
         'micro_dev': 13,
         'hexagon': 14,
+        'webgpu': 15,
     }
     def __init__(self, device_type, device_id):
         super(TVMContext, self).__init__()

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -66,6 +66,7 @@ def _alias(name):
         'vtacpu': 'vta',
 
         'metal': 'opencl',
+        'webgpu': 'opencl',
         'vulkan': 'opencl',
         'nvptx': 'cuda',
     }

--- a/python/tvm/contrib/emcc.py
+++ b/python/tvm/contrib/emcc.py
@@ -61,6 +61,7 @@ def create_tvmjs_wasm(output,
         objects += [find_lib_path("wasm_runtime.bc")[0]]
 
     objects += [find_lib_path("tvmjs_support.bc")[0]]
+    objects += [find_lib_path("webgpu_runtime.bc")[0]]
 
     cmd += ["-o", output]
     cmd += objects

--- a/python/tvm/exec/rpc_proxy.py
+++ b/python/tvm/exec/rpc_proxy.py
@@ -31,14 +31,20 @@ def find_example_resource():
     curr_path = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
     base_path = os.path.abspath(os.path.join(curr_path, "..", "..", ".."))
     index_page = os.path.join(base_path, "web", "apps", "browser", "rpc_server.html")
-    js_files = [
-        os.path.join(base_path, "web/dist/tvmjs.bundle.js"),
-        os.path.join(base_path, "web/dist/wasm/tvmjs_runtime.wasi.js")
+    resource_files = [
+        os.path.join(base_path, "web", "dist", "tvmjs.bundle.js"),
+        os.path.join(base_path, "web", "dist", "wasm", "tvmjs_runtime.wasi.js")
     ]
-    for fname in [index_page] + js_files:
+    resource_base = os.path.join(base_path, "web", "dist", "www")
+    if os.path.isdir(resource_base):
+        for fname in os.listdir(resource_base):
+            full_name = os.path.join(resource_base, fname)
+            if os.path.isfile(full_name):
+                resource_files.append(full_name)
+    for fname in [index_page] + resource_files:
         if not os.path.exists(fname):
             raise RuntimeError("Cannot find %s" % fname)
-    return index_page, js_files
+    return index_page, resource_files
 
 
 def main(args):

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -190,6 +190,10 @@ class RPCSession(object):
         """Construct extension device."""
         return self.context(12, dev_id)
 
+    def webgpu(self, dev_id=0):
+        """Construct WebGPU device."""
+        return self.context(15, dev_id)
+
 
 class LocalSession(RPCSession):
     """RPCSession interface backed by local environment.

--- a/python/tvm/rpc/proxy.py
+++ b/python/tvm/rpc/proxy.py
@@ -130,7 +130,7 @@ class ForwardHandler(object):
     def on_close_event(self):
         """on close event"""
         assert not self._done
-        logging.info("RPCProxy:on_close %s ...", self.name())
+        logging.info("RPCProxy:on_close_event %s ...", self.name())
         if self.match_key:
             key = self.match_key
             if self._proxy._client_pool.get(key, None) == self:
@@ -158,10 +158,12 @@ class TCPHandler(tornado_util.TCPHandler, ForwardHandler):
         self.on_data(message)
 
     def on_close(self):
+        logging.info("RPCProxy: on_close %s ...", self.name())
+        self._close_process = True
+
         if self.forward_proxy:
             self.forward_proxy.signal_close()
             self.forward_proxy = None
-        logging.info("%s Close socket..", self.name())
         self.on_close_event()
 
 
@@ -187,6 +189,7 @@ class WebSocketHandler(websocket.WebSocketHandler, ForwardHandler):
             self.on_error(err)
 
     def on_close(self):
+        logging.info("RPCProxy: on_close %s ...", self.name())
         if self.forward_proxy:
             self.forward_proxy.signal_close()
             self.forward_proxy = None

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -319,7 +319,7 @@ class Module(object):
 
         if self.imported_modules:
             if enabled("llvm") and llvm_target_triple:
-                path_obj = temp.relpath("devc.o")
+                path_obj = temp.relpath("devc." + object_format)
                 m = _ffi_api.ModulePackImportsToLLVM(self, is_system_lib, llvm_target_triple)
                 m.save(path_obj)
                 files.append(path_obj)

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -478,6 +478,22 @@ def hexagon(dev_id=0):
     return TVMContext(14, dev_id)
 
 
+def webgpu(dev_id=0):
+    """Construct a webgpu device.
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    ctx : TVMContext
+        The created context
+    """
+    return TVMContext(15, dev_id)
+
+
 cl = opencl
 mtl = metal
 

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -750,8 +750,10 @@ class VulkanModuleNode final : public runtime::ModuleNode {
     }
   }
 
-  std::shared_ptr<VulkanPipeline> GetPipeline(size_t device_id, const std::string& func_name,
-                                               size_t num_pack_args) {
+  std::shared_ptr<VulkanPipeline> GetPipeline(
+      size_t device_id,
+      const std::string& func_name,
+      size_t num_pack_args) {
     const auto& vctx = VulkanDeviceAPI::Global()->context(device_id);
     std::lock_guard<std::mutex> lock(mutex_);
     const auto& cp = ecache_[device_id][func_name];
@@ -776,6 +778,7 @@ class VulkanModuleNode final : public runtime::ModuleNode {
     std::vector<VkDescriptorSetLayoutBinding> arg_binding;
     std::vector<VkDescriptorUpdateTemplateEntryKHR> arg_template;
     uint32_t num_pod = 0, num_buffer = 0;
+
     {
       auto fit = fmap_.find(func_name);
       CHECK(fit != fmap_.end());
@@ -931,8 +934,6 @@ class VulkanModuleNode final : public runtime::ModuleNode {
   }
 
  private:
-  // the binary data
-  std::vector<uint32_t> data_;
   // function information table.
   std::unordered_map<std::string, VulkanShader> smap_;
   // function information table.

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -30,7 +30,9 @@
 namespace tvm {
 namespace codegen {
 
-std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const PrimFunc& f) {
+std::vector<uint32_t> CodeGenSPIRV::BuildFunction(
+    const PrimFunc& f,
+    const std::string& name) {
   this->InitFuncState();
   CHECK(f->HasNonzeroAttr(tir::attr::kNoAlias))
       << "SPIRV only takes restricted memory model";
@@ -77,12 +79,7 @@ std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const PrimFunc& f) {
   builder_->MakeInst(spv::OpReturn);
   builder_->MakeInst(spv::OpFunctionEnd);
 
-  auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol);
-  CHECK(global_symbol.defined())
-      << "CodeGenSPIRV: Expect PrimFunc to have the global_symbol attribute";
-
-  builder_->CommitKernelFunction(
-    func_ptr, static_cast<std::string>(global_symbol.value()));
+  builder_->CommitKernelFunction(func_ptr, name);
 
   return builder_->Finalize();
 }

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -32,6 +32,7 @@
 #include <vector>
 #include <memory>
 #include <unordered_map>
+#include <string>
 
 #include "ir_builder.h"
 #include "../../runtime/thread_storage_scope.h"
@@ -51,9 +52,11 @@ class CodeGenSPIRV:
   /*!
    * \brief Compile and add function f to the current module.
    * \param f The function to be added.
+   * \param name The name of the target function.
    * \return The final spirv module.
    */
-  virtual std::vector<uint32_t> BuildFunction(const PrimFunc& f);
+  virtual std::vector<uint32_t> BuildFunction(const PrimFunc& f,
+                                              const std::string& name);
   /*!
    * \brief Create Value for expression e
    * \param e The expression to be created value for.

--- a/src/target/spirv/intrin_rule_spirv.cc
+++ b/src/target/spirv/intrin_rule_spirv.cc
@@ -65,6 +65,7 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.fabs")
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.exp")
 .set_body(DispatchGLSLPureIntrin<GLSLstd450Exp>);
 
+
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.log")
 .set_body(DispatchGLSLPureIntrin<GLSLstd450Log>);
 
@@ -75,6 +76,37 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.pow")
 .set_body(DispatchGLSLPureIntrin<GLSLstd450Pow>);
 
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.tanh")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Tanh>);
+
+// WebGPU rules.
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.floor")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Floor>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.ceil")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Ceil>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.round")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Round>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.trunc")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Trunc>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.fabs")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450FAbs>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.exp")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Exp>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.log")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Log>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.sqrt")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Sqrt>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.pow")
+.set_body(DispatchGLSLPureIntrin<GLSLstd450Pow>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.webgpu.tanh")
 .set_body(DispatchGLSLPureIntrin<GLSLstd450Tanh>);
 
 }  // namespace spirv

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -40,6 +40,7 @@ namespace tvm {
 namespace codegen {
 namespace spirv {
 
+
 /*! \brief Represent the SPIRV Type */
 struct SType {
   /*! \brief The Id to represent type */
@@ -301,6 +302,7 @@ class IRBuilder {
     data.insert(data.end(), debug_.begin(), debug_.end());
     data.insert(data.end(), decorate_.begin(), decorate_.end());
     data.insert(data.end(), global_.begin(), global_.end());
+    data.insert(data.end(), func_header_.begin(), func_header_.end());
     data.insert(data.end(), function_.begin(), function_.end());
     return data;
   }
@@ -612,6 +614,8 @@ class IRBuilder {
   std::vector<uint32_t> decorate_;
     /*! \brief Global segment: types, variables, types */
   std::vector<uint32_t> global_;
+  /*! \brief Function header segment */
+  std::vector<uint32_t> func_header_;
   /*! \brief Function segment */
   std::vector<uint32_t> function_;
 };

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -110,11 +110,15 @@ Target CreateTarget(const std::string& target_name,
     if (t->device_name == "intel_graphics") {
       t->thread_warp_size = 16;
     }
-  } else if (target_name == "metal" || target_name == "vulkan") {
+  } else if (target_name == "metal" ||
+             target_name == "vulkan" ||
+             target_name == "webgpu") {
     if (target_name == "metal") {
       t->device_type = kDLMetal;
-    } else {
+    } else if (target_name == "vulkan") {
       t->device_type = kDLVulkan;
+    } else {
+      t->device_type = kDLWebGPU;
     }
     t->keys_array.push_back(target_name);
     t->keys_array.push_back("gpu");
@@ -139,6 +143,9 @@ Target CreateTarget(const std::string& target_name,
   } else if (target_name == "hexagon") {
     t->keys_array.push_back("hexagon");
     t->device_type = kDLHexagon;
+  } else if (target_name == "webgpu") {
+    t->keys_array.push_back("webgpu");
+    t->device_type = kDLWebGPU;
   } else {
     LOG(ERROR) << "Unknown target name " << target_name << "; falling back to stackvm";
     return target::stackvm();

--- a/web/Makefile
+++ b/web/Makefile
@@ -20,7 +20,7 @@ TVM_ROOT=$(shell cd ..; pwd)
 INCLUDE_FLAGS = -I$(TVM_ROOT) -I$(TVM_ROOT)/include\
 	-I$(TVM_ROOT)/3rdparty/dlpack/include -I$(TVM_ROOT)/3rdparty/dmlc-core/include
 
-.PHONY: clean all
+.PHONY: clean all removetypedep
 
 all: dist/wasm/tvmjs_runtime.wasm dist/wasm/tvmjs_runtime.wasi.js
 
@@ -37,7 +37,7 @@ dist/wasm/%.bc: emcc/%.cc
 	$(EMCC) $(EMCC_CFLAGS) -c -o dist/wasm/$*.bc $<
 
 
-dist/wasm/tvmjs_runtime.wasm: dist/wasm/wasm_runtime.bc dist/wasm/tvmjs_support.bc
+dist/wasm/tvmjs_runtime.wasm: dist/wasm/wasm_runtime.bc dist/wasm/tvmjs_support.bc dist/wasm/webgpu_runtime.bc
 	@mkdir -p $(@D)
 	$(EMCC)  $(EMCC_CFLAGS) -o dist/wasm/tvmjs_runtime.js $+ $(EMCC_LDFLAGS)
 

--- a/web/README.md
+++ b/web/README.md
@@ -82,3 +82,16 @@ The following is an example to reproduce this.
   - Browswer version:  open https://localhost:8888, click connect to proxy
   - NodeJS version: `npm run rpc`
 - run `python tests/node/websock_rpc_test.py` to run the rpc client.
+
+
+## WebGPU Experiments
+
+Web gpu is still experimental, so apis can change.
+Right now we use the SPIRV to generate shaders that can be accepted by Chrome and Firefox.
+
+- Obtain a browser that support webgpu.
+  - So far only Chrome Canary on MacOS works
+  - Firefox should be close pending the support of Fence.
+- Download vulkan SDK (1.1 or higher) that supports SPIRV 1.3
+- Start the WebSocket RPC
+- run `python tests/node/webgpu_rpc_test.py`

--- a/web/apps/browser/rpc_server.html
+++ b/web/apps/browser/rpc_server.html
@@ -74,6 +74,6 @@
     <button onclick="connectRPC()">Connect To Proxy</button>
     <button onclick="clearLog()">Clear Log</button>
     <div id="log"></div>
-    <canvas id="canvas"></canvas>
+    <canvas id="canvas" width="224" height="224"></canvas>
   </body>
 </html>

--- a/web/emcc/tvmjs_support.cc
+++ b/web/emcc/tvmjs_support.cc
@@ -37,6 +37,7 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/container.h>
 #include <tvm/runtime/device_api.h>
+#include "../../src/runtime/rpc/rpc_local_session.h"
 
 extern "C" {
 // --- Additional C API for the Wasm runtime ---
@@ -108,85 +109,224 @@ int TVMWasmFuncCreateFromCFunc(void* resource_handle,
 namespace tvm {
 namespace runtime {
 
-// chrono in the WASI does not provide very accurate time support
-// and also have problems in the i64 support in browser.
-// We redirect the timer to a JS side time using performance.now
-PackedFunc WrapWasmTimeEvaluator(PackedFunc pf,
-                                 TVMContext ctx,
-                                 int number,
-                                 int repeat,
-                                 int min_repeat_ms) {
-  auto ftimer = [pf, ctx, number, repeat, min_repeat_ms](
-      TVMArgs args, TVMRetValue *rv) {
-
-    TVMRetValue temp;
-    auto finvoke = [&](int n) {
-      // start timing
-      for (int i = 0; i < n; ++i) {
-        pf.CallPacked(args, &temp);
-      }
-      DeviceAPI::Get(ctx)->StreamSync(ctx, nullptr);
-    };
-
-    auto* get_timer = runtime::Registry::Get("wasm.GetTimer");
-    CHECK(get_timer != nullptr) << "Cannot find wasm.GetTimer in the global function";
-    TypedPackedFunc<double(int number)> timer_ms = (*get_timer)(
-        TypedPackedFunc<void(int)>(finvoke));
-
-    std::ostringstream os;
-    finvoke(1);
-
-    int setup_number = number;
-
-    for (int i = 0; i < repeat; ++i) {
-      double duration_ms = 0.0;
-
-      do {
-        if (duration_ms > 0.0) {
-          setup_number = static_cast<int>(
-              std::max((min_repeat_ms / (duration_ms / number) + 1),
-                       number * 1.618));   // 1.618 is chosen by random
-        }
-        duration_ms = timer_ms(setup_number);
-      } while (duration_ms < min_repeat_ms);
-
-      double speed = duration_ms / setup_number / 1000;
-      os.write(reinterpret_cast<char*>(&speed), sizeof(speed));
-    }
-
-    std::string blob = os.str();
-    TVMByteArray arr;
-    arr.size = blob.length();
-    arr.data = blob.data();
-    // return the time.
-    *rv = arr;
-  };
-  return PackedFunc(ftimer);
-}
-
-TVM_REGISTER_GLOBAL("wasm.RPCTimeEvaluator")
-.set_body_typed([](Optional<Module> opt_mod,
-                   std::string name,
-                   int device_type,
-                   int device_id,
-                   int number,
-                   int repeat,
-                   int min_repeat_ms) {
-  TVMContext ctx;
-  ctx.device_type = static_cast<DLDeviceType>(device_type);
-  ctx.device_id = device_id;
-
-  if (opt_mod.defined()) {
-    Module m = opt_mod.value();
-    std::string tkey = m->type_key();
-    return WrapWasmTimeEvaluator(
-        m.GetFunction(name, false), ctx, number, repeat, min_repeat_ms);
-  } else {
-    auto* pf = runtime::Registry::Get(name);
-    CHECK(pf != nullptr) << "Cannot find " << name << " in the global function";
-    return WrapWasmTimeEvaluator(
-        *pf, ctx, number, repeat, min_repeat_ms);
+// A special local session that can interact with async
+// functions in the JS runtime.
+class AsyncLocalSession : public LocalSession {
+ public:
+  AsyncLocalSession() {
   }
+
+  PackedFuncHandle GetFunction(const std::string& name) final {
+    if (name == "runtime.RPCTimeEvaluator") {
+      return get_time_eval_placeholder_.get();
+    } else if (auto* fp = tvm::runtime::Registry::Get(name)) {
+      // return raw handle because the remote need to explicitly manage it.
+      return new PackedFunc(*fp);
+    } else if(auto* fp = tvm::runtime::Registry::Get("__async." + name)) {
+      auto* rptr = new PackedFunc(*fp);
+      async_func_set_.insert(rptr);
+      return rptr;
+    } else {
+      return nullptr;
+    }
+  }
+
+  void FreeHandle(void* handle, int type_code) final {
+    if (type_code == kTVMPackedFuncHandle) {
+      auto it = async_func_set_.find(handle);
+      if (it != async_func_set_.end()) {
+        async_func_set_.erase(it);
+      }
+    }
+    if (handle != get_time_eval_placeholder_.get()) {
+      LocalSession::FreeHandle(handle, type_code);
+    }
+  }
+
+  void AsyncCallFunc(PackedFuncHandle func,
+                     const TVMValue* arg_values,
+                     const int* arg_type_codes,
+                     int num_args,
+                     FAsyncCallback callback) final {
+    auto it = async_func_set_.find(func);
+    if (it != async_func_set_.end()) {
+      PackedFunc packed_callback([callback, this](TVMArgs args, TVMRetValue*) {
+        int code = args[0];
+        TVMRetValue rv;
+        rv = args[1];
+        this->EncodeReturn(std::move(rv), [&](TVMArgs encoded_args) {
+          callback(RPCCode::kReturn, encoded_args);
+        });
+      });
+
+      TVMRetValue temp;
+      std::vector<TVMValue> values(arg_values, arg_values + num_args);
+      std::vector<int> type_codes(arg_type_codes, arg_type_codes + num_args);
+      values.emplace_back(TVMValue());
+      type_codes.emplace_back(0);
+
+      TVMArgsSetter setter(&values[0], &type_codes[0]);
+      // pass the callback as the last argument.
+      setter(num_args, packed_callback);
+
+      auto* pf = static_cast<PackedFunc*>(func);
+      pf->CallPacked(TVMArgs(values.data(), type_codes.data(), num_args + 1), &temp);
+    } else if (func == get_time_eval_placeholder_.get()) {
+      // special handle time evaluator.
+      try {
+        TVMArgs args(arg_values, arg_type_codes, num_args);
+        PackedFunc retfunc = this->GetTimeEvaluator(
+            args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+        TVMRetValue rv;
+        rv = retfunc;
+        this->EncodeReturn(std::move(rv), [&](TVMArgs encoded_args) {
+          // mark as async.
+          async_func_set_.insert(encoded_args.values[1].v_handle);
+          callback(RPCCode::kReturn, encoded_args);
+        });
+      } catch (const std::runtime_error& e) {
+        this->SendException(callback, e.what());
+      }
+    } else {
+      LocalSession::AsyncCallFunc(func, arg_values, arg_type_codes, num_args, callback);
+    }
+  }
+
+  void AsyncCopyToRemote(void* local_from,
+                         size_t local_from_offset,
+                         void* remote_to,
+                         size_t remote_to_offset,
+                         size_t nbytes,
+                         TVMContext remote_ctx_to,
+                         DLDataType type_hint,
+                         FAsyncCallback on_complete) final {
+    TVMContext cpu_ctx;
+    cpu_ctx.device_type = kDLCPU;
+    cpu_ctx.device_id = 0;
+    try {
+      this->GetDeviceAPI(remote_ctx_to)->CopyDataFromTo(
+          local_from, local_from_offset,
+          remote_to, remote_to_offset,
+          nbytes, cpu_ctx, remote_ctx_to, type_hint, nullptr);
+      this->AsyncStreamWait(remote_ctx_to, nullptr, on_complete);
+    } catch (const std::runtime_error& e) {
+      this->SendException(on_complete, e.what());
+    }
+  }
+
+  void AsyncCopyFromRemote(void* remote_from,
+                           size_t remote_from_offset,
+                           void* local_to,
+                           size_t local_to_offset,
+                           size_t nbytes,
+                           TVMContext remote_ctx_from,
+                           DLDataType type_hint,
+                           FAsyncCallback on_complete) final {
+    TVMContext cpu_ctx;
+    cpu_ctx.device_type = kDLCPU;
+    cpu_ctx.device_id = 0;
+    try {
+      this->GetDeviceAPI(remote_ctx_from)->CopyDataFromTo(
+          remote_from, remote_from_offset,
+          local_to, local_to_offset,
+          nbytes, remote_ctx_from, cpu_ctx, type_hint, nullptr);
+      this->AsyncStreamWait(remote_ctx_from, nullptr, on_complete);
+    } catch (const std::runtime_error& e) {
+      this->SendException(on_complete, e.what());
+    }
+  }
+
+  void AsyncStreamWait(TVMContext ctx,
+                       TVMStreamHandle stream,
+                       FAsyncCallback on_complete) final {
+    if (ctx.device_type == kDLCPU) {
+      TVMValue value;
+      int32_t tcode = kTVMNullptr;
+      value.v_handle = nullptr;
+      on_complete(RPCCode::kReturn, TVMArgs(&value, &tcode, 1));
+    } else {
+      CHECK(ctx.device_type == static_cast<DLDeviceType>(kDLWebGPU));
+      if (async_wait_ == nullptr) {
+        async_wait_ = tvm::runtime::Registry::Get("__async.wasm.WebGPUWaitForTasks");
+      }
+      CHECK(async_wait_ != nullptr);
+      PackedFunc packed_callback([on_complete](TVMArgs args, TVMRetValue*) {
+        int code = args[0];
+        on_complete(static_cast<RPCCode>(code),
+                    TVMArgs(args.values + 1, args.type_codes + 1, args.size() - 1));
+      });
+      (*async_wait_)(packed_callback);
+    }
+  }
+
+  bool IsAsync() const final {
+    return true;
+  }
+
+ private:
+  std::unordered_set<void*> async_func_set_;
+  std::unique_ptr<PackedFunc> get_time_eval_placeholder_ = std::make_unique<PackedFunc>();
+  const PackedFunc* async_wait_{nullptr};
+
+  // time evaluator
+  PackedFunc GetTimeEvaluator(Optional<Module> opt_mod,
+                              std::string name,
+                              int device_type,
+                              int device_id,
+                              int number,
+                              int repeat,
+                              int min_repeat_ms) {
+    TVMContext ctx;
+    ctx.device_type = static_cast<DLDeviceType>(device_type);
+    ctx.device_id = device_id;
+
+    if (opt_mod.defined()) {
+      Module m = opt_mod.value();
+      std::string tkey = m->type_key();
+      return WrapWasmTimeEvaluator(
+          m.GetFunction(name, false), ctx, number, repeat, min_repeat_ms);
+    } else {
+      auto* pf = runtime::Registry::Get(name);
+      CHECK(pf != nullptr) << "Cannot find " << name << " in the global function";
+      return WrapWasmTimeEvaluator(
+          *pf, ctx, number, repeat, min_repeat_ms);
+    }
+  }
+
+  // time evaluator
+  PackedFunc WrapWasmTimeEvaluator(PackedFunc pf,
+                                   TVMContext ctx,
+                                   int number,
+                                   int repeat,
+                                   int min_repeat_ms) {
+    auto ftimer = [pf, ctx, number, repeat, min_repeat_ms](
+        TVMArgs args, TVMRetValue *rv) {
+      // the function is a async function.
+      PackedFunc on_complete = args[args.size() - 1];
+      // keep argument alive in finvoke so that they
+      // can be used throughout the async benchmark
+      std::vector<TVMValue> values(args.values, args.values + args.size() - 1);
+      std::vector<int> type_codes(args.type_codes, args.type_codes + args.size() - 1);
+
+      auto finvoke = [pf, values, type_codes](int n) {
+        TVMRetValue temp;
+        TVMArgs invoke_args(values.data(), type_codes.data(), values.size());
+        for (int i = 0; i < n; ++i) {
+          pf.CallPacked(invoke_args, &temp);
+        }
+      };
+      auto* time_exec = runtime::Registry::Get("__async.wasm.TimeExecution");
+      CHECK(time_exec != nullptr) << "Cannot find wasm.GetTimer in the global function";
+      (*time_exec)(TypedPackedFunc<void(int)>(finvoke),
+                   ctx, number, repeat, min_repeat_ms, on_complete);
+    };
+    return PackedFunc(ftimer);
+  }
+};
+
+TVM_REGISTER_GLOBAL("wasm.LocalSession")
+.set_body_typed([]() {
+  return CreateRPCSessionModule(std::make_shared<AsyncLocalSession>());
 });
 
 }  // namespace runtime

--- a/web/emcc/webgpu_runtime.cc
+++ b/web/emcc/webgpu_runtime.cc
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * \file webgpu_runtime.cc
+ * \brief WebGPU runtime based on the TVM JS.
+ */
+
+// configurations for the dmlc log.
+#define DMLC_LOG_CUSTOMIZE 0
+#define DMLC_LOG_STACK_TRACE 0
+#define DMLC_LOG_DEBUG 0
+#define DMLC_LOG_NODATE 1
+#define DMLC_LOG_FATAL_THROW 0
+
+#include <dmlc/thread_local.h>
+#include <tvm/runtime/c_runtime_api.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/device_api.h>
+#include "../../src/runtime/meta_data.h"
+#include "../../src/runtime/workspace_pool.h"
+#include "../../src/runtime/vulkan/vulkan_shader.h"
+
+namespace tvm {
+namespace runtime {
+
+/*! \brief Thread local workspace */
+class WebGPUThreadEntry {
+ public:
+  /*! \brief thread local pool*/
+  WorkspacePool pool;
+  /*! \brief constructor */
+  WebGPUThreadEntry();
+  // get the threadlocal workspace
+  static WebGPUThreadEntry* ThreadLocal();
+};
+
+
+// All the implementations are redirectly to the JS side.
+class WebGPUDeviceAPI : public DeviceAPI {
+ public:
+  WebGPUDeviceAPI() {
+    auto* fp = tvm::runtime::Registry::Get("wasm.WebGPUDeviceAPI");
+    CHECK(fp != nullptr) << "Cannot find wasm.WebGPUContext in the env";
+    auto getter = TypedPackedFunc<PackedFunc(std::string)>(*fp);
+    alloc_space_ = getter("deviceAllocDataSpace");
+    free_space_ = getter("deviceFreeDataSpace");
+    copy_to_gpu_ = getter("deviceCopyToGPU");
+    copy_from_gpu_ = getter("deviceCopyFromGPU");
+    copy_within_gpu_ = getter("deviceCopyWithinGPU");
+  }
+
+  void SetDevice(TVMContext ctx) final {
+  }
+  void GetAttr(TVMContext ctx, DeviceAttrKind kind, TVMRetValue* rv) final {
+    if (kind == kExist) {
+      *rv = 1;
+    }
+  }
+
+  void* AllocDataSpace(TVMContext ctx,
+                       size_t nbytes,
+                       size_t alignment,
+                       DLDataType type_hint) final {
+
+    double ptr_number = alloc_space_(nbytes);
+    return reinterpret_cast<void*>(static_cast<int64_t>(ptr_number));
+  }
+
+  void FreeDataSpace(TVMContext ctx, void* ptr) final {
+    return free_space_(ptr);
+  }
+
+  void CopyDataFromTo(const void* from,
+                      size_t from_offset,
+                      void* to, size_t to_offset, size_t size,
+                      TVMContext ctx_from,
+                      TVMContext ctx_to, DLDataType type_hint,
+                      TVMStreamHandle stream) final {
+    if (static_cast<int>(ctx_from.device_type) == kDLWebGPU &&
+        static_cast<int>(ctx_to.device_type) == kDLWebGPU) {
+      CHECK_EQ(ctx_from.device_id, ctx_to.device_id);
+      copy_within_gpu_(const_cast<void*>(from), from_offset, to, to_offset, size);
+    } else if (static_cast<int>(ctx_from.device_type) == kDLWebGPU &&
+               ctx_to.device_type == kDLCPU) {
+      void* to_ptr = static_cast<uint8_t*>(to) + to_offset;
+      copy_from_gpu_(const_cast<void*>(from), from_offset, to_ptr, size);
+    } else if (ctx_from.device_type == kDLCPU &&
+               static_cast<int>(ctx_to.device_type) == kDLWebGPU) {
+      void* from_ptr = static_cast<uint8_t*>(const_cast<void*>(from)) + from_offset;
+      copy_to_gpu_(from_ptr, to, to_offset, size);
+    } else {
+      LOG(FATAL) << "expect copy from/to WebGPU or between WebGPU";
+    }
+  }
+
+  TVMStreamHandle CreateStream(TVMContext ctx) final {
+    LOG(FATAL) << "Not implemented";
+    return nullptr;
+  }
+
+  void FreeStream(TVMContext ctx, TVMStreamHandle stream) final {
+    LOG(FATAL) << "Not implemented";
+    return;
+  }
+
+  void SyncStreamFromTo(TVMContext ctx, TVMStreamHandle event_src, TVMStreamHandle event_dst) {
+    LOG(FATAL) << "Not implemented";
+    return;
+  }
+
+  void StreamSync(TVMContext ctx, TVMStreamHandle stream) final {
+    LOG(FATAL) << "Not implemented";
+  }
+
+  void SetStream(TVMContext ctx, TVMStreamHandle stream) final {
+    LOG(FATAL) << "Not implemented";
+    return;
+  }
+
+  void* AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) final {
+    return WebGPUThreadEntry::ThreadLocal()->pool.AllocWorkspace(ctx, size);
+  }
+
+  void FreeWorkspace(TVMContext ctx, void* data) final {
+    WebGPUThreadEntry::ThreadLocal()->pool.FreeWorkspace(ctx, data);
+  }
+
+  static const std::shared_ptr<WebGPUDeviceAPI>& Global() {
+    static std::shared_ptr<WebGPUDeviceAPI> inst =
+        std::make_shared<WebGPUDeviceAPI>();
+    return inst;
+  }
+
+ private:
+  // NOTE: js return number as double.
+  TypedPackedFunc<double(int64_t nbytes)> alloc_space_;
+  TypedPackedFunc<void(void* ptr)> free_space_;
+  TypedPackedFunc<void(void* from, void* to, int64_t to_offset, int64_t nbytes)> copy_to_gpu_;
+  TypedPackedFunc<void(void* from, int64_t from_offset, void* to, int64_t nbytes)> copy_from_gpu_;
+  TypedPackedFunc<void(void* from, int64_t from_offset,
+                       void* to, int64_t to_offset, int64_t nbytes)> copy_within_gpu_;
+};
+
+
+typedef dmlc::ThreadLocalStore<WebGPUThreadEntry> WebGPUThreadStore;
+
+WebGPUThreadEntry::WebGPUThreadEntry()
+    : pool(static_cast<DLDeviceType>(kDLWebGPU), WebGPUDeviceAPI::Global()) {
+}
+
+WebGPUThreadEntry* WebGPUThreadEntry::ThreadLocal() {
+  return WebGPUThreadStore::Get();
+}
+
+
+class WebGPUModuleNode final : public runtime::ModuleNode {
+ public:
+  explicit WebGPUModuleNode(std::unordered_map<std::string, VulkanShader> smap,
+                            std::unordered_map<std::string, FunctionInfo> fmap,
+                            std::string source)
+      : smap_(smap), fmap_(fmap), source_(source) {
+    auto* fp = tvm::runtime::Registry::Get("wasm.WebGPUCreateShader");
+    CHECK(fp != nullptr);
+    create_shader_ = *fp;
+  }
+
+  const char* type_key() const final { return "webgpu"; }
+
+  PackedFunc GetFunction(const std::string& name,
+                         const ObjectPtr<Object>& sptr_to_self) final {
+    auto it = smap_.find(name);
+    if (it != smap_.end()) {
+      FunctionInfo info = fmap_.at(name);
+      info.name = name;
+      std::ostringstream os;
+      dmlc::JSONWriter writer(&os);
+      info.Save(&writer);
+      TVMByteArray arr;
+      arr.data = reinterpret_cast<char*>(it->second.data.data());
+      arr.size = it->second.data.size() * sizeof(it->second.data[0]);
+      return create_shader_(os.str(), arr);
+    } else {
+      return PackedFunc(nullptr);
+    }
+  }
+
+  void SaveToFile(const std::string& file_name, const std::string& format) final {
+    LOG(FATAL) << "Not implemented";
+  }
+
+  void SaveToBinary(dmlc::Stream* stream) final {
+    LOG(FATAL) << "Not implemented";
+  }
+
+  std::string GetSource(const std::string& format) final {
+    // can only return source code.
+    return source_;
+  }
+
+ private:
+  // function information table.
+  std::unordered_map<std::string, VulkanShader> smap_;
+  // function information table.
+  std::unordered_map<std::string, FunctionInfo> fmap_;
+  // The source
+  std::string source_;
+  // Callback to get the GPU function.
+  TypedPackedFunc<PackedFunc(std::string finfo, TVMByteArray shader_data)> create_shader_;
+};
+
+
+Module WebGPUModuleLoadBinary(void* strm) {
+  dmlc::Stream* stream = static_cast<dmlc::Stream*>(strm);
+  std::unordered_map<std::string, VulkanShader> smap;
+  std::unordered_map<std::string, FunctionInfo> fmap;
+
+  std::string fmt;
+  stream->Read(&fmt);
+  stream->Read(&fmap);
+  stream->Read(&smap);
+  return Module(make_object<WebGPUModuleNode>(smap, fmap, ""));
+}
+
+// for now webgpu is hosted via a vulkan module.
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_vulkan")
+.set_body_typed(WebGPUModuleLoadBinary);
+
+TVM_REGISTER_GLOBAL("device_api.webgpu")
+.set_body([](TVMArgs args, TVMRetValue* rv) {
+  DeviceAPI* ptr = WebGPUDeviceAPI::Global().get();
+  *rv = static_cast<void*>(ptr);
+});
+
+}  // namespace runtime
+}  // namespace tvm

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,6 @@
     "version": "0.7.0",
     "scripts": {
         "build": "tsc -b",
-        "watch": "tsc -b -w",
         "lint": "eslint -c .eslintrc.json .",
         "bundle": "npm run build && rollup -c rollup.config.js",
         "example": "npm run bundle && node apps/node/example.js",
@@ -15,6 +14,7 @@
     "devDependencies": {
         "typescript": "^3.8.3",
         "@types/node": "^12.12.37",
+        "@webgpu/types": "^0.0.24",
         "eslint": "^6.8.0",
         "@typescript-eslint/eslint-plugin": "^2.29.0",
         "@typescript-eslint/parser": "^2.29.0",
@@ -24,6 +24,5 @@
         "@rollup/plugin-commonjs": "^11.1.0",
         "@rollup/plugin-node-resolve": "^7.1.3",
         "rollup-plugin-typescript2": "^0.27.0"
-    },
-    "dependencies": {}
+    }
 }

--- a/web/rollup.config.js
+++ b/web/rollup.config.js
@@ -27,8 +27,10 @@ export default {
     format: 'umd',
     name: 'tvmjs',
     exports: 'named',
-    globals: {'ws': 'ws'}
+    globals: {'ws': 'ws',
+              'perf_hooks': 'perf_hooks',
+              '@webgpu/types': 'webgputypes'}
   },
   plugins: [commonjs(), resolve()],
-  external: ['ws']
+  external: ['ws', 'perf_hooks', '@webgpu/types']
 };

--- a/web/src/compact.ts
+++ b/web/src/compact.ts
@@ -16,14 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/** NodeJS and Web compact layer */
 
-export {
-  Scalar, DLContext, DLDataType,
-  PackedFunc, Module, NDArray, Instance,
-  instantiate
-} from "./runtime";
-export { Disposable, LibraryProvider } from "./types";
-export { RPCServer } from "./rpc_server";
-export { wasmPath } from "./support";
-export { detectGPUDevice } from "./webgpu";
-export { assert } from "./support";
+/**
+ * Get performance masurement.
+ */
+export function getPeformance(): Performance {
+  if (typeof performance == "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const performanceNode = require("perf_hooks");
+    return performanceNode.performance as Performance;
+  } else {
+    return performance as Performance;
+  }
+}
+
+/**
+ * Create a new websocket for a given URL
+ * @param url The url.
+ */
+export function createWebSocket(url: string): WebSocket {
+  if (typeof WebSocket == "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const WebSocket = require("ws");
+    return new WebSocket(url);
+  } else {
+    return new (WebSocket as any)(url);
+  }
+
+}

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@webgpu/types";
+import { assert } from "./support";
+import { Pointer } from "./ctypes";
+import { Memory } from "./memory";
+
+/** A pointer to points to the raw address space. */
+export type GPUPointer = number;
+
+/**
+ * DetectGPU device in the environment.
+ */
+export async function detectGPUDevice(): Promise<GPUDevice | undefined> {
+  if (typeof navigator !== "undefined" && navigator.gpu !== undefined) {
+    const adapter = await navigator.gpu.requestAdapter();
+    return await adapter.requestDevice();
+  } else {
+    return undefined;
+  }
+}
+
+interface FunctionInfo {
+  name: string;
+  arg_types: Array<string>;
+  thread_axis_tags: Array<string>;
+}
+
+/**
+ * WebGPU context
+ * Manages all the webgpu resources here.
+ */
+export class WebGPUContext {
+  device: GPUDevice;
+  memory: Memory;
+
+  //private readBuffer:;
+  private bufferTable: Array<GPUBuffer | undefined> = [undefined];
+  private bufferTableFreeId: Array<number> = [];
+  private pendingRead: Promise<void> = Promise.resolve();
+  private numPendingReads = 0;
+
+  constructor(memory: Memory, device: GPUDevice) {
+    this.memory = memory;
+    this.device = device;
+  }
+
+  /**
+   * Wait for all pending GPU tasks to complete
+   */
+  async sync(): Promise<void> {
+    const fence = this.device.defaultQueue.createFence();
+    this.device.defaultQueue.signal(fence, 1);
+    if (this.numPendingReads != 0) {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      await Promise.all([fence.onCompletion(1), this.pendingRead]);
+    } else {
+      await fence.onCompletion(1);
+    }
+  }
+
+  /**
+   * Create a PackedFunc that runs the given shader
+   *
+   * @param info The function information in json.
+   * @param data The shader data(in SPIRV)
+   */
+  createShader(info: string, data: Uint8Array): Function {
+    const finfo = JSON.parse(info);
+    const layoutEntries: Array<GPUBindGroupLayoutEntry> = [];
+    for (let i = 0; i < finfo.arg_types.length; ++i) {
+      const dtype = finfo.arg_types[i];
+      if (dtype == "handle") {
+        layoutEntries.push({
+          binding: i,
+          visibility: GPUShaderStage.COMPUTE,
+          type: "storage-buffer"
+        });
+      } else {
+        throw new Error("Cannot handle argument type " + dtype + " in WebGPU shader");
+      }
+    }
+    const bindGroupLayout = this.device.createBindGroupLayout({
+      entries: layoutEntries
+    });
+
+    const pipeline = this.device.createComputePipeline({
+      layout: this.device.createPipelineLayout({
+        bindGroupLayouts: [ bindGroupLayout ]
+      }),
+      computeStage: {
+        module: this.device.createShaderModule({
+          code: new Uint32Array(data.buffer)
+        }),
+        entryPoint: "main"
+      }
+    });
+
+    const dispatchToDim: Array<number> = [];
+
+    for (let i = 0; i < finfo.thread_axis_tags.length; ++i) {
+      const tag: string = finfo.thread_axis_tags[i];
+      if (tag.startsWith("blockIdx.")) {
+        const target: number = tag.charCodeAt(tag.length - 1) - ("x".charCodeAt(0));
+        assert(target >= 0 && target < 3);
+        dispatchToDim.push(target);
+      } else if (tag.startsWith("threadIdx.")) {
+        const target: number = tag.charCodeAt(tag.length - 1) - ("x".charCodeAt(0));
+        assert(target >= 0 && target < 3);
+        dispatchToDim.push(target + 3);
+      } else {
+        throw new Error("Cannot handle thread_axis " + tag);
+      }
+    }
+
+    const submitShader = (...args: Array<GPUPointer | number>): void => {
+      const commandEncoder = this.device.createCommandEncoder();
+      const compute = commandEncoder.beginComputePass();
+      compute.setPipeline(pipeline);
+      const bindGroupEntries: Array<GPUBindGroupEntry> = [];
+      assert(args.length == layoutEntries.length + dispatchToDim.length);
+
+      for (let i = 0; i < layoutEntries.length; ++i) {
+        bindGroupEntries.push({
+          binding: i,
+          resource: {
+            buffer: this.gpuBufferFromPtr(args[i])
+          }
+        });
+      }
+
+      compute.setBindGroup(0, this.device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: bindGroupEntries
+      }));
+      const wl: Array<number> = [1, 1, 1, 1, 1, 1];
+      for (let i = 0; i < dispatchToDim.length; ++i) {
+        wl[dispatchToDim[i]] = args[layoutEntries.length + i];
+      }
+      compute.dispatch(wl[0], wl[1], wl[2]);
+      compute.endPass();
+      const command = commandEncoder.finish();
+      this.device.defaultQueue.submit([command]);
+    };
+
+    return submitShader;
+  }
+
+  /**
+   * Get the device API according to its name
+   * @param The name of the API.
+   * @returns The corresponding device api.
+   */
+  getDeviceAPI(name: string): Function {
+    if (name == "deviceAllocDataSpace") {
+      return (nbytes: number): GPUPointer => {
+        return this.deviceAllocDataSpace(nbytes);
+      };
+    } else if (name == "deviceFreeDataSpace") {
+      return (ptr: GPUPointer): void => {
+        return this.deviceFreeDataSpace(ptr);
+      };
+    } else if (name == "deviceCopyToGPU") {
+      return (
+        from: Pointer,
+        to: GPUPointer,
+        toOffset: number,
+        nbytes: number
+      ): void => {
+        this.deviceCopyToGPU(from, to, toOffset, nbytes);
+      };
+    } else if (name == "deviceCopyFromGPU") {
+      return (
+        from: GPUPointer,
+        fromOffset: number,
+        to: Pointer,
+        nbytes: number
+      ): void => {
+        this.deviceCopyFromGPU(from, fromOffset, to, nbytes);
+      };
+    } else if (name == "deviceCopyWithinGPU") {
+      return (
+        from: GPUPointer,
+        fromOffset: number,
+        to: Pointer,
+        toOffset: number,
+        nbytes: number
+      ): void => {
+        this.deviceCopyWithinGPU(from, fromOffset, to, toOffset, nbytes);
+      };
+    } else {
+      throw new Error("Unknown DeviceAPI function " + name);
+    }
+
+  }
+
+  // DeviceAPI
+  private deviceAllocDataSpace(nbytes: number): GPUPointer {
+    const buffer = this.device.createBuffer({
+      size: nbytes,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+    return this.attachToBufferTable(buffer);
+  }
+
+  private deviceFreeDataSpace(ptr: GPUPointer): void {
+    const idx = ptr;
+    const buffer = this.bufferTable[idx];
+    this.bufferTable[idx] = undefined;
+    assert(buffer !== undefined);
+    this.bufferTableFreeId.push(idx);
+    buffer.destroy();
+  }
+
+  private deviceCopyToGPU(
+    from: Pointer,
+    to: GPUPointer,
+    toOffset: number,
+    nbytes: number
+  ): void {
+    // Perhaps it would be more useful to use a staging buffer?
+    const [gpuTemp, cpuTemp] = this.device.createBufferMapped({
+      size: nbytes,
+      usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
+    });
+
+    const viewU8 = new Uint8Array(cpuTemp);
+    viewU8.set(this.memory.loadRawBytes(from, nbytes));
+    gpuTemp.unmap();
+
+    const copyEncoder = this.device.createCommandEncoder();
+    copyEncoder.copyBufferToBuffer(
+      gpuTemp,
+      0,
+      this.gpuBufferFromPtr(to),
+      toOffset,
+      nbytes
+    );
+    const copyCommands = copyEncoder.finish();
+    this.device.defaultQueue.submit([copyCommands]);
+    gpuTemp.destroy();
+  }
+
+  private deviceCopyFromGPU(
+    from: GPUPointer,
+    fromOffset: number,
+    to: Pointer,
+    nbytes: number
+  ): void {
+    // Perhaps it would be more useful to resuse a staging buffer?
+    const gpuTemp = this.device.createBuffer({
+      size: nbytes,
+      usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    });
+
+    const copyEncoder = this.device.createCommandEncoder();
+    copyEncoder.copyBufferToBuffer(
+      this.gpuBufferFromPtr(from),
+      fromOffset,
+      gpuTemp,
+      0,
+      nbytes
+    );
+    const copyCommands = copyEncoder.finish();
+    this.device.defaultQueue.submit([copyCommands]);
+
+    this.numPendingReads += 1;
+    const readEvent = gpuTemp.mapReadAsync().then((data: ArrayBuffer) => {
+      this.memory.storeRawBytes(to, new Uint8Array(data));
+      this.numPendingReads -= 1;
+      gpuTemp.destroy();
+    });
+
+    if (this.numPendingReads == 1) {
+      this.pendingRead = readEvent;
+    } else {
+      this.pendingRead = Promise.all([
+        this.pendingRead,
+        readEvent,
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+      ]).then(() => {});
+    }
+  }
+
+  private deviceCopyWithinGPU(
+    from: GPUPointer,
+    fromOffset: number,
+    to: Pointer,
+    toOffset: number,
+    nbytes: number
+  ): void {
+    const copyEncoder = this.device.createCommandEncoder();
+    copyEncoder.copyBufferToBuffer(
+      this.gpuBufferFromPtr(from),
+      fromOffset,
+      this.gpuBufferFromPtr(to),
+      toOffset,
+      nbytes
+    );
+    const copyCommands = copyEncoder.finish();
+    this.device.defaultQueue.submit([copyCommands]);
+  }
+
+  private gpuBufferFromPtr(ptr: GPUPointer): GPUBuffer {
+    const buffer = this.bufferTable[ptr];
+    assert(buffer !== undefined);
+    return buffer;
+  }
+
+  private attachToBufferTable(buffer: GPUBuffer): GPUPointer {
+    if (this.bufferTableFreeId.length != 0) {
+      const idx = this.bufferTableFreeId.pop() as number;
+      this.bufferTable[idx] = buffer;
+      return idx;
+    } else {
+      const idx = this.bufferTable.length;
+      this.bufferTable.push(buffer);
+      return idx;
+    }
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,7 +6,7 @@
 		"rootDir": "src",
 		"declaration": true,
 		"sourceMap": true,
-		"strict": true,
+		"strict": true
 	},
     "include": ["src"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
This PR introduces WebGPU support to tvm. The WebGPU runtime is directly built in javascript(as WebGPU is a first-class js API) and exposes back to the tvm's runtime via PackedFuncs.

One important note is that `ctx.sync` is now async. This is due to the fact that WebGPU is a purely async API and we cannot block in the web environment.

So the current best way to use the js api is to wrap things in an async function. When copy a GPU array to CPU, `await ctx.sync()` need to be called to wait for copy completion.

We use a AsyncIO rpc server to serve the async functions to the clients.

## Limitation
So far the webgpu runtime only takes in buffer arguments(so not dynamic shape arguments like n)

Right now we use the SPIRV to generate shaders that can be accepted by Chrome and Firefox.

- Obtain a browser that support webgpu.
  - So far only Chrome Canary on MacOS works
  - Firefox should be close pending the support of Fence.
- Download and build tvm with vulkan SDK (1.1 or higher) that supports SPIRV 1.3
- Start the WebSocket RPC in the browser
- run `python tests/node/webgpu_rpc_test.py`