### PR TITLE
[Autotvm]Fix the runtime raise error

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -275,9 +275,8 @@ class RPCRunner(Runner):
                 if isinstance(res, Exception):   # executor error or timeout
                     results.append(MeasureResult((str(res),), MeasureErrorNo.RUN_TIMEOUT,
                                                  self.timeout, time.time()))
-                    raise Exception(f'encountered exception during measurement: {results}')
-
-                results.append(res)
+                else:
+                    results.append(res)
 
         return results
 


### PR DESCRIPTION
While tuning, the program will crash if encounter a run_timeout error (err_no=7). The bug is introduced by [PR-5417](https://github.com/apache/incubator-tvm/pull/5417).