### PR TITLE
Allow ubuntu_install_darknet.sh to work in both 18.04 and 16.04

### DIFF
--- a/docker/install/ubuntu_install_darknet.sh
+++ b/docker/install/ubuntu_install_darknet.sh
@@ -22,5 +22,8 @@ set -o pipefail
 
 #install the necessary dependancies, cffi, opencv
 wget -q 'https://github.com/siju-samuel/darknet/blob/master/lib/libdarknet.so?raw=true' -O libdarknet.so
-pip2 install opencv-python cffi
+debian_version=`cat /etc/debian_version`
+if [ "$debian_version" == "stretch/sid" ]; then
+    pip2 install opencv-python cffi
+fi
 pip3 install opencv-python cffi


### PR DESCRIPTION
Our internal CI uses ci_cpu for all testing unlike upstream. The move to 18.04 also dropped pip2 support. This requires darknet installations to drop pip2 installations when on 18.04.

Ramana

@tqchen 
