### PR TITLE
add schedule algorithm for super large batch and small inner dimension

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -440,6 +440,12 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
                 wrap_topi_schedule(topi.cuda.schedule_dense_large_batch),
                 name="dense_large_batch.cuda",
                 plevel=5)
+        with SpecializedCondition((b >= 65536) and (i <= 16)):
+            strategy.add_implementation(
+                wrap_compute_dense(topi.cuda.dense_super_large_batch_small_inner),
+                wrap_topi_schedule(topi.cuda.schedule_dense_super_large_batch_small_inner),
+                name="dense_super_large_batch_small_inner.cuda",
+                plevel=3)
         if target.target_name == "cuda":
             if nvcc.have_tensorcore(tvm.gpu(0).compute_version):
                 if(i % 16 == 0 and b % 16 == 0 and o % 16 == 0) \

--- a/topi/tests/python/test_topi_dense.py
+++ b/topi/tests/python/test_topi_dense.py
@@ -135,6 +135,8 @@ def test_dense():
     verify_dense(2, 1024, 1000, use_bias=True)
     verify_dense(128, 1024, 1000, use_bias=False)
     verify_dense(128, 1024, 1000, use_bias=True)
+    verify_dense(215296, 1, 4, use_bias=False)
+    verify_dense(215296, 1, 4, use_bias=True)
 
 
 def test_dense_int8():


### PR DESCRIPTION
For dense operation such as `C = relay.op.dense(A, B), A.shape = [215296, 1], B.shape = [1, 4]`, no valid config can be found for current schedule algorithms either `dense_small_batch` nor `dense_large_batch`, because the batch size is too large and it will lead to a grid dimension larger than 65535 which is the max grid dimension size the CUDA can handle currently. 

Therefore, a new schedule algorithm dealing with such situation is uploaded.
