### PR TITLE
[uTVM] Increase bss section size.

### DIFF
--- a/python/tvm/micro/device/arm/stm32f746xx.py
+++ b/python/tvm/micro/device/arm/stm32f746xx.py
@@ -32,7 +32,7 @@ DEFAULT_SECTION_CONSTRAINTS = {
     "text": (18000, MemConstraint.ABSOLUTE_BYTES),
     "rodata": (100, MemConstraint.ABSOLUTE_BYTES),
     "data": (100, MemConstraint.ABSOLUTE_BYTES),
-    "bss": (600, MemConstraint.ABSOLUTE_BYTES),
+    "bss": (640, MemConstraint.ABSOLUTE_BYTES),
     "args": (4096, MemConstraint.ABSOLUTE_BYTES),
     "heap": (100.0, MemConstraint.WEIGHT),
     "workspace": (64000, MemConstraint.ABSOLUTE_BYTES),


### PR DESCRIPTION
 * Likely broken in PR 5590.

This fix unbreaks `tests/micro/test_runtime_micro_on_arm.py` for me. Let's bump the global default, since this is a minimal test case.