### PR TITLE
[PYTORCH] Support max_pool2d_with_indices

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2247,7 +2247,8 @@ def convert_operators(operators, outputs, ret_names, convert_map, prelude):
                 out_names = _get_output_names(op_node)
                 outputs.update(zip(out_names, relay_out))
             else:
-                outputs[_get_output_name(op_node)] = relay_out
+                assert op_node.outputsSize() == 1
+                outputs[node_name] = relay_out
 
     return [_wrap_const(outputs[ret_name])
             for ret_name in ret_names]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2241,7 +2241,7 @@ def convert_operators(operators, outputs, ret_names, convert_map, prelude):
                 out_names = _get_output_names(op_node)
                 outputs.update(zip(out_names, relay_out))
             else:
-                outputs[node_name] = relay_out
+                outputs[_get_output_names(op_node)[0]] = relay_out
 
     return [_wrap_const(outputs[ret_name])
             for ret_name in ret_names]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -628,6 +628,12 @@ def _maxpool_2d():
         return _op.nn.max_pool2d(data, pool_size, strides, padding, "NCHW", ceil_mode)
     return _impl
 
+def _maxpool_2d_with_indices():
+    def _impl(inputs, input_types):
+        # returns dummy indices too
+        return _maxpool_2d()(inputs, input_types), None
+    return _impl
+
 def _maxpool_1d():
     def _impl(inputs, input_types):
         data = inputs[0]
@@ -1645,7 +1651,7 @@ def _get_convert_map(prelude):
         "aten::adaptive_avg_pool2d"             : _adaptive_avg_pool_2d(),
         "aten::adaptive_max_pool2d"             : _adaptive_max_pool_2d(),
         "aten::max_pool2d"                      : _maxpool_2d(),
-        "aten::max_pool2d_with_indices"         : _maxpool_2d(),
+        "aten::max_pool2d_with_indices"         : _maxpool_2d_with_indices(),
         "aten::max_pool1d"                      : _maxpool_1d(),
         "aten::max_pool3d"                      : _maxpool_3d(),
         "aten::hardtanh"                        : _hardtanh(),
@@ -2241,7 +2247,7 @@ def convert_operators(operators, outputs, ret_names, convert_map, prelude):
                 out_names = _get_output_names(op_node)
                 outputs.update(zip(out_names, relay_out))
             else:
-                outputs[_get_output_names(op_node)[0]] = relay_out
+                outputs[_get_output_name(op_node)] = relay_out
 
     return [_wrap_const(outputs[ret_name])
             for ret_name in ret_names]

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -525,14 +525,18 @@ def test_forward_maxpool2d():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
 
-    verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1]).eval(),
-                 input_data)
-    verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10]).eval(),
-                 input_data)
-    verify_model(torch.nn.MaxPool2d(kernel_size=[4, 4],
-                                    padding=2,
-                                    stride=2).eval(),
-                 input_data)
+    for return_indices in [True, False]:
+        verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1],
+                                        return_indices=return_indices).eval(),
+                    input_data)
+        verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10],
+                                        return_indices=return_indices).eval(),
+                    input_data)
+        verify_model(torch.nn.MaxPool2d(kernel_size=[4, 4],
+                                        padding=2,
+                                        stride=2,
+                                        return_indices=return_indices).eval(),
+                    input_data)
 
 def test_forward_maxpool1d():
     torch.set_grad_enabled(False)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -525,18 +525,22 @@ def test_forward_maxpool2d():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
 
-    for return_indices in [True, False]:
-        verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1],
-                                        return_indices=return_indices).eval(),
-                    input_data)
-        verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10],
-                                        return_indices=return_indices).eval(),
-                    input_data)
-        verify_model(torch.nn.MaxPool2d(kernel_size=[4, 4],
-                                        padding=2,
-                                        stride=2,
-                                        return_indices=return_indices).eval(),
-                    input_data)
+    verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1]).eval(), input_data)
+    verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10]).eval(), input_data)
+    verify_model(torch.nn.MaxPool2d(kernel_size=[4, 4],
+                                    padding=2,
+                                    stride=2).eval(), input_data)
+
+    class MaxPool2DWithIndices(Module):
+        def __init__(self):
+            super(MaxPool2DWithIndices, self).__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[1, 1], return_indices=True)
+
+        def forward(self, *args):
+            output, indices = self.pool(args[0])
+            return output
+
+    verify_model(MaxPool2DWithIndices().float().eval(), input_data=input_data)
 
 def test_forward_maxpool1d():
     torch.set_grad_enabled(False)
@@ -2040,6 +2044,11 @@ def test_forward_addcmul():
 
 if __name__ == "__main__":
     # Single operator tests
+
+    #test_adaptive_pool3d()
+    test_forward_maxpool2d()
+
+
     test_forward_add()
     test_forward_subtract()
     test_forward_multiply()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -525,11 +525,14 @@ def test_forward_maxpool2d():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
 
-    verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1]).eval(), input_data)
-    verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10]).eval(), input_data)
+    verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1]).eval(),
+                 input_data)
+    verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10]).eval(),
+                 input_data)
     verify_model(torch.nn.MaxPool2d(kernel_size=[4, 4],
                                     padding=2,
-                                    stride=2).eval(), input_data)
+                                    stride=2).eval(),
+                 input_data)
 
     class MaxPool2DWithIndices(Module):
         def __init__(self):
@@ -2044,11 +2047,6 @@ def test_forward_addcmul():
 
 if __name__ == "__main__":
     # Single operator tests
-
-    #test_adaptive_pool3d()
-    test_forward_maxpool2d()
-
-
     test_forward_add()
     test_forward_subtract()
     test_forward_multiply()


### PR DESCRIPTION
Pytorch converter doesn't gracefully handle the situation when a pytorch op has multiple outputs but the converter function only returns a single output.

* Fix specific case I encountered for `aten::max_pool2d_with_indices` by adding converter which returns a second dummy output.
* Also, improve handling of the situation by using `outputs[_get_output_name(op_node)] = relay_out` instead of `outputs[node_name] = relay_out` so that the assert in `_get_output_name` will be hit instead of a confusing key error later on. When a pytorch op has multiple outputs, node_name is a concatenation of all of the output names so downstream operators would never be able to find the specific output in `outputs` that they wanted.
