### PR TITLE
[Runtime] Introduce runtime::Array

### DIFF
--- a/include/tvm/node/container.h
+++ b/include/tvm/node/container.h
@@ -37,6 +37,9 @@
 
 namespace tvm {
 
+using runtime::Array;
+using runtime::ArrayNode;
+using runtime::IterAdapter;
 using runtime::make_object;
 using runtime::Object;
 using runtime::ObjectEqual;
@@ -45,16 +48,6 @@ using runtime::ObjectPtr;
 using runtime::ObjectRef;
 using runtime::String;
 using runtime::StringObj;
-
-/*! \brief array node content in array */
-class ArrayNode : public Object {
- public:
-  /*! \brief the data content */
-  std::vector<ObjectRef> data;
-
-  static constexpr const char* _type_key = "Array";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ArrayNode, Object);
-};
 
 /*! \brief map node content */
 class MapNode : public Object {
@@ -80,273 +73,6 @@ class StrMapNode : public Object {
 
   static constexpr const char* _type_key = "StrMap";
   TVM_DECLARE_FINAL_OBJECT_INFO(StrMapNode, Object);
-};
-
-/*!
- * \brief iterator adapter that adapts TIter to return another type.
- * \tparam Converter a struct that contains converting function
- * \tparam TIter the content iterator type.
- */
-template <typename Converter, typename TIter>
-class IterAdapter {
- public:
-  using difference_type = typename std::iterator_traits<TIter>::difference_type;
-  using value_type = typename Converter::ResultType;
-  using pointer = typename Converter::ResultType*;
-  using reference = typename Converter::ResultType&;  // NOLINT(*)
-  using iterator_category = typename std::iterator_traits<TIter>::iterator_category;
-
-  explicit IterAdapter(TIter iter) : iter_(iter) {}
-  inline IterAdapter& operator++() {
-    ++iter_;
-    return *this;
-  }
-  inline IterAdapter operator+(difference_type offset) const { return IterAdapter(iter_ + offset); }
-
-  template <typename T = IterAdapter>
-  typename std::enable_if<std::is_same<iterator_category, std::random_access_iterator_tag>::value,
-                          typename T::difference_type>::type inline
-  operator-(const IterAdapter& rhs) const {
-    return iter_ - rhs.iter_;
-  }
-
-  inline bool operator==(IterAdapter other) const { return iter_ == other.iter_; }
-  inline bool operator!=(IterAdapter other) const { return !(*this == other); }
-  inline const value_type operator*() const { return Converter::convert(*iter_); }
-
- private:
-  TIter iter_;
-};
-
-/*!
- * \brief Array container of NodeRef in DSL graph.
- *  Array implements copy on write semantics, which means array is mutable
- *  but copy will happen when array is referenced in more than two places.
- *
- * operator[] only provide const acces, use Set to mutate the content.
- * \tparam T The content NodeRef type.
- */
-template <typename T,
-          typename = typename std::enable_if<std::is_base_of<ObjectRef, T>::value>::type>
-class Array : public ObjectRef {
- public:
-  /*!
-   * \brief default constructor
-   */
-  Array() { data_ = make_object<ArrayNode>(); }
-  /*!
-   * \brief move constructor
-   * \param other source
-   */
-  Array(Array<T>&& other) : ObjectRef() {  // NOLINT(*)
-    data_ = std::move(other.data_);
-  }
-  /*!
-   * \brief copy constructor
-   * \param other source
-   */
-  Array(const Array<T>& other) : ObjectRef() {  // NOLINT(*)
-    data_ = std::move(other.data_);
-  }
-  /*!
-   * \brief constructor from pointer
-   * \param n the container pointer
-   */
-  explicit Array(ObjectPtr<Object> n) : ObjectRef(n) {}
-  /*!
-   * \brief constructor from iterator
-   * \param begin begin of iterator
-   * \param end end of iterator
-   * \tparam IterType The type of iterator
-   */
-  template <typename IterType>
-  Array(IterType begin, IterType end) {
-    assign(begin, end);
-  }
-  /*!
-   * \brief constructor from initializer list
-   * \param init The initalizer list
-   */
-  Array(std::initializer_list<T> init) {  // NOLINT(*)
-    assign(init.begin(), init.end());
-  }
-  /*!
-   * \brief constructor from vector
-   * \param init The vector
-   */
-  Array(const std::vector<T>& init) {  // NOLINT(*)
-    assign(init.begin(), init.end());
-  }
-  /*!
-   * \brief Constructs a container with n elements. Each element is a copy of val
-   * \param n The size of the container
-   * \param val The init value
-   */
-  explicit Array(size_t n, const T& val) {
-    auto tmp_node = make_object<ArrayNode>();
-    for (size_t i = 0; i < n; ++i) {
-      tmp_node->data.push_back(val);
-    }
-    data_ = std::move(tmp_node);
-  }
-  /*!
-   * \brief move assign operator
-   * \param other The source of assignment
-   * \return reference to self.
-   */
-  Array<T>& operator=(Array<T>&& other) {
-    data_ = std::move(other.data_);
-    return *this;
-  }
-  /*!
-   * \brief copy assign operator
-   * \param other The source of assignment
-   * \return reference to self.
-   */
-  Array<T>& operator=(const Array<T>& other) {
-    data_ = other.data_;
-    return *this;
-  }
-  /*!
-   * \brief reset the array to content from iterator.
-   * \param begin begin of iterator
-   * \param end end of iterator
-   * \tparam IterType The type of iterator
-   */
-  template <typename IterType>
-  void assign(IterType begin, IterType end) {
-    auto n = make_object<ArrayNode>();
-    for (IterType it = begin; it != end; ++it) {
-      n->data.push_back(T(*it));
-    }
-    data_ = std::move(n);
-  }
-  /*!
-   * \brief Read i-th element from array.
-   * \param i The index
-   * \return the i-th element.
-   */
-  inline const T operator[](size_t i) const {
-    return DowncastNoCheck<T>(static_cast<const ArrayNode*>(data_.get())->data[i]);
-  }
-  /*! \return The size of the array */
-  inline size_t size() const {
-    if (data_.get() == nullptr) return 0;
-    return static_cast<const ArrayNode*>(data_.get())->data.size();
-  }
-  /*!
-   * \brief copy on write semantics
-   *  Do nothing if current handle is the unique copy of the array.
-   *  Otherwise make a new copy of the array to ensure the current handle
-   *  hold a unique copy.
-   *
-   * \return Handle to the internal node container(which ganrantees to be unique)
-   */
-  inline ArrayNode* CopyOnWrite() {
-    if (data_.get() == nullptr || !data_.unique()) {
-      ObjectPtr<ArrayNode> n = make_object<ArrayNode>();
-      n->data = static_cast<ArrayNode*>(data_.get())->data;
-      ObjectPtr<Object>(std::move(n)).swap(data_);
-    }
-    return static_cast<ArrayNode*>(data_.get());
-  }
-  /*!
-   * \brief push a new item to the back of the list
-   * \param item The item to be pushed.
-   */
-  inline void push_back(const T& item) {
-    ArrayNode* n = this->CopyOnWrite();
-    n->data.push_back(item);
-  }
-  /*!
-   * \brief Resize the array.
-   * \param size The new size.
-   */
-  inline void resize(size_t size) {
-    ArrayNode* n = this->CopyOnWrite();
-    n->data.resize(size);
-  }
-  /*!
-   * \brief set i-th element of the array.
-   * \param i The index
-   * \param value The value to be setted.
-   */
-  inline void Set(size_t i, const T& value) {
-    ArrayNode* n = this->CopyOnWrite();
-    n->data[i] = value;
-  }
-  /*! \return whether array is empty */
-  inline bool empty() const { return size() == 0; }
-  /*!
-   * \brief Helper function to apply fmutate to mutate an array.
-   * \param fmutate The transformation function T -> T.
-   * \tparam F the type of the mutation function.
-   * \note This function performs copy on write optimization.
-   */
-  template <typename F>
-  inline void MutateByApply(F fmutate) {
-    ArrayNode* ptr = static_cast<ArrayNode*>(data_.get());
-    if (ptr == nullptr) return;
-    if (data_.unique()) {
-      // Copy on write optimization.
-      // Perform inplace update because this is an unique copy.
-      for (size_t i = 0; i < ptr->data.size(); ++i) {
-        // It is important to use move here
-        // to make prevent the element's ref count from increasing
-        // so fmutate itself can perform copy-on-write optimization
-        T old_elem = DowncastNoCheck<T>(std::move(ptr->data[i]));
-        T new_elem = fmutate(std::move(old_elem));
-        ptr->data[i] = std::move(new_elem);
-      }
-    } else {
-      // lazily trigger copy if there is element change.
-      ObjectPtr<ArrayNode> copy;
-      for (size_t i = 0; i < ptr->data.size(); ++i) {
-        T old_elem = DowncastNoCheck<T>(ptr->data[i]);
-        T new_elem = fmutate(old_elem);
-        if (!new_elem.same_as(ptr->data[i])) {
-          // copy the old array
-          if (copy == nullptr) {
-            copy = runtime::make_object<ArrayNode>(*ptr);
-          }
-          copy->data[i] = std::move(new_elem);
-        }
-      }
-      // replace the data with the new copy.
-      if (copy != nullptr) {
-        data_ = std::move(copy);
-      }
-    }
-  }
-
-  /*! \brief specify container node */
-  using ContainerType = ArrayNode;
-
-  struct ValueConverter {
-    using ResultType = T;
-    static inline T convert(const ObjectRef& n) { return DowncastNoCheck<T>(n); }
-  };
-  using iterator = IterAdapter<ValueConverter, std::vector<ObjectRef>::const_iterator>;
-
-  using reverse_iterator =
-      IterAdapter<ValueConverter, std::vector<ObjectRef>::const_reverse_iterator>;
-
-  /*! \return begin iterator */
-  inline iterator begin() const {
-    return iterator(static_cast<const ArrayNode*>(data_.get())->data.begin());
-  }
-  /*! \return end iterator */
-  inline iterator end() const {
-    return iterator(static_cast<const ArrayNode*>(data_.get())->data.end());
-  }
-  /*! \return rbegin iterator */
-  inline reverse_iterator rbegin() const {
-    return reverse_iterator(static_cast<const ArrayNode*>(data_.get())->data.rbegin());
-  }
-  /*! \return rend iterator */
-  inline reverse_iterator rend() const {
-    return reverse_iterator(static_cast<const ArrayNode*>(data_.get())->data.rend());
-  }
 };
 
 /*!
@@ -404,8 +130,8 @@ class Map : public ObjectRef {
     assign(init.begin(), init.end());
   }
   /*!
-   * \brief constructor from vector
-   * \param init The vector
+   * \brief constructor from unordered_map
+   * \param init The unordered_map
    */
   template <typename Hash, typename Equal>
   Map(const std::unordered_map<K, V, Hash, Equal>& init) {  // NOLINT(*)
@@ -625,7 +351,7 @@ struct ObjectTypeChecker<Array<T> > {
     if (ptr == nullptr) return true;
     if (!ptr->IsInstance<ArrayNode>()) return false;
     const ArrayNode* n = static_cast<const ArrayNode*>(ptr);
-    for (const auto& p : n->data) {
+    for (const ObjectRef& p : *n) {
       if (!ObjectTypeChecker<T>::Check(p.get())) {
         return false;
       }

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -188,7 +188,7 @@ struct SqueezeAttrs : public tvm::AttrsNode<SqueezeAttrs> {
             "If `axis = None`, all axis of dimension 1 get squeezed;"
             "Else, the dimension in axes get squeezed."
             "It is an error if an axis does not has dimension 1.")
-        .set_default(NullValue<Array<Integer> >());
+        .set_default(NullValue<Array<Integer>>());
   }
 };  // struct SqueezeAttrs
 

--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -29,8 +29,10 @@
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/packed_func.h>
 
+#include <algorithm>
 #include <cstring>
 #include <initializer_list>
+#include <memory>
 #include <string>
 // We use c++14 std::experimental::string_view for optimizing hash computation
 // only right now, its usage is limited in this file. Any broader usage of
@@ -160,7 +162,6 @@ class InplaceArrayBase {
     new (field_ptr) ElemType(std::forward<Args>(args)...);
   }
 
- private:
   /*!
    * \brief Return the self object for the array.
    *
@@ -188,6 +189,777 @@ class InplaceArrayBase {
     return data_start + idx * sizeof(ElemType);
   }
 };
+
+/*!
+ * \brief iterator adapter that adapts TIter to return another type.
+ * \tparam Converter a struct that contains converting function
+ * \tparam TIter the content iterator type.
+ */
+template <typename Converter, typename TIter>
+class IterAdapter {
+ public:
+  using difference_type = typename std::iterator_traits<TIter>::difference_type;
+  using value_type = typename Converter::ResultType;
+  using pointer = typename Converter::ResultType*;
+  using reference = typename Converter::ResultType&;  // NOLINT(*)
+  using iterator_category = typename std::iterator_traits<TIter>::iterator_category;
+
+  explicit IterAdapter(TIter iter) : iter_(iter) {}
+  IterAdapter& operator++() {
+    ++iter_;
+    return *this;
+  }
+  IterAdapter& operator--() {
+    --iter_;
+    return *this;
+  }
+  IterAdapter& operator++(int) {
+    IterAdapter copy = *this;
+    ++iter_;
+    return copy;
+  }
+  IterAdapter& operator--(int) {
+    IterAdapter copy = *this;
+    --iter_;
+    return copy;
+  }
+
+  IterAdapter operator+(difference_type offset) const { return IterAdapter(iter_ + offset); }
+
+  template <typename T = IterAdapter>
+  typename std::enable_if<std::is_same<iterator_category, std::random_access_iterator_tag>::value,
+                          typename T::difference_type>::type inline
+  operator-(const IterAdapter& rhs) const {
+    return iter_ - rhs.iter_;
+  }
+
+  bool operator==(IterAdapter other) const { return iter_ == other.iter_; }
+  bool operator!=(IterAdapter other) const { return !(*this == other); }
+  const value_type operator*() const { return Converter::convert(*iter_); }
+
+ private:
+  TIter iter_;
+};
+
+/*!
+ * \brief iterator adapter that adapts TIter to return another type.
+ * \tparam Converter a struct that contains converting function
+ * \tparam TIter the content iterator type.
+ */
+template <typename Converter, typename TIter>
+class ReverseIterAdapter {
+ public:
+  using difference_type = typename std::iterator_traits<TIter>::difference_type;
+  using value_type = typename Converter::ResultType;
+  using pointer = typename Converter::ResultType*;
+  using reference = typename Converter::ResultType&;  // NOLINT(*)
+  using iterator_category = typename std::iterator_traits<TIter>::iterator_category;
+
+  explicit ReverseIterAdapter(TIter iter) : iter_(iter) {}
+  ReverseIterAdapter& operator++() {
+    --iter_;
+    return *this;
+  }
+  ReverseIterAdapter& operator--() {
+    ++iter_;
+    return *this;
+  }
+  ReverseIterAdapter& operator++(int) {
+    ReverseIterAdapter copy = *this;
+    --iter_;
+    return copy;
+  }
+  ReverseIterAdapter& operator--(int) {
+    ReverseIterAdapter copy = *this;
+    ++iter_;
+    return copy;
+  }
+  ReverseIterAdapter operator+(difference_type offset) const {
+    return ReverseIterAdapter(iter_ - offset);
+  }
+
+  template <typename T = ReverseIterAdapter>
+  typename std::enable_if<std::is_same<iterator_category, std::random_access_iterator_tag>::value,
+                          typename T::difference_type>::type inline
+  operator-(const ReverseIterAdapter& rhs) const {
+    return rhs.iter_ - iter_;
+  }
+
+  bool operator==(ReverseIterAdapter other) const { return iter_ == other.iter_; }
+  bool operator!=(ReverseIterAdapter other) const { return !(*this == other); }
+  const value_type operator*() const { return Converter::convert(*iter_); }
+
+ private:
+  TIter iter_;
+};
+
+/*! \brief array node content in array */
+class ArrayNode : public Object, public InplaceArrayBase<ArrayNode, ObjectRef> {
+ public:
+  /*! \return The size of the array */
+  size_t size() const { return this->size_; }
+
+  /*!
+   * \brief Read i-th element from array.
+   * \param i The index
+   * \return the i-th element.
+   */
+  const ObjectRef at(int64_t i) const { return this->operator[](i); }
+
+  /*! \return begin constant iterator */
+  const ObjectRef* begin() const { return static_cast<ObjectRef*>(InplaceArrayBase::AddressOf(0)); }
+
+  /*! \return end constant iterator */
+  const ObjectRef* end() const { return begin() + size_; }
+
+  /*! \brief Release reference to all the elements */
+  void clear() { ShrinkBy(size_); }
+
+  /*!
+   * \brief Set i-th element of the array in-place
+   * \param i The index
+   * \param item The value to be set
+   */
+  void SetItem(int64_t i, ObjectRef item) { this->operator[](i) = std::move(item); }
+
+  /*!
+   * \brief Constructs a container and copy from another
+   * \param cap The capacity of the container
+   * \param from Source of the copy
+   * \return Ref-counted ArrayNode requested
+   */
+  static ObjectPtr<ArrayNode> CopyFrom(int64_t cap, ArrayNode* from) {
+    int64_t size = from->size_;
+    CHECK_GE(cap, size) << "ValueError: not enough capacity";
+    ObjectPtr<ArrayNode> p = ArrayNode::Empty(cap);
+    ObjectRef* write = p->MutableBegin();
+    ObjectRef* read = from->MutableBegin();
+    // To ensure exception safety, size is only incremented after the initialization succeeds
+    for (int64_t& i = p->size_ = 0; i < size; ++i) {
+      new (write++) ObjectRef(*read++);
+    }
+    return p;
+  }
+
+  /*!
+   * \brief Constructs a container and move from another
+   * \param cap The capacity of the container
+   * \param from Source of the move
+   * \return Ref-counted ArrayNode requested
+   */
+  static ObjectPtr<ArrayNode> MoveFrom(int64_t cap, ArrayNode* from) {
+    int64_t size = from->size_;
+    CHECK_GE(cap, size) << "ValueError: not enough capacity";
+    ObjectPtr<ArrayNode> p = ArrayNode::Empty(cap);
+    ObjectRef* write = p->MutableBegin();
+    ObjectRef* read = from->MutableBegin();
+    // To ensure exception safety, size is only incremented after the initialization succeeds
+    for (int64_t& i = p->size_ = 0; i < size; ++i) {
+      new (write++) ObjectRef(std::move(*read++));
+    }
+    from->size_ = 0;
+    return p;
+  }
+
+  /*!
+   * \brief Constructs a container with n elements. Each element is a copy of val
+   * \param n The size of the container
+   * \param val The init value
+   * \return Ref-counted ArrayNode requested
+   */
+  static ObjectPtr<ArrayNode> CreateRepeated(int64_t n, const ObjectRef& val) {
+    ObjectPtr<ArrayNode> p = ArrayNode::Empty(n);
+    ObjectRef* itr = p->MutableBegin();
+    for (int64_t& i = p->size_ = 0; i < n; ++i) {
+      new (itr++) ObjectRef(val);
+    }
+    return p;
+  }
+
+  static constexpr const uint32_t _type_index = TypeIndex::kRuntimeArray;
+  static constexpr const char* _type_key = "Array";
+  TVM_DECLARE_FINAL_OBJECT_INFO(ArrayNode, Object);
+
+ private:
+  /*! \return Size of initialized memory, used by InplaceArrayBase. */
+  size_t GetSize() const { return this->size_; }
+
+  /*! \return begin mutable iterator */
+  ObjectRef* MutableBegin() const {
+    return static_cast<ObjectRef*>(InplaceArrayBase::AddressOf(0));
+  }
+
+  /*! \return end mutable iterator */
+  ObjectRef* MutableEnd() const { return MutableBegin() + size_; }
+
+  /*!
+   * \brief Create an ArrayNode with the given capacity.
+   * \param n Required capacity
+   * \return Ref-counted ArrayNode requested
+   */
+  static ObjectPtr<ArrayNode> Empty(int64_t n = kInitSize) {
+    CHECK_GE(n, 0);
+    ObjectPtr<ArrayNode> p = make_inplace_array_object<ArrayNode, ObjectRef>(n);
+    p->capacity_ = n;
+    p->size_ = 0;
+    return p;
+  }
+
+  /*!
+   * \brief Inplace-initialize the elements starting idx from [first, last)
+   * \param idx The starting point
+   * \param first Begin of iterator
+   * \param last End of iterator
+   * \tparam IterType The type of iterator
+   * \return Self
+   */
+  template <typename IterType>
+  ArrayNode* InitRange(int64_t idx, IterType first, IterType last) {
+    ObjectRef* itr = MutableBegin() + idx;
+    for (; first != last; ++first) {
+      ObjectRef ref = *first;
+      new (itr++) ObjectRef(std::move(ref));
+    }
+    return this;
+  }
+
+  /*!
+   * \brief Move elements from right to left, requires src_begin > dst
+   * \param dst Destination
+   * \param src_begin The start point of copy (inclusive)
+   * \param src_end The end point of copy (exclusive)
+   * \return Self
+   */
+  ArrayNode* MoveElementsLeft(int64_t dst, int64_t src_begin, int64_t src_end) {
+    ObjectRef* from = MutableBegin() + src_begin;
+    ObjectRef* to = MutableBegin() + dst;
+    while (src_begin++ != src_end) {
+      *to++ = std::move(*from++);
+    }
+    return this;
+  }
+
+  /*!
+   * \brief Move elements from left to right, requires src_begin < dst
+   * \param dst Destination
+   * \param src_begin The start point of move (inclusive)
+   * \param src_end The end point of move (exclusive)
+   * \return Self
+   */
+  ArrayNode* MoveElementsRight(int64_t dst, int64_t src_begin, int64_t src_end) {
+    ObjectRef* from = MutableBegin() + src_end;
+    ObjectRef* to = MutableBegin() + (src_end - src_begin + dst);
+    while (src_begin++ != src_end) {
+      *--to = std::move(*--from);
+    }
+    return this;
+  }
+
+  /*!
+   * \brief Enlarges the size of the array
+   * \param delta Size enlarged, should be positive
+   * \param val Default value
+   * \return Self
+   */
+  ArrayNode* EnlargeBy(int64_t delta, const ObjectRef& val = ObjectRef(nullptr)) {
+    ObjectRef* itr = MutableEnd();
+    while (delta-- > 0) {
+      new (itr++) ObjectRef(val);
+      ++size_;
+    }
+    return this;
+  }
+
+  /*!
+   * \brief Shrinks the size of the array
+   * \param delta Size shrinked, should be positive
+   * \return Self
+   */
+  ArrayNode* ShrinkBy(int64_t delta) {
+    ObjectRef* itr = MutableEnd();
+    while (delta-- > 0) {
+      (--itr)->ObjectRef::~ObjectRef();
+      --size_;
+    }
+    return this;
+  }
+
+  /*! \brief Number of elements used */
+  int64_t size_;
+
+  /*! \brief Number of elements allocated */
+  int64_t capacity_;
+
+  /*! \brief Initial size of ArrayNode */
+  static const constexpr int64_t kInitSize = 4;
+
+  /*! \brief Expansion factor of the Array */
+  static const constexpr int64_t kIncFactor = 2;
+
+  // CRTP parent class
+  friend InplaceArrayBase<ArrayNode, ObjectRef>;
+
+  // Reference class
+  template <typename, typename>
+  friend class Array;
+
+  // To specialize make_object<ArrayNode>
+  friend ObjectPtr<ArrayNode> make_object<>();
+};
+
+/*!
+ * \brief Array container of ObjectRef in DSL graph.
+ *  Array implements copy-on-write semantics, which means array is mutable
+ *  but copy will happen when array is referenced in more than two places.
+ *
+ * operator[] only provide const access, use Set to mutate the content.
+ * \tparam T The content ObjectRef type.
+ */
+template <typename T,
+          typename = typename std::enable_if<std::is_base_of<ObjectRef, T>::value>::type>
+class Array : public ObjectRef {
+ public:
+  // constructors
+  /*!
+   * \brief default constructor
+   */
+  Array() { data_ = ArrayNode::Empty(); }
+
+  /*!
+   * \brief move constructor
+   * \param other source
+   */
+  Array(Array<T>&& other) : ObjectRef() {  // NOLINT(*)
+    data_ = std::move(other.data_);
+  }
+
+  /*!
+   * \brief copy constructor
+   * \param other source
+   */
+  Array(const Array<T>& other) : ObjectRef() {  // NOLINT(*)
+    data_ = other.data_;
+  }
+
+  /*!
+   * \brief constructor from pointer
+   * \param n the container pointer
+   */
+  explicit Array(ObjectPtr<Object> n) : ObjectRef(n) {}
+
+  /*!
+   * \brief Constructor from iterator
+   * \param first begin of iterator
+   * \param last end of iterator
+   * \tparam IterType The type of iterator
+   */
+  template <typename IterType>
+  Array(IterType first, IterType last) {
+    Assign(first, last);
+  }
+
+  /*!
+   * \brief constructor from initializer list
+   * \param init The initializer list
+   */
+  Array(std::initializer_list<T> init) {  // NOLINT(*)
+    Assign(init.begin(), init.end());
+  }
+
+  /*!
+   * \brief constructor from vector
+   * \param init The vector
+   */
+  Array(const std::vector<T>& init) {  // NOLINT(*)
+    Assign(init.begin(), init.end());
+  }
+
+  /*!
+   * \brief Constructs a container with n elements. Each element is a copy of val
+   * \param n The size of the container
+   * \param val The init value
+   */
+  explicit Array(const size_t n, const T& val) { data_ = ArrayNode::CreateRepeated(n, val); }
+
+  /*!
+   * \brief move assign operator
+   * \param other The source of assignment
+   * \return reference to self.
+   */
+  Array<T>& operator=(Array<T>&& other) {
+    data_ = std::move(other.data_);
+    return *this;
+  }
+
+  /*!
+   * \brief copy assign operator
+   * \param other The source of assignment
+   * \return reference to self.
+   */
+  Array<T>& operator=(const Array<T>& other) {
+    data_ = other.data_;
+    return *this;
+  }
+
+ public:
+  // iterators
+  struct ValueConverter {
+    using ResultType = T;
+    static T convert(const ObjectRef& n) { return DowncastNoCheck<T>(n); }
+  };
+
+  using iterator = IterAdapter<ValueConverter, const ObjectRef*>;
+  using reverse_iterator = ReverseIterAdapter<ValueConverter, const ObjectRef*>;
+
+  /*! \return begin iterator */
+  iterator begin() const { return iterator(GetArrayNode()->begin()); }
+
+  /*! \return end iterator */
+  iterator end() const { return iterator(GetArrayNode()->end()); }
+
+  /*! \return rbegin iterator */
+  reverse_iterator rbegin() const {
+    // ArrayNode::end() is never nullptr
+    return reverse_iterator(GetArrayNode()->end() - 1);
+  }
+
+  /*! \return rend iterator */
+  reverse_iterator rend() const {
+    // ArrayNode::begin() is never nullptr
+    return reverse_iterator(GetArrayNode()->begin() - 1);
+  }
+
+ public:
+  // const methods in std::vector
+  /*!
+   * \brief Immutably read i-th element from array.
+   * \param i The index
+   * \return the i-th element.
+   */
+  const T operator[](int64_t i) const {
+    ArrayNode* p = GetArrayNode();
+    CHECK(p != nullptr) << "ValueError: cannot index a null array";
+    CHECK(0 <= i && i < p->size_) << "IndexError: indexing " << i << " on an array of size "
+                                  << p->size_;
+    return DowncastNoCheck<T>(*(p->begin() + i));
+  }
+
+  /*! \return The size of the array */
+  size_t size() const {
+    ArrayNode* p = GetArrayNode();
+    return p == nullptr ? 0 : GetArrayNode()->size_;
+  }
+
+  /*! \return The capacity of the array */
+  size_t capacity() const {
+    ArrayNode* p = GetArrayNode();
+    return p == nullptr ? 0 : GetArrayNode()->capacity_;
+  }
+
+  /*! \return Whether array is empty */
+  bool empty() const { return size() == 0; }
+
+  /*! \return The first element of the array */
+  const T& front() const {
+    ArrayNode* p = GetArrayNode();
+    CHECK(p != nullptr) << "ValueError: cannot index a null array";
+    CHECK_GT(p->size_, 0) << "IndexError: cannot index an empty array";
+    return *p->begin();
+  }
+
+  /*! \return The last element of the array */
+  const T& back() const {
+    ArrayNode* p = GetArrayNode();
+    CHECK(p != nullptr) << "ValueError: cannot index a null array";
+    CHECK_GT(p->size_, 0) << "IndexError: cannot index an empty array";
+    return *(p->end() - 1);
+  }
+
+ public:
+  // mutation in std::vector, implements copy-on-write
+
+  /*!
+   * \brief push a new item to the back of the list
+   * \param item The item to be pushed.
+   */
+  void push_back(const T& item) {
+    ArrayNode* p = CopyOnWrite(1);
+    p->EmplaceInit(p->size_++, item);
+  }
+
+  /*!
+   * \brief Insert an element into the given position
+   * \param position An iterator pointing to the insertion point
+   * \param val The element to insert
+   */
+  void insert(iterator position, const T& val) {
+    CHECK(data_ != nullptr) << "ValueError: cannot insert a null array";
+    int64_t idx = std::distance(begin(), position);
+    int64_t size = GetArrayNode()->size_;
+    auto addr = CopyOnWrite(1)                               //
+                    ->EnlargeBy(1)                           //
+                    ->MoveElementsRight(idx + 1, idx, size)  //
+                    ->MutableBegin();
+    new (addr + idx) ObjectRef(val);
+  }
+
+  /*!
+   * \brief Insert a range of elements into the given position
+   * \param position An iterator pointing to the insertion point
+   * \param first The begin iterator of the range
+   * \param last The end iterator of the range
+   */
+  template <typename IterType>
+  void insert(iterator position, IterType first, IterType last) {
+    if (first == last) {
+      return;
+    }
+    CHECK(data_ != nullptr) << "ValueError: cannot insert a null array";
+    int64_t idx = std::distance(begin(), position);
+    int64_t size = GetArrayNode()->size_;
+    int64_t numel = std::distance(first, last);
+    CopyOnWrite(numel)
+        ->EnlargeBy(numel)
+        ->MoveElementsRight(idx + numel, idx, size)
+        ->InitRange(idx, first, last);
+  }
+
+  /*! \brief Remove the last item of the list */
+  void pop_back() {
+    CHECK(data_ != nullptr) << "ValueError: cannot pop_back because array is null";
+    int64_t size = GetArrayNode()->size_;
+    CHECK_GT(size, 0) << "ValueError: cannot pop_back because array is empty";
+    CopyOnWrite()->ShrinkBy(1);
+  }
+
+  /*!
+   * \brief Erase an element on the given position
+   * \param position An iterator pointing to the element to be erased
+   */
+  void erase(iterator position) {
+    CHECK(data_ != nullptr) << "ValueError: cannot erase a null array";
+    int64_t st = std::distance(begin(), position);
+    int64_t size = GetArrayNode()->size_;
+    CHECK(0 <= st && st < size) << "ValueError: cannot erase at index " << st
+                                << ", because Array size is " << size;
+    CopyOnWrite()                             //
+        ->MoveElementsLeft(st, st + 1, size)  //
+        ->ShrinkBy(1);
+  }
+
+  /*!
+   * \brief Erase a given range of elements
+   * \param first The begin iterator of the range
+   * \param last The end iterator of the range
+   */
+  void erase(iterator first, iterator last) {
+    if (first == last) {
+      return;
+    }
+    CHECK(data_ != nullptr) << "ValueError: cannot erase a null array";
+    int64_t size = GetArrayNode()->size_;
+    int64_t st = std::distance(begin(), first);
+    int64_t ed = std::distance(begin(), last);
+    CHECK_LT(st, ed) << "ValueError: cannot erase array in range [" << st << ", " << ed << ")";
+    CHECK(0 <= st && st <= size && 0 <= ed && ed <= size)
+        << "ValueError: cannot erase array in range [" << st << ", " << ed << ")"
+        << ", because array size is " << size;
+    CopyOnWrite()                         //
+        ->MoveElementsLeft(st, ed, size)  //
+        ->ShrinkBy(ed - st);
+  }
+
+  /*!
+   * \brief Resize the array.
+   * \param n The new size.
+   */
+  void resize(int64_t n) {
+    CHECK_GE(n, 0) << "ValueError: cannot resize an Array to negative size";
+    if (data_ == nullptr) {
+      SwitchContainer(n);
+      return;
+    }
+    int64_t size = GetArrayNode()->size_;
+    if (size < n) {
+      CopyOnWrite(n - size)->EnlargeBy(n - size);
+    } else if (size > n) {
+      CopyOnWrite()->ShrinkBy(size - n);
+    }
+  }
+
+  /*!
+   * \brief Make sure the list has the capacity of at least n
+   * \param n lower bound of the capacity
+   */
+  void reserve(int64_t n) {
+    if (data_ == nullptr || n > GetArrayNode()->capacity_) {
+      SwitchContainer(n);
+    }
+  }
+
+  /*! \brief Release reference to all the elements */
+  void clear() {
+    if (data_ != nullptr) {
+      ArrayNode* p = CopyOnWrite();
+      p->clear();
+    }
+  }
+
+ public:
+  // Array's own methods
+
+  /*!
+   * \brief set i-th element of the array.
+   * \param i The index
+   * \param value The value to be setted.
+   */
+  void Set(int64_t i, T value) {
+    ArrayNode* p = this->CopyOnWrite();
+    CHECK(0 <= i && i < p->size_) << "IndexError: indexing " << i << " on an array of size "
+                                  << p->size_;
+    *(p->MutableBegin() + i) = std::move(value);
+  }
+
+  /*! \return The underlying ArrayNode */
+  ArrayNode* GetArrayNode() const { return static_cast<ArrayNode*>(data_.get()); }
+
+  /*!
+   * \brief Helper function to apply fmutate to mutate an array.
+   * \param fmutate The transformation function T -> T.
+   * \tparam F the type of the mutation function.
+   * \note This function performs copy on write optimization.
+   */
+  template <typename F>
+  void MutateByApply(F fmutate) {
+    if (data_ == nullptr) {
+      return;
+    }
+    struct StackFrame {
+      ArrayNode* p;
+      ObjectRef* itr;
+      int64_t i;
+      int64_t size;
+    };
+    std::unique_ptr<StackFrame> s = std::make_unique<StackFrame>();
+    s->p = GetArrayNode();
+    s->itr = s->p->MutableBegin();
+    s->i = 0;
+    s->size = s->p->size_;
+    if (!data_.unique()) {
+      // Loop invariant: keeps iterating when
+      // 1) data is not unique
+      // 2) no elements are actually mutated yet
+      for (; s->i < s->size; ++s->i, ++s->itr) {
+        T new_elem = fmutate(DowncastNoCheck<T>(*s->itr));
+        // do nothing when there is no mutation
+        if (new_elem.same_as(*s->itr)) {
+          continue;
+        }
+        // loop invariant breaks when the first real mutation happens
+        // we copy the elements into a new unique array
+        ObjectPtr<ArrayNode> copy = ArrayNode::CopyFrom(s->p->capacity_, s->p);
+        s->itr = copy->MutableBegin() + (s->i++);
+        *s->itr++ = std::move(new_elem);
+        data_ = std::move(copy);
+        // make sure `data_` is unique and break
+        break;
+      }
+    }
+    // when execution comes to this line, it is guaranteed that either
+    //    1) i == size
+    // or 2) data_.unique() is true
+    for (; s->i < s->size; ++s->i, ++s->itr) {
+      *s->itr = std::move(fmutate(std::move(DowncastNoCheck<T>(std::move(*s->itr)))));
+    }
+  }
+
+  /*!
+   * \brief reset the array to content from iterator.
+   * \param first begin of iterator
+   * \param last end of iterator
+   * \tparam IterType The type of iterator
+   */
+  template <typename IterType>
+  void Assign(IterType first, IterType last) {
+    int64_t cap = std::distance(first, last);
+    CHECK_GE(cap, 0) << "ValueError: cannot construct an Array of negative size";
+    ArrayNode* p = GetArrayNode();
+    if (p != nullptr && data_.unique() && p->capacity_ >= cap) {
+      // do not have to make new space
+      p->clear();
+    } else {
+      // create new space
+      data_ = ArrayNode::Empty(cap);
+      p = GetArrayNode();
+    }
+    // To ensure exception safety, size is only incremented after the initialization succeeds
+    ObjectRef* itr = p->MutableBegin();
+    for (int64_t& i = p->size_ = 0; i < cap; ++i, ++first, ++itr) {
+      new (itr) ObjectRef(*first);
+    }
+  }
+
+  /*!
+   * \brief Copy on write semantics
+   *  Do nothing if current handle is the unique copy of the array.
+   *  Otherwise make a new copy of the array to ensure the current handle
+   *  hold a unique copy.
+   *
+   * \return Handle to the internal node container(which ganrantees to be unique)
+   */
+  ArrayNode* CopyOnWrite() {
+    if (data_ == nullptr) {
+      return SwitchContainer(ArrayNode::kInitSize);
+    }
+    if (!data_.unique()) {
+      return SwitchContainer(capacity());
+    }
+    return static_cast<ArrayNode*>(data_.get());
+  }
+
+  /*! \brief specify container node */
+  using ContainerType = ArrayNode;
+
+ private:
+  /*!
+   * \brief Implement copy-on-write semantics, and ensures capacity is enough for extra elements.
+   * \param reserve_extra Number of extra slots needed
+   * \return ArrayNode pointer to the unique copy
+   */
+  ArrayNode* CopyOnWrite(int64_t reserve_extra) {
+    ArrayNode* p = GetArrayNode();
+    if (p == nullptr) {
+      return SwitchContainer(std::max(ArrayNode::kInitSize, reserve_extra));
+    }
+    if (p->capacity_ >= p->size_ + reserve_extra) {
+      return CopyOnWrite();
+    }
+    int64_t cap = p->capacity_ * ArrayNode::kIncFactor;
+    cap = std::max(cap, p->size_ + reserve_extra);
+    return SwitchContainer(cap);
+  }
+
+  /*!
+   * \brief Move or copy the ArrayNode to new address with the given capacity
+   * \param capacity The capacity requirement of the new address
+   */
+  ArrayNode* SwitchContainer(int64_t capacity) {
+    if (data_ == nullptr) {
+      data_ = ArrayNode::Empty(capacity);
+    } else if (data_.unique()) {
+      data_ = ArrayNode::MoveFrom(capacity, GetArrayNode());
+    } else {
+      data_ = ArrayNode::CopyFrom(capacity, GetArrayNode());
+    }
+    return static_cast<ArrayNode*>(data_.get());
+  }
+};
+
+// Specialize make_object<ArrayNode> to make sure it is correct.
+template <>
+inline ObjectPtr<ArrayNode> make_object() {
+  return ArrayNode::Empty();
+}
 
 /*! \brief An object representing a structure or enumeration. */
 class ADTObj : public Object, public InplaceArrayBase<ADTObj, ObjectRef> {

--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -660,19 +660,19 @@ class Array : public ObjectRef {
   bool empty() const { return size() == 0; }
 
   /*! \return The first element of the array */
-  const T& front() const {
+  const T front() const {
     ArrayNode* p = GetArrayNode();
     CHECK(p != nullptr) << "ValueError: cannot index a null array";
     CHECK_GT(p->size_, 0) << "IndexError: cannot index an empty array";
-    return *p->begin();
+    return DowncastNoCheck<T>(*(p->begin()));
   }
 
   /*! \return The last element of the array */
-  const T& back() const {
+  const T back() const {
     ArrayNode* p = GetArrayNode();
     CHECK(p != nullptr) << "ValueError: cannot index a null array";
     CHECK_GT(p->size_, 0) << "IndexError: cannot index an empty array";
-    return *(p->end() - 1);
+    return DowncastNoCheck<T>(*(p->end() - 1));
   }
 
  public:

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -64,6 +64,8 @@ struct TypeIndex {
     kRuntimeNDArray = 2,
     /*! \brief runtime::String. */
     kRuntimeString = 3,
+    /*! \brief runtime::Array. */
+    kRuntimeArray = 4,
     // static assignments that may subject to change.
     kRuntimeClosure,
     kRuntimeADT,

--- a/python/tvm/ir/container.py
+++ b/python/tvm/ir/container.py
@@ -22,7 +22,7 @@ from tvm.runtime.container import getitem_helper
 from tvm.runtime import _ffi_node_api
 
 
-@tvm._ffi.register_object
+@tvm._ffi.register_object("Array")
 class Array(Object):
     """Array container of TVM.
 

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -158,11 +158,11 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<ArrayNode>([](const ObjectRef& node, ReprPrinter* p) {
       auto* op = static_cast<const ArrayNode*>(node.get());
       p->stream << '[';
-      for (size_t i = 0; i < op->data.size(); ++i) {
+      for (size_t i = 0; i < op->size(); ++i) {
         if (i != 0) {
           p->stream << ", ";
         }
-        p->Print(op->data[i]);
+        p->Print(op->at(i));
       }
       p->stream << ']';
     });

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -732,7 +732,7 @@ Doc RelayTextPrinter::VisitAttr_(const ArrayNode* op) {
   Doc doc;
   doc << "[";
   std::vector<Doc> arr_vals;
-  for (auto val : op->data) {
+  for (auto val : *op) {
     arr_vals.push_back(PrintAttr(val));
   }
   doc << Doc::Concat(arr_vals);

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -164,11 +164,11 @@ Doc TIRTextPrinter::PrintIRModule(const IRModule& module) {
 Doc TIRTextPrinter::PrintArray(const ArrayNode* op) {
   Doc doc;
   doc << '[';
-  for (size_t i = 0; i < op->data.size(); ++i) {
+  for (size_t i = 0; i < op->size(); ++i) {
     if (i != 0) {
       doc << ", ";
     }
-    doc << Print(op->data[i]);
+    doc << Print(op->at(i));
   }
   doc << ']';
   return doc;

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -509,8 +509,8 @@ bool ReshapeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   if (param->newshape) {
     auto temp = param->newshape.value();
     if (param->reverse) {
-      data_shape.assign(data->shape.rbegin(), data->shape.rend());
-      newshape.assign(temp.rbegin(), temp.rend());
+      data_shape.Assign(data->shape.rbegin(), data->shape.rend());
+      newshape.Assign(temp.rbegin(), temp.rend());
     } else {
       data_shape = data->shape;
       newshape = temp;
@@ -1938,7 +1938,7 @@ bool SplitRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     }
     reporter->Assign(types[1], TupleType(Array<Type>(fields)));
   } else {
-    auto indices = param->indices_or_sections.as<ArrayNode>()->data;
+    auto indices = Downcast<Array<ObjectRef>>(param->indices_or_sections);
     auto begin = IndexExpr(tir::make_zero(DataType::Int(32)));
     std::vector<Type> fields;
     for (unsigned int i = 0; i < indices.size(); ++i) {

--- a/src/relay/transforms/infer_layout_util.h
+++ b/src/relay/transforms/infer_layout_util.h
@@ -135,9 +135,9 @@ inline Array<Array<Layout>> BinaryBroadcastLayout(const Attrs& attrs,
   }
 
   if (new_in_layouts.defined()) {
-    layouts.assign(new_in_layouts.begin(), new_in_layouts.end());
+    layouts.Assign(new_in_layouts.begin(), new_in_layouts.end());
   } else {
-    layouts.assign(old_in_layouts.begin(), old_in_layouts.end());
+    layouts.Assign(old_in_layouts.begin(), old_in_layouts.end());
   }
 
   if (!layouts[0].defined() && !layouts[1].defined()) {

--- a/src/tir/transforms/storage_access.cc
+++ b/src/tir/transforms/storage_access.cc
@@ -116,7 +116,7 @@ void StorageAccessVisitor::VisitStmt_(const AttrStmtNode* op) {
     IterVar iv = Downcast<IterVar>(op->node);
     env_threads_.push_back(iv);
     StmtExprVisitor::VisitStmt_(op);
-    env_threads_.CopyOnWrite()->data.pop_back();
+    env_threads_.pop_back();
   } else if (op->attr_key == attr::thread_extent) {
     IterVar iv = Downcast<IterVar>(op->node);
     env_threads_.push_back(iv);
@@ -131,7 +131,7 @@ void StorageAccessVisitor::VisitStmt_(const AttrStmtNode* op) {
     } else {
       StmtExprVisitor::VisitStmt_(op);
     }
-    env_threads_.CopyOnWrite()->data.pop_back();
+    env_threads_.pop_back();
   } else {
     StmtExprVisitor::VisitStmt_(op);
   }

--- a/tests/cpp/container_test.cc
+++ b/tests/cpp/container_test.cc
@@ -271,7 +271,6 @@ TEST(Array, InsertEraseRange) {
   }
 }
 
-
 TEST(Map, Expr) {
   using namespace tvm;
   Var x("x");

--- a/tests/cpp/container_test.cc
+++ b/tests/cpp/container_test.cc
@@ -171,6 +171,107 @@ TEST(Array, Iterator) {
   CHECK(vector[1].as<IntImmNode>()->value == 2);
 }
 
+TEST(Array, PushPop) {
+  using namespace tvm;
+  Array<Integer> a;
+  std::vector<int> b;
+  for (int i = 0; i < 10; ++i) {
+    a.push_back(i);
+    b.push_back(i);
+    ASSERT_EQ(a.front(), b.front());
+    ASSERT_EQ(a.back(), b.back());
+    ASSERT_EQ(a.size(), b.size());
+    int n = a.size();
+    for (int j = 0; j < n; ++j) {
+      ASSERT_EQ(a[j], b[j]);
+    }
+  }
+  for (int i = 9; i >= 0; --i) {
+    ASSERT_EQ(a.front(), b.front());
+    ASSERT_EQ(a.back(), b.back());
+    ASSERT_EQ(a.size(), b.size());
+    a.pop_back();
+    b.pop_back();
+    int n = a.size();
+    for (int j = 0; j < n; ++j) {
+      ASSERT_EQ(a[j], b[j]);
+    }
+  }
+  ASSERT_EQ(a.empty(), true);
+}
+
+TEST(Array, ResizeReserveClear) {
+  using namespace tvm;
+  for (size_t n = 0; n < 10; ++n) {
+    Array<Integer> a;
+    Array<Integer> b;
+    a.resize(n);
+    b.reserve(n);
+    ASSERT_EQ(a.size(), n);
+    ASSERT_GE(a.capacity(), n);
+    a.clear();
+    b.clear();
+    ASSERT_EQ(a.size(), 0);
+    ASSERT_EQ(b.size(), 0);
+  }
+}
+
+TEST(Array, InsertErase) {
+  using namespace tvm;
+  Array<Integer> a;
+  std::vector<int> b;
+  for (int n = 1; n <= 10; ++n) {
+    a.insert(a.end(), n);
+    b.insert(b.end(), n);
+    for (int pos = 0; pos <= n; ++pos) {
+      a.insert(a.begin() + pos, pos);
+      b.insert(b.begin() + pos, pos);
+      ASSERT_EQ(a.front(), b.front());
+      ASSERT_EQ(a.back(), b.back());
+      ASSERT_EQ(a.size(), n + 1);
+      ASSERT_EQ(b.size(), n + 1);
+      for (int k = 0; k <= n; ++k) {
+        ASSERT_EQ(a[k], b[k]);
+      }
+      a.erase(a.begin() + pos);
+      b.erase(b.begin() + pos);
+    }
+    ASSERT_EQ(a.front(), b.front());
+    ASSERT_EQ(a.back(), b.back());
+    ASSERT_EQ(a.size(), n);
+  }
+}
+
+TEST(Array, InsertEraseRange) {
+  using namespace tvm;
+  Array<Integer> range_a{-1, -2, -3, -4};
+  std::vector<int> range_b{-1, -2, -3, -4};
+  Array<Integer> a;
+  std::vector<int> b;
+  for (size_t n = 1; n <= 10; ++n) {
+    a.insert(a.end(), n);
+    b.insert(b.end(), n);
+    for (size_t pos = 0; pos <= n; ++pos) {
+      a.insert(a.begin() + pos, range_a.begin(), range_a.end());
+      b.insert(b.begin() + pos, range_b.begin(), range_b.end());
+      ASSERT_EQ(a.front(), b.front());
+      ASSERT_EQ(a.back(), b.back());
+      ASSERT_EQ(a.size(), n + range_a.size());
+      ASSERT_EQ(b.size(), n + range_b.size());
+      size_t m = n + range_a.size();
+      for (size_t k = 0; k < m; ++k) {
+        ASSERT_EQ(a[k], b[k]);
+      }
+      a.erase(a.begin() + pos, a.begin() + pos + range_a.size());
+      b.erase(b.begin() + pos, b.begin() + pos + range_b.size());
+    }
+    ASSERT_EQ(a.front(), b.front());
+    ASSERT_EQ(a.back(), b.back());
+    ASSERT_EQ(a.size(), n);
+  }
+}
+
+
 TEST(Map, Expr) {
   using namespace tvm;
   Var x("x");

--- a/tests/python/relay/test_backend_graph_runtime.py
+++ b/tests/python/relay/test_backend_graph_runtime.py
@@ -105,7 +105,7 @@ def test_with_params():
     mod.run()
     res = mod.get_output(0).asnumpy()
     ref_res = np.exp(y_data + x_data)
-    tvm.testing.assert_allclose(res, ref_res)
+    tvm.testing.assert_allclose(res, ref_res, atol=1e-5, rtol=1e-5)
 
 
 def test_plan_memory():


### PR DESCRIPTION
This PR introduces the data structure `tvm:runtime::Array`, which replaces the original `tvm::Array`.

Related discussion: https://discuss.tvm.ai/t/discuss-runtime-array-containers-array-adt-string/4582.

### Features
* Removes dependency to `std::vector`
* The new array is POD-C compatible in terms of Itanium C++ ABI
* Copy-on-write semantic is preserved in `Array`
* `make_object` is specialized and overloaded to properly support creating `ArrayNode`
* New features on `Array` that mimics `std::vector`, including `Array::insert`, `Array::erase`, `Array::resize`, `Array::reserve`, `Array::clear`, etc
* This PR, in the meantime, also improves the stack usage, because we have identified the stack over-utilization problem, and patched dmlc-core during the development. Hopefully this would allow the recursive visitor pattern in TVM/Relay to deal with deeper neural networks :smile:. See [my post below](https://github.com/apache/incubator-tvm/pull/5585#issuecomment-631147088) for more details.

### Breaking changes
* `ArrayNode` no longer has the field `std::vector data`
* Read-only member access in `ArrayNode` is supported via `ArrayNode::at`, which comes with proper boundary checking
*  Capacity change is no longer supported in `ArrayNode`
*  In-place changing an item is supported via `ArrayNode::SetItem`, but it is never recommended even before this PR (because `ArrayNode` doesn't have copy-on-write semantic like `Array` does)
*  Iterating through `ArrayNode` is supported with a raw constant pointer

### Performance impact
* We ran several end-to-end workloads, and didn't find any significant performance change
* This shouldn't affect the size of `libtvm_runtime`, because the registration logic remains outside of `tvm::runtime`.

### Future work
* Move registration logic from `src/node` to `src/runtime`, and closely monitor the change of binary size
* Refactor/Remove `IterAdaptor`, make it more correct, and add more features (e.g. -=)