### PR TITLE
[CI] Enable llvm-11 and llvm-10 in build tests, recover webdocs.

### DIFF
--- a/docs/api/links.rst
+++ b/docs/api/links.rst
@@ -16,10 +16,10 @@
     under the License.
 
 Links to API References
-==================================
+=======================
 
 This page contains links to API references that are build with different doc build system.
 
 * `C++ doyxgen API <doxygen/index.html>`_
-* `Javascript jsdoc API <jsdoc/index.html>`_
+* `Typescript typedoc API <typedoc/index.html>`_
 * `Java Javadoc API <javadoc/index.html>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ API Reference
 
    langref/index
    api/python/index
-   api_links
+   api/links
 
 Developer Guide
 ---------------
@@ -47,7 +47,7 @@ Developer Guide
    dev/index
 
 Frontends
-----------------
+---------
 .. toctree::
    :maxdepth: 1
 

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -29,7 +29,7 @@ echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME_DEBUG ON\) >> config.cmake
 echo set\(USE_VM_PROFILER ON\) >> config.cmake
 echo set\(USE_EXAMPLE_EXT_RUNTIME ON\) >> config.cmake
-echo set\(USE_LLVM llvm-config-9\) >> config.cmake
+echo set\(USE_LLVM llvm-config-10\) >> config.cmake
 echo set\(USE_NNPACK ON\) >> config.cmake
 echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake

--- a/tests/scripts/task_config_build_wasm.sh
+++ b/tests/scripts/task_config_build_wasm.sh
@@ -29,7 +29,7 @@ echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME_DEBUG ON\) >> config.cmake
 echo set\(USE_VM_PROFILER ON\) >> config.cmake
 echo set\(USE_EXAMPLE_EXT_RUNTIME ON\) >> config.cmake
-echo set\(USE_LLVM llvm-config-10\) >> config.cmake
+echo set\(USE_LLVM llvm-config-11\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake
 echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -46,12 +46,19 @@ rm -f docs/doxygen/html/*.map docs/doxygen/html/*.md5
 # Java doc
 make javadoc
 
+# type doc
+cd web
+npm install
+npm run typedoc
+cd ..
+
 # Prepare the doc dir
 rm -rf _docs
 mv docs/_build/html _docs
 rm -f _docs/.buildinfo
 mv docs/doxygen/html _docs/doxygen
 mv jvm/core/target/site/apidocs _docs/javadoc
+mv web/dist/docs _docs/typedoc
 
 echo "Start creating the docs tarball.."
 # make the tarball

--- a/tests/scripts/task_rust.sh
+++ b/tests/scripts/task_rust.sh
@@ -24,7 +24,7 @@ export TVM_HOME="$(git rev-parse --show-toplevel)"
 export LD_LIBRARY_PATH="$TVM_HOME/lib:$TVM_HOME/build:${LD_LIBRARY_PATH:-}"
 export PYTHONPATH="$TVM_HOME/python":"$TVM_HOME/topi/python"
 export RUST_DIR="$TVM_HOME/rust"
-export LLVM_CONFIG_PATH=`which llvm-config-9`
+export LLVM_CONFIG_PATH=`which llvm-config-10`
 echo "Using $LLVM_CONFIG_PATH"
 
 cd $RUST_DIR


### PR DESCRIPTION
This PR ties up the last loosen end of the recent CI update.

These changes have to be staged after the images are merged, so that the commands are available.