### PR TITLE
[Arith] Handle likely in IRMutatorWithAnalyzer

### DIFF
--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -211,7 +211,9 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const AddNode* op) {
 
 std::function<void()> RewriteSimplifier::Impl::EnterConstraint(const PrimExpr& constraint) {
   size_t old_literal_size = literal_constraints_.size();
-  literal_constraints_.push_back(constraint);
+  // we will compare the already simplified result with the constraint,
+  // so simplify the constarint as well
+  literal_constraints_.push_back(operator()(constraint));
   size_t new_literal_size = literal_constraints_.size();
   auto frecover = [old_literal_size, new_literal_size, this]() {
     CHECK_EQ(literal_constraints_.size(), new_literal_size);


### PR DESCRIPTION
For `if (likely(x))`, `x` rather than `likely(x)` should be fed into the analyzer as a constraint.

This changes helps `tir.transform.Simplify` simplify

```
// attr [iter_var(threadIdx.x, , threadIdx.x)] thread_extent = 32
// attr [iter_var(threadIdx.y, , threadIdx.y)] thread_extent = 32
if (likely((((threadIdx.x*32) + threadIdx.y) < {n|n>=0}))) {
  if (likely((((threadIdx.x*32) + threadIdx.y) < {n|n>=0}))) {
    A[threadIdx.x] = C[((threadIdx.x*32) + threadIdx.y)]
  }
}
```

into

```
// attr [iter_var(threadIdx.x, , threadIdx.x)] thread_extent = 32
// attr [iter_var(threadIdx.y, , threadIdx.y)] thread_extent = 32
if (likely((((threadIdx.x*32) + threadIdx.y) < {n|n>=0}))) {
  A[threadIdx.x] = C[((threadIdx.x*32) + threadIdx.y)]
}
```

I added this case as a new test.

@tqchen 