### PR TITLE
[RELAY][BYOC] Fix the creation of tuple of tuples in PartitionGraph

### DIFF
--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -406,7 +406,9 @@ IRModule RemoveDefaultAnnotations(IRModule module) {
 
 /*! \brief There can be regions with multiple outputs where each output
  *  could be a tuple output. Such tuple outputs needs to be flattened
- *  otherwise the function would create tuples of tuples.
+ *  otherwise the function would create tuples of tuples. Moreover, tuple
+ *  of tuples are valid relay, however they are not currently supported by
+ *  graph runtime or relay VM.
  */
 
 // New annotations would be required to be added for each flattened output


### PR DESCRIPTION
If the annotated compiler region contains multiple outputs where some of the outputs are tuple output, the current PartitionGraph will create tuple of tuples. This will not be handled by the runtime (and may be other passes). This PR flattens the such tuples and re-create them after the call site of the partitioned function.

cc : @zhiics @comaniac @masahi 

