### PR TITLE
Fix topi test (/topi/tests/python/test_topi_conv2d_nhwc_winograd.py) for non tensorcore CI.

### DIFF
--- a/topi/tests/python/test_topi_conv2d_nhwc_winograd.py
+++ b/topi/tests/python/test_topi_conv2d_nhwc_winograd.py
@@ -137,6 +137,9 @@ def test_conv2d_nhwc_winograd_direct():
 
 def test_conv2d_nhwc_winograd_tensorcore():
     """Test the conv2d with winograd for nhwc layout"""
+    if not tvm.gpu(0).exist or not tvm.runtime.enabled("cuda"):
+        print("skip because cuda is not enabled..")
+        return
     if not nvcc.have_tensorcore(tvm.gpu(0).compute_version):
         return
     verify_conv2d_nhwc(8,  64, 56,  64, 3, 1, 1, bgemm="tensorcore")


### PR DESCRIPTION
This test is missing a check for whether tvm.gpu is valid or not and thus fails when run in a non GPU context in our CI world.

@tqchen 

regards
Ramana