### PR TITLE
Add ostream formatters for TargetPtr/TargetVal.

### DIFF
--- a/src/runtime/micro/host_driven/utvm_runtime.h
+++ b/src/runtime/micro/host_driven/utvm_runtime.h
@@ -31,6 +31,7 @@ extern "C" {
 #include <stdint.h>
 #include <tvm/runtime/c_backend_api.h>
 #include <tvm/runtime/c_runtime_api.h>
+
 #include "utvm_runtime_enum.h"
 
 /*!

--- a/src/runtime/micro/host_driven/utvm_runtime.h
+++ b/src/runtime/micro/host_driven/utvm_runtime.h
@@ -31,22 +31,7 @@ extern "C" {
 #include <stdint.h>
 #include <tvm/runtime/c_backend_api.h>
 #include <tvm/runtime/c_runtime_api.h>
-
-/*!
- * \brief TODO
- */
-enum UTVMReturnCode {
-  UTVM_ERR_OK = 0,
-  UTVM_ERR_NOT_FINISHED = -1,
-  UTVM_ERR_TIMER_NOT_IMPLEMENTED = -2,
-  UTVM_ERR_TIMER_OVERFLOW = -3,
-  UTVM_ERR_WS_DOUBLE_FREE = -4,
-  UTVM_ERR_WS_OUT_OF_SPACE = -5,
-  UTVM_ERR_WS_TOO_MANY_ALLOCS = -6,
-  UTVM_ERR_WS_ZERO_SIZE_ALLOC = -7,
-  UTVM_ERR_WS_UNALIGNED_START = -8,
-  UTVM_ERR_WS_UNALIGNED_ALLOC_SIZE = -9,
-};
+#include "utvm_runtime_enum.h"
 
 /*!
  * \brief Task structure for uTVM

--- a/src/runtime/micro/host_driven/utvm_runtime_enum.h
+++ b/src/runtime/micro/host_driven/utvm_runtime_enum.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file utvm_runtime_enum.h
+ * \brief Defines constants used both on the host and on device.
+ */
+#ifndef TVM_RUNTIME_MICRO_HOST_DRIVEN_UTVM_RUNTIME_ENUM_H_
+#define TVM_RUNTIME_MICRO_HOST_DRIVEN_UTVM_RUNTIME_ENUM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief TODO
+ */
+enum UTVMReturnCode {
+  UTVM_ERR_OK = 0,
+  UTVM_ERR_NOT_FINISHED = -1,
+  UTVM_ERR_TIMER_NOT_IMPLEMENTED = -2,
+  UTVM_ERR_TIMER_OVERFLOW = -3,
+  UTVM_ERR_WS_DOUBLE_FREE = -4,
+  UTVM_ERR_WS_OUT_OF_SPACE = -5,
+  UTVM_ERR_WS_TOO_MANY_ALLOCS = -6,
+  UTVM_ERR_WS_ZERO_SIZE_ALLOC = -7,
+  UTVM_ERR_WS_UNALIGNED_START = -8,
+  UTVM_ERR_WS_UNALIGNED_ALLOC_SIZE = -9,
+};
+
+#ifdef __cplusplus
+}  // TVM_EXTERN_C
+#endif
+
+#endif  // TVM_RUNTIME_MICRO_HOST_DRIVEN_UTVM_RUNTIME_ENUM_H_

--- a/src/runtime/micro/micro_common.cc
+++ b/src/runtime/micro/micro_common.cc
@@ -103,20 +103,20 @@ std::ostream& operator<<(std::ostream& os, const TargetVal& v) {
   std::ios_base::fmtflags f(os.flags());
   os << std::dec << "0x";
   switch (v.width_bits()) {
-  case 8:
-    os << uint8_t(v.uint32());
-    break;
+    case 8:
+      os << uint8_t(v.uint32());
+      break;
     case 16:
       os << uint16_t(v.uint32());
       break;
-  case 32:
-    os << v.uint32();
-    break;
-  case 64:
-    os << v.uint64();
-    break;
-  default:
-    os << (v.uint64() & ((1 << v.width_bits())) - 1);
+    case 32:
+      os << v.uint32();
+      break;
+    case 64:
+      os << v.uint64();
+      break;
+    default:
+      os << (v.uint64() & ((1 << v.width_bits())) - 1);
   }
   os.flags(f);
   return os;

--- a/src/runtime/micro/micro_common.cc
+++ b/src/runtime/micro/micro_common.cc
@@ -116,7 +116,7 @@ std::ostream& operator<<(std::ostream& os, const TargetVal& v) {
       os << v.uint64();
       break;
     default:
-      os << (v.uint64() & ((1 << v.width_bits())) - 1);
+      os << (v.uint64() & ((1 << v.width_bits()) - 1));
   }
   os.flags(f);
   return os;

--- a/src/runtime/micro/micro_common.cc
+++ b/src/runtime/micro/micro_common.cc
@@ -99,5 +99,33 @@ size_t GetSectionSize(const std::string& binary_path, SectionKind section,
   return UpperAlignValue(size, word_size.bytes());
 }
 
+std::ostream& operator<<(std::ostream& os, const TargetVal& v) {
+  std::ios_base::fmtflags f(os.flags());
+  os << std::dec << "0x";
+  switch (v.width_bits()) {
+  case 8:
+    os << uint8_t(v.uint32());
+    break;
+    case 16:
+      os << uint16_t(v.uint32());
+      break;
+  case 32:
+    os << v.uint32();
+    break;
+  case 64:
+    os << v.uint64();
+    break;
+  default:
+    os << (v.uint64() & ((1 << v.width_bits())) - 1);
+  }
+  os.flags(f);
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const TargetPtr& v) {
+  os << "*" << v.value_;
+  return os;
+}
+
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/micro/micro_common.h
+++ b/src/runtime/micro/micro_common.h
@@ -133,7 +133,7 @@ class TargetVal {
     return *this;
   }
 
-private:
+ private:
   friend std::ostream& operator<<(std::ostream& os, const TargetVal& v);
 };
 

--- a/src/runtime/micro/micro_common.h
+++ b/src/runtime/micro/micro_common.h
@@ -132,6 +132,9 @@ class TargetVal {
     value_ = other.value_ & Bitmask();
     return *this;
   }
+
+private:
+  friend std::ostream& operator<<(std::ostream& os, const TargetVal& v);
 };
 
 // TODO(weberlo, areusch): just get rid of `TargetPtr`.
@@ -201,6 +204,8 @@ class TargetPtr {
  private:
   /*! \brief raw value storing the pointer */
   TargetVal value_;
+
+  friend std::ostream& operator<<(std::ostream& os, const TargetPtr& v);
 };
 
 /*!

--- a/src/runtime/micro/target_data_layout_encoder.h
+++ b/src/runtime/micro/target_data_layout_encoder.h
@@ -26,7 +26,7 @@
 
 #include <vector>
 
-#include "host_driven/utvm_runtime.h"
+#include "host_driven/utvm_runtime_enum.h"
 
 namespace tvm {
 namespace runtime {


### PR DESCRIPTION
This PR adds formatters so you can use TargetPtr/Val with e.g. LOG(INFO) and std::cout. Planning to add tests will after the runtime rewrite (it's possible these two classes won't be needed after that, but they're very useful now).