### PR TITLE
[BYOC] Remove kCompiler attr from external functions

### DIFF
--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -581,6 +581,9 @@ class CompileEngineImpl : public CompileEngineNode {
         CHECK(symbol_name.defined()) << "No external symbol is set for:\n"
                                      << AsText(src_func, false);
         auto gv = GlobalVar(std::string(symbol_name.value()));
+        // No need to keep compiler attribute at this point, functions have been
+        // extracted for specific codegen.
+        src_func = WithAttr(std::move(src_func), attr::kCompiler, NullValue<ObjectRef>());
         ext_mods[code_gen_name]->Add(gv, src_func);
         cached_ext_funcs.push_back(it.first);
       }


### PR DESCRIPTION
Functions destined for external codegen keep their kCompiler attribute which means SkipFunction returns true when running a pass over them. This makes sense during graph partitioning, however when lowering the functions for codegen there is no reason to keep this behavior.

Removing this behavior will mean a codegen can run a pass on functions only intended for the 3rd party library - specifically, allowing pre-processing of a series of sub-graphs right before it is passes through codegen. This can help to ensure that the functions destined for the 3rd party library are in the expected format. For example, we may want to ensure that these functions have a kernel layout of OHWI because the 3rd party library only supports OHWI. This wouldn't be possible before partitioning the graph as we don't know how the graph will be partitioned ahead of time.

Change-Id: Ia68b9da335ef1acfc405a8528aac823de60a65c2
