### PR TITLE
[VTA][Bugfix] RPC Server error fix on Pynq FPGA

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -89,6 +89,7 @@ elseif(PYTHON)
 
   # VTA FPGA driver sources
   if(USE_VTA_FPGA)
+    file(GLOB FSIM_RUNTIME_SRCS ${VTA_HW_PATH}/src/*.cc)
     file(GLOB FPGA_RUNTIME_SRCS vta/runtime/*.cc)
     # Rules for Zynq-class FPGAs with pynq OS support (see pynq.io)
     if(${VTA_TARGET} STREQUAL "pynq" OR

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -42,7 +42,7 @@ def server_start():
         os.path.abspath(os.path.expanduser(__file__)))
     proj_root = os.path.abspath(os.path.join(curr_path, "../../../../"))
     dll_path = find_libvta("libvta")[0]
-    cfg_path = os.path.abspath(os.path.join(proj_root, "build/vta_config.json"))
+    cfg_path = os.path.abspath(os.path.join(proj_root, "3rdparty/vta-hw/config/vta_config.json"))
     runtime_dll = []
     _load_module = tvm.get_global_func("tvm.rpc.server.load_module")
 


### PR DESCRIPTION
A bug was introduced upon the recent refactor of TVM that can only be caught on hardware runs.

The fix was tested on the Pynq target on the ResNet-18 example.