### PR TITLE
[BYOC, MergeComposite] Add additional check before re-using the cached match

### DIFF
--- a/src/relay/transforms/merge_composite.cc
+++ b/src/relay/transforms/merge_composite.cc
@@ -122,7 +122,9 @@ class MergeCompositeWrapper : public ExprMutator {
       Expr new_arg;
       if (arg->IsInstance<CallNode>()) {
         // if we've already processed this call node, return the previous result
-        if (call_map->find(arg) != call_map->end()) {
+        if (call_map->find(arg) != call_map->end() &&
+            ExtractPattern(Downcast<Call>(arg), Downcast<Call>(root->args[i]), var_map, call_map)
+                .defined()) {
           new_arg = (*call_map)[arg];
         } else {
           // fail if the root argument is not also a call node

--- a/src/relay/transforms/merge_composite.cc
+++ b/src/relay/transforms/merge_composite.cc
@@ -121,19 +121,12 @@ class MergeCompositeWrapper : public ExprMutator {
     for (const auto& arg : pattern->args) {
       Expr new_arg;
       if (arg->IsInstance<CallNode>()) {
+        new_arg =
+            ExtractPattern(Downcast<Call>(arg), Downcast<Call>(root->args[i]), var_map, call_map);
         // if we've already processed this call node, return the previous result
-        if (call_map->find(arg) != call_map->end() &&
-            ExtractPattern(Downcast<Call>(arg), Downcast<Call>(root->args[i]), var_map, call_map)
-                .defined()) {
+        if (call_map->find(arg) != call_map->end() && new_arg.defined()) {
           new_arg = (*call_map)[arg];
         } else {
-          // fail if the root argument is not also a call node
-          if (!root->args[i]->IsInstance<CallNode>()) {
-            return Expr();
-          }
-          // if it's a call node, recursively call this function
-          new_arg =
-              ExtractPattern(Downcast<Call>(arg), Downcast<Call>(root->args[i]), var_map, call_map);
           call_map->Set(arg, new_arg);
         }
       } else if (arg->IsInstance<VarNode>()) {


### PR DESCRIPTION
I found a bug in the merge composite pass where the pattern on the left incorrectly matches the structure on the right, returning a composite function without the intermediate `add` op.

```
   pattern          target

    relu             relu
     | \              | \
     | clip           | add
     |  /             |  |
     mul              | clip
                      |  /
                      mul
```

This happens because when MergeComposite found `relu` in the pattern for the second time as an argument of `clip`, it simply reuses the match result from the first time `relu` was found as an argument of `mul`. 

But since the target of `clip` in the target is not `relu`, re-using the cached match and reporting match success is not right.

Please review @mbaret @lhutton1 @soiferj @zhiics @comaniac @trevor-m 