### PR TITLE
[DOCS] Fix the QNN TFLite tutorial build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,7 +259,7 @@ stage('Integration Test') {
     }
   },
   'docs: GPU': {
-    node('GPU') {
+    node('TensorCore') {
       ws(per_exec_ws("tvm/docs-python-gpu")) {
         init_git()
         unpack_lib('gpu', tvm_multilib)

--- a/tutorials/frontend/deploy_prequantized_tflite.py
+++ b/tutorials/frontend/deploy_prequantized_tflite.py
@@ -114,8 +114,13 @@ data = get_real_image(224, 224)
 tflite_model_file = os.path.join(model_dir, "mobilenet_v2_1.0_224_quant.tflite")
 tflite_model_buf = open(tflite_model_file, "rb").read()
 
-tflite_model = tflite.Model.GetRootAsModel(tflite_model_buf, 0)
-
+# Get TFLite model from buffer
+try:
+    import tflite
+    tflite_model = tflite.Model.GetRootAsModel(tflite_model_buf, 0)
+except AttributeError:
+    import tflite.Model
+    tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 ###############################################################################
 # Lets run TFLite pre-quantized model inference and get the TFLite prediction.


### PR DESCRIPTION
Slipped through in https://github.com/apache/incubator-tvm/pull/5595.

Partly was due to flaws in sphinx gallery'e error reporting  mechanism, will open a new PR to enhance the that part later.