### PR TITLE
[Relay,Topi][OP] affine_grid and grid_sample

### DIFF
--- a/include/tvm/relay/attrs/image.h
+++ b/include/tvm/relay/attrs/image.h
@@ -167,6 +167,35 @@ struct Dilation2DAttrs : public tvm::AttrsNode<Dilation2DAttrs> {
   }
 };
 
+/*! \brief Attributes used in image affine_grid operator */
+struct AffineGridAttrs : public tvm::AttrsNode<AffineGridAttrs> {
+  Array<IndexExpr> target_shape;
+
+  TVM_DECLARE_ATTRS(AffineGridAttrs, "relay.attrs.AffineGridAttrs") {
+    TVM_ATTR_FIELD(target_shape)
+        .describe("Specifies the output shape (H, W).");
+  }
+};
+
+/*! \brief Attributes used in image grid_sample operator */
+struct GridSampleAttrs : public tvm::AttrsNode<GridSampleAttrs> {
+  String method;
+  String layout;
+
+  TVM_DECLARE_ATTRS(GridSampleAttrs, "relay.attrs.GridSampleAttrs") {
+    TVM_ATTR_FIELD(method)
+        .set_default("bilinear")
+        .describe(
+            "Specify the mode to use for scaling."
+            "bilinear - Bilinear Interpolation");
+    TVM_ATTR_FIELD(layout).set_default("NCHW").describe(
+        "Dimension ordering of input data. Can be 'NCHW', 'NHWC', etc."
+        "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"
+        "dimensions respectively. Resize is applied on the 'H' and"
+        "'W' dimensions.");
+  }
+};
+
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_ATTRS_IMAGE_H_

--- a/include/tvm/relay/attrs/image.h
+++ b/include/tvm/relay/attrs/image.h
@@ -172,8 +172,7 @@ struct AffineGridAttrs : public tvm::AttrsNode<AffineGridAttrs> {
   Array<IndexExpr> target_shape;
 
   TVM_DECLARE_ATTRS(AffineGridAttrs, "relay.attrs.AffineGridAttrs") {
-    TVM_ATTR_FIELD(target_shape)
-        .describe("Specifies the output shape (H, W).");
+    TVM_ATTR_FIELD(target_shape).describe("Specifies the output shape (H, W).");
   }
 };
 

--- a/python/tvm/relay/op/image/_image.py
+++ b/python/tvm/relay/op/image/_image.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 
 import topi
+from topi.util import get_const_tuple
 from .. import op as reg
 from .. import strategy
 from ..op import OpPattern
