### PR TITLE
Fix Topological Order calculation for DFPattern Language

### DIFF
--- a/src/relay/ir/indexed_graph.cc
+++ b/src/relay/ir/indexed_graph.cc
@@ -191,10 +191,12 @@ IndexedGraph<DFPattern> CreateIndexedGraph(const DFPattern& pattern) {
 
    protected:
     void VisitDFPattern(const DFPattern& pattern) override {
-      DFPatternVisitor::VisitDFPattern(pattern);
-      auto node = std::make_shared<IndexedGraph<DFPattern>::Node>(pattern, index_++);
-      graph_.node_map_[pattern] = node;
-      graph_.topological_order_.push_back(node);
+      if (this->visited_.count(pattern.get()) == 0) {
+        DFPatternVisitor::VisitDFPattern(pattern);
+        auto node = std::make_shared<IndexedGraph<DFPattern>::Node>(pattern, index_++);
+        graph_.node_map_[pattern] = node;
+        graph_.topological_order_.push_back(node);
+      }
     }
     IndexedGraph<DFPattern> graph_;
     size_t index_ = 0;

--- a/src/relay/ir/indexed_graph.h
+++ b/src/relay/ir/indexed_graph.h
@@ -69,7 +69,7 @@ class IndexedGraph {
     std::vector<Node*> outputs_;
 
     /*! \brief The depth of the node in the dominator tree */
-    size_t depth_;
+    size_t depth_ = 0;
     /*! \brief The dominator parent/final user of the outputs of this node */
     Node* dominator_parent_;
     /*! \brief The nodes this node dominates */
@@ -115,6 +115,8 @@ class IndexedGraph {
       return nullptr;
     }
     while (lhs != rhs) {
+      CHECK(lhs);
+      CHECK(rhs);
       if (lhs->depth_ < rhs->depth_) {
         rhs = rhs->dominator_parent_;
       } else if (lhs->depth_ > rhs->depth_) {


### PR DESCRIPTION
@comaniac It was a bug in topological sort for the patterns, memoization wasn't quite applied correctly. Fixed it, added this as a test, and put a check for null pointers in the pass.

Thanks for checking out the language and [filing the bug](https://github.com/apache/incubator-tvm/issues/5605) when you ran into an issue! Please let me know if I can help with anything else.