### PR TITLE
[CI] Allow CI_PYTEST_ADD_OPTIONS to be unbound.

### DIFF
--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -16,8 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# NOTE: allow unbound variable here
+set +u
+if [[ ! -z $CI_PYTEST_ADD_OPTIONS ]]; then
+    export PYTEST_ADDOPTS="-v $CI_PYTEST_ADD_OPTIONS"
+else
+    export PYTEST_ADDOPTS=""
+fi
 set -u
-set -e
+
 export TVM_PATH=`pwd`
 export PYTHONPATH=${TVM_PATH}/python:${TVM_PATH}/topi/python
-export PYTEST_ADDOPTS="-v $CI_PYTEST_ADD_OPTIONS"


### PR DESCRIPTION
This patch allows the test script to execute normally when CI_PYTEST_ADD_OPTIONS is not available.