@@ -67,3 +68,22 @@ reg.register_injective_schedule("image.crop_and_resize")
 # dilation2d
 reg.register_strategy("image.dilation2d", strategy.dilation2d_strategy)
 reg.register_pattern("image.dilation2d", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+
+# affine_grid
+@reg.register_compute("image.affine_grid")
+def compute_affine_grid(attrs, inputs, out_dtype):
+    target_shape = get_const_tuple(attrs.target_shape)
+    return [topi.image.affine_grid(inputs[0], target_shape)]
+
+reg.register_injective_schedule("image.affine_grid")
+
+
+# grid_sample
+@reg.register_compute("image.grid_sample")
+def compute_grid_sample(attrs, inputs, out_dtype):
+    method = attrs.method
+    layout = attrs.layout
+    return [topi.image.grid_sample(inputs[0], inputs[1], method, layout)]
+
+reg.register_injective_schedule("image.grid_sample")

--- a/python/tvm/relay/op/image/image.py
+++ b/python/tvm/relay/op/image/image.py
@@ -215,3 +215,67 @@ def dilation2d(data,
 
     return _make.dilation2d(data, weight, strides, padding, dilations, data_layout,
                             kernel_layout, out_dtype)
+
+
+def affine_grid(data, target_shape=None):
+    """affine_grid operator that generates 2D sampling grid.
+
+    This operation is described in https://arxiv.org/pdf/1506.02025.pdf. It generates a uniform
+    sampling grid within the target shape and normalizes it to [-1, 1]. The provided affine
+    transformation is then applied on the sampling grid.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        3-D with shape [batch, 2, 3]. The affine matrix.
+
+    target_shape: list/tuple of two int
+        Specifies the output shape (H, W).
+
+    Returns
+    -------
+    Output : tvm.Tensor
+        4-D with shape [batch, 2, target_height, target_width]
+    """
+    return _make.affine_grid(data, target_shape)
+
+def grid_sample(data, grid, method='bilinear', layout='NCHW'):
+    """Applies bilinear sampling to input feature map.
+
+    Given :math:`data` and :math:`grid`, then the output is computed by
+
+    .. math::
+
+        x_{src} = grid[batch, 0, y_{dst}, x_{dst}] \\
+        y_{src} = grid[batch, 1, y_{dst}, x_{dst}] \\
+        output[batch, channel, y_{dst}, x_{dst}] = G(data[batch, channel, y_{src}, x_{src})
+
+    :math:`x_{dst}`, :math:`y_{dst}` enumerate all spatial locations in :math:`output`, and
+    :math:`G()` denotes the interpolation function.
+    The out-boundary points will be padded with zeros. The shape of the output will be
+    (data.shape[0], data.shape[1], grid.shape[2], grid.shape[3]).
+
+    The operator assumes that :math:`grid` has been normalized to [-1, 1].
+
+    grid_sample often cooperates with affine_grid which generates sampling grids for grid_sample.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        4-D with shape [batch, in_channel, in_height, in_width]
+
+    grid : tvm.Tensor
+        4-D with shape [batch, 2, out_height, out_width]
+
+    method : str
+        The interpolation method. Only 'bilinear' is supported.
+
+    layout : str
+        The layout of input data and the output.
+
+    Returns
+    -------
+    Output : tvm.Tensor
+        4-D with shape [batch, 2, out_height, out_width]
+    """
+    return _make.grid_sample(data, grid, method, layout)

--- a/src/relay/op/image/grid_sample.cc
+++ b/src/relay/op/image/grid_sample.cc
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file grid_sample.cc
+ * \brief affine_grid and grid_sample operator
+ */
+#include <tvm/tir/data_layout.h>
+#include <tvm/relay/op.h>
+#include <tvm/relay/attrs/image.h>
+#include "../op_common.h"
+
+namespace tvm {
+namespace relay {
+
+// relay.image.affine_grid
+TVM_REGISTER_NODE_TYPE(AffineGridAttrs);
+
+bool AffineGridRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+                      const TypeReporter& reporter) {
+  CHECK_EQ(types.size(), 2);
+  const auto* data = types[0].as<TensorTypeNode>();
+  if (data == nullptr) return false;
+  auto batch_size = data->shape[0];
+
+  const AffineGridAttrs* param = attrs.as<AffineGridAttrs>();
+  CHECK(param != nullptr);
+
+  Array<IndexExpr> oshape;
+
+  CHECK(data->shape.size() == 3U && reporter->AssertEQ(data->shape[1], 2) &&
+        reporter->AssertEQ(data->shape[2], 3))
+      << "data should be an"
+         "affine matrix with shape [batch_size, 2, 3]";
+  CHECK(param->target_shape.defined() && param->target_shape.size() == 2)
+      << "target_shape should be 2D";
+  oshape.push_back(batch_size);
+  oshape.push_back(2);
+  oshape.push_back(param->target_shape[0]);
+  oshape.push_back(param->target_shape[1]);
+
+  // assign output type
+  reporter->Assign(types[1], TensorType(oshape, data->dtype));
+  return true;
+}
+
+// Positional relay function to create affine_grid operator
+// used by frontend FFI.
+Expr MakeAffineGrid(Expr data, Array<IndexExpr> target_shape) {
+  auto attrs = make_object<AffineGridAttrs>();
+  attrs->target_shape = std::move(target_shape);
+  static const Op& op = Op::Get("image.affine_grid");
+  return Call(op, {data}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relay.op.image._make.affine_grid").set_body_typed(MakeAffineGrid);
+
+RELAY_REGISTER_OP("image.affine_grid")
+    .describe(R"code(affine_grid operator that generates 2D sampling grid.
+
+This operation is described in https://arxiv.org/pdf/1506.02025.pdf. It generates a uniform
+sampling grid within the target shape and normalizes it to [-1, 1]. The provided affine
+transformation is then applied on the sampling grid.
+
+- **data**: data is 3D array of shape [batch, 2, 3], which defines an affine transformation.
+
+- **out**: out is 4D array of shape [batch, 2, height, width], where each vector
+           :math:`out[b, :, h, w]` represents the coordinate :math:`(x, y)`
+
+)code" TVM_ADD_FILELINE)
+    .set_attrs_type<AffineGridAttrs>()
+    .set_num_inputs(1)
+    .add_argument("data", "Tensor", "The affine matrix.")
+    .set_support_level(5)
+    .add_type_rel("AffineGrid", AffineGridRel)
+    .set_attr<TOpPattern>("TOpPattern", kInjective);
+
+// relay.image.grid_sample
+TVM_REGISTER_NODE_TYPE(GridSampleAttrs);
+
+bool GridSampleRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+                        const TypeReporter& reporter) {
+  CHECK_EQ(types.size(), 3);
+  const auto* data = types[0].as<TensorTypeNode>();
+  const auto* grid = types[1].as<TensorTypeNode>();
+  if (!data || !grid) return false;
+  const auto* param = attrs.as<GridSampleAttrs>();
+  CHECK(param);
+  static const Layout kNCHW("NCHW");
+  const Layout in_layout(param->layout);
+  auto layout_converter = tir::BijectiveLayout(in_layout, kNCHW);
+  auto oshape = layout_converter.ForwardShape(data->shape);
+  oshape.Set(2, grid->shape[2]);
+  oshape.Set(3, grid->shape[3]);
+  // assign output type
+  reporter->Assign(types[2], TensorType(layout_converter.BackwardShape(oshape), data->dtype));
+  return true;
+}
+
+// Positional relay function to create affine_grid operator
+// used by frontend FFI.
+Expr MakeGridSample(Expr data, Expr grid, String method, String layout) {
+  auto attrs = make_object<GridSampleAttrs>();
+  attrs->method = method;
+  attrs->layout = layout;
+  static const Op& op = Op::Get("image.grid_sample");
+  return Call(op, {data, grid}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relay.op.image._make.grid_sample").set_body_typed(MakeGridSample);
+
+RELAY_REGISTER_OP("image.grid_sample")
+    .describe(R"code(Applies grid sampling to input feature map.
+
+Given :math:`data` and :math:`grid`, then the output is computed by
+
+.. math::
+  x_{src} = grid[batch, 0, y_{dst}, x_{dst}] \\
+  y_{src} = grid[batch, 1, y_{dst}, x_{dst}] \\
+  output[batch, channel, y_{dst}, x_{dst}] = G(data[batch, channel, y_{src}, x_{src})
+
+:math:`x_{dst}`, :math:`y_{dst}` enumerate all spatial locations in :math:`output`, and
+:math:`G()` denotes the interpolation function.
+The out-boundary points will be padded with zeros. The shape of the output will be
+(data.shape[0], data.shape[1], grid.shape[2], grid.shape[3]).
+
+The operator assumes that :math:`data` has 'NCHW' layout and :math:`grid` has been normalized to [-1, 1].
+
+grid_sample often cooperates with affine_grid which generates sampling grids for grid_sample.
+
+- **data**: data is 4D array of shape
+            (batch_size, channels, in_height, in_width) for NCHW
+            (batch_size, in_height, in_width, channels) for NHWC
+
+- **grid**: out is 4D array of shape [batch, 2, out_height, out_width], where each vector
+           :math:`out[b, :, h, w]` represents the coordinate :math:`(x, y)`
+
+- **out**: out is 4D array of shape
+           (batch, in_channel, out_height, out_width) for NCHW
+           (batch_size, in_height, in_width, channels) for NHWC
+
+)code" TVM_ADD_FILELINE)
+    .set_num_inputs(2)
+    .set_attrs_type<GridSampleAttrs>()
+    .add_argument("data", "Tensor", "The input tensor.")
+    .set_support_level(5)
+    .add_type_rel("GridSample", GridSampleRel)
+    .set_attr<TOpPattern>("TOpPattern", kInjective);
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/op/image/grid_sample.cc
+++ b/src/relay/op/image/grid_sample.cc
@@ -21,9 +21,10 @@
  * \file grid_sample.cc
  * \brief affine_grid and grid_sample operator
  */
-#include <tvm/tir/data_layout.h>
-#include <tvm/relay/op.h>
 #include <tvm/relay/attrs/image.h>
+#include <tvm/relay/op.h>
+#include <tvm/tir/data_layout.h>
+
 #include "../op_common.h"
 
 namespace tvm {
@@ -33,7 +34,7 @@ namespace relay {
 TVM_REGISTER_NODE_TYPE(AffineGridAttrs);
 
 bool AffineGridRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
-                      const TypeReporter& reporter) {
+                   const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 2);
   const auto* data = types[0].as<TensorTypeNode>();
   if (data == nullptr) return false;
@@ -95,7 +96,7 @@ transformation is then applied on the sampling grid.
 TVM_REGISTER_NODE_TYPE(GridSampleAttrs);
 
 bool GridSampleRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
-                        const TypeReporter& reporter) {
+                   const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 3);
   const auto* data = types[0].as<TensorTypeNode>();
   const auto* grid = types[1].as<TensorTypeNode>();
@@ -117,8 +118,8 @@ bool GridSampleRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 // used by frontend FFI.
 Expr MakeGridSample(Expr data, Expr grid, String method, String layout) {
   auto attrs = make_object<GridSampleAttrs>();
-  attrs->method = method;
-  attrs->layout = layout;
+  attrs->method = std::move(method);
+  attrs->layout = std::move(layout);
   static const Op& op = Op::Get("image.grid_sample");
   return Call(op, {data, grid}, Attrs(attrs), {});
 }

--- a/topi/python/topi/image/__init__.py
+++ b/topi/python/topi/image/__init__.py
@@ -21,3 +21,4 @@ from __future__ import absolute_import as _abs
 
 from .resize import *
 from .dilation2d import *
+from .grid_sample import *

--- a/topi/python/topi/image/grid_sample.py
+++ b/topi/python/topi/image/grid_sample.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""affine_grid and grid_sample operator"""
+from tvm import te, tir
+
+
+def affine_grid(data, target_shape):
+    """affine_grid operator that generates 2D sampling grid.
+
+    This operation is described in https://arxiv.org/pdf/1506.02025.pdf. It generates a uniform
+    sampling grid within the target shape and normalizes it to [-1, 1]. The provided affine
+    transformation is then applied on the sampling grid.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        3-D with shape [batch, 2, 3]. The affine matrix.
+
+    target_shape: list/tuple of two int
+        Specifies the output shape (H, W).
+
+    Returns
+    -------
+    Output : tvm.Tensor
+        4-D with shape [batch, 2, target_height, target_width]
+    """
+    assert target_shape is not None
+    assert len(target_shape) == 2
+    assert target_shape[0] > 1 and target_shape[1] > 1, \
+        "target height/width should be greater than 1"
+
+    dtype = data.dtype
+    y_step = tir.const((2.0 - 1e-7)/ (target_shape[0] - 1), dtype=dtype)
+    x_step = tir.const((2.0 - 1e-7)/ (target_shape[1] - 1), dtype=dtype)
+    start = tir.const(-1.0, dtype=dtype)
+
+    def _compute(n, dim, i, j):
+        y = start + i * y_step
+        x = start + j * x_step
+        return data[n, dim, 0] * x + data[n, dim, 1] * y + data[n, dim, 2]
+
+    oshape = (data.shape[0], len(target_shape), *target_shape)
+    return te.compute(oshape, _compute, tag='affine_grid')
+
+
+def grid_sample(data, grid, method='bilinear', layout='NCHW'):
+    """Applies bilinear sampling to input feature map.
+
+    Given :math:`data` and :math:`grid`, assuming NCHW layout, then the output is computed by
+
+    .. math::
+
+        x_{src} = grid[batch, 0, y_{dst}, x_{dst}] \\
+        y_{src} = grid[batch, 1, y_{dst}, x_{dst}] \\
+        output[batch, channel, y_{dst}, x_{dst}] = G(data[batch, channel, y_{src}, x_{src})
+
+    :math:`x_{dst}`, :math:`y_{dst}` enumerate all spatial locations in :math:`output`, and
+    :math:`G()` denotes the interpolation method.
+    The out-boundary points will be padded with zeros. The shape of the output will be
+    (data.shape[0], data.shape[1], grid.shape[2], grid.shape[3]).
+
+    The operator assumes that :math:`grid` has been normalized to [-1, 1].
+
+    grid_sample often cooperates with affine_grid which generates sampling grids for grid_sample.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        4-D with shape [batch, in_channel, in_height, in_width]
+
+    grid : tvm.Tensor
+        4-D with shape [batch, 2, out_height, out_width]
+
+    method : str
+        The interpolation method. Only 'bilinear' is supported.
+
+    layout : str
+        The layout of input data and the output.
+
+    Returns
+    -------
+    Output : tvm.Tensor
+        4-D with shape [batch, 2, out_height, out_width]
+    """
+    batch, in_channel, in_height, in_width = data.shape
+    out_height, out_width = grid.shape[2:]
+    assert method == 'bilinear', "Only bilinear is supported"
+    assert layout == "NCHW", "Only NCHW is supported"
+
+    def _get_pixel_value(n, c, h, w):
+        return te.if_then_else(te.all(h >= 0, w >= 0, h < in_height, w < in_width),
+                               data[n, c, h, w], tir.const(0.0, dtype=data.dtype))
+
+    def _bilinear_sample(n, c, h, w):
+        x = grid[n, 0, h, w]
+        y = grid[n, 1, h, w]
+        y = (y + 1) * (in_height - 1) / 2
+        x = (x + 1) * (in_width - 1) / 2
+        x0 = te.floor(x).astype('int32')
+        y0 = te.floor(y).astype('int32')
+        x1 = x0 + tir.const(1, 'int32')
+        y1 = y0 + tir.const(1, 'int32')
+        return _get_pixel_value(n, c, y0, x0) * (1.0 - (y - y0)) * (1.0 - (x - x0)) \
+            + _get_pixel_value(n, c, y0, x1) * (1.0 - (y - y0)) * (x - x0) \
+            + _get_pixel_value(n, c, y1, x0) * (y - y0) * (1.0 - (x - x0)) \
+            + _get_pixel_value(n, c, y1, x1) * (y - y0) * (x - x0)
+
+    return te.compute((batch, in_channel, out_height, out_width), _bilinear_sample,
+                      tag='grid_sample')

--- a/topi/python/topi/testing/__init__.py
+++ b/topi/python/topi/testing/__init__.py
@@ -57,3 +57,4 @@ from .crop_and_resize_python import crop_and_resize_python
 from .common import get_injective_schedule, get_reduce_schedule, get_broadcast_schedule, \
     get_elemwise_schedule, get_conv2d_nchw_implement, dispatch
 from .adaptive_pool_python import adaptive_pool
+from .grid_sample_python import affine_grid_python, grid_sample_nchw_python

--- a/topi/python/topi/testing/grid_sample_python.py
+++ b/topi/python/topi/testing/grid_sample_python.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, line-too-long, unused-variable, too-many-locals
+"""affine_grid and grid_sample operators in python"""
+import math
+import numpy as np
+
+
+def affine_grid_python(data, target_shape):
+    yv, xv = np.meshgrid(
+        np.arange(target_shape[0]), np.arange(target_shape[1]))
+    yv = yv.T * 2 / (target_shape[0] - 1) - 1
+    xv = xv.T * 2 / (target_shape[1] - 1) - 1
+    ones = np.ones_like(xv)
+    grid = np.stack([xv, yv, ones]).reshape(3, -1)
+    return data.reshape(-1, 3).dot(grid).reshape(data.shape[0], 2, *target_shape)
+
+
+def _bilinear_sample_nchw_python(data, grid):
+    batch, in_channel, in_height, in_width = data.shape
+    _, _, out_height, out_width = grid.shape
+    out = np.zeros((batch, in_channel, out_height, out_width), dtype=data.dtype)
+
+    def _within_bound(y, x):
+        return 0 <= y < in_height and 0 <= x < in_width
+
+    for n in range(0, batch):
+        for h in range(0, out_height):
+            for w in range(0, out_width):
+                x, y = grid[n, :, h, w]
+                y = (y + 1) * (in_height - 1) / 2
+                x = (x + 1) * (in_width - 1) / 2
+                y0 = int(math.floor(y))
+                x0 = int(math.floor(x))
+                y1 = y0 + 1
+                x1 = x0 + 1
+                if _within_bound(y0, x0):
+                    out[n, :, h, w] += data[n, :, y0, x0] * (1.0 - (y - y0)) * (1.0 - (x - x0))
+                if _within_bound(y0, x1):
+                    out[n, :, h, w] += data[n, :, y0, x1] * (1.0 - (y - y0)) * (x - x0)
+                if _within_bound(y1, x0):
+                    out[n, :, h, w] += data[n, :, y1, x0] * (y - y0) * (1.0 - (x - x0))
+                if _within_bound(y1, x1):
+                    out[n, :, h, w] += data[n, :, y1, x1] * (y - y0) * (x - x0)
+    return out
+
+
+def grid_sample_nchw_python(data, grid, method='bilinear'):
+    if method == 'bilinear':
+        return _bilinear_sample_nchw_python(data, grid)
+    raise ValueError("invalid method")


### PR DESCRIPTION
This PR added the `affine_grid` and `grid_sample` operator introduced in [Spatial Transformer Networks](https://arxiv.org/abs/1506.02025).

API reference:
MXNet: [GridGenerator](https://beta.mxnet.io/api/ndarray/_autogen/mxnet.ndarray.GridGenerator.html), [BilinearSampler](https://beta.mxnet.io/api/ndarray/_autogen/mxnet.ndarray.BilinearSampler.html)
Pytorch: [affine_grid](https://pytorch.org/docs/stable/nn.functional.html?highlight=affine_grid#torch.nn.functional.affine_grid), [grid_sample](https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.grid_sample)


cc @masahi @icemelon9 