### PR TITLE
[PYTORCH]ImplicitTensorToNum support added

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1007,6 +1007,13 @@ def _numtotensor():
         return arr
     return _impl
 
+
+def _tensortonum():
+    def _impl(inputs, input_types):
+        return inputs[0]
+    return _impl
+
+
 def _view():
     def _impl(inputs, input_types):
         data = inputs[0]
@@ -1699,6 +1706,7 @@ def _get_convert_map(prelude):
         "aten::expand"                          : _expand(),
         "aten::Int"                             : _int(),
         "prim::NumToTensor"                     : _numtotensor(),
+        "prim::ImplicitTensorToNum"             : _tensortonum(),
         "aten::constant_pad_nd"                 : _pad(),
         "aten::permute"                         : _transpose(prelude),
         "aten::sum"                             : _reduce("sum"),


### PR DESCRIPTION
#5133 & [problems-when-import-bert-model-from-pytorch-relay](https://discuss.tvm.ai/t/problems-when-import-bert-model-from-pytorch-relay/6659)

`prim::ImplicitTensorToNum` support is added.
@masahi please help to review this PR. 

Note: Test_case is not added for this op as we cannot write with simple code. 
And the processing to just return the input number.