### PR TITLE
[TIR][Bugfix] Improved massive build times caused by tir.floormod and tir.floordiv. Fixed Topi testcase.

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1013,7 +1013,14 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const SelectNode* op) {
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const LetNode* op) {
-  CHECK(!var_map_.count(op->var.get()));
+  auto it = let_binding_.find(op->var);
+  if (it != let_binding_.end()) {
+    CHECK(deep_equal_(it->second->value, op->value))
+        << "Let cannot bind the same var to two different values";
+    return var_map_[op->var.get()];
+  } else {
+    let_binding_[op->var] = op;
+  }
   var_map_[op->var.get()] = MakeValue(op->value);
   analyzer_->Bind(op->var, op->value);
   return MakeValue(op->body);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1017,7 +1017,6 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const LetNode* op) {
   if (it != let_binding_.end()) {
     CHECK(deep_equal_(it->second->value, op->value))
         << "Let cannot bind the same var to two different values";
-    return var_map_[op->var.get()];
   } else {
     let_binding_[op->var] = op;
   }

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -29,6 +29,7 @@
 #include <tvm/ir/module.h>
 #include <tvm/runtime/container.h>
 #include <tvm/target/codegen.h>
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/function.h>
 #include <tvm/tir/op.h>
@@ -322,6 +323,10 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   std::unordered_set<const VarNode*> alias_var_set_;
   // set of volatile buffer.
   std::unordered_set<const VarNode*> volatile_buf_;
+  // deep comparison of PrimExpr
+  ExprDeepEqual deep_equal_;
+  // binding of let variables. Enables duplicate var defs that map to same value
+  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
   // Cache potential common path ops to slightly improve lookup time.
   // global symbol table.
   OpAttrMap<TGlobalSymbol> op_attr_global_symbol_ = Op::GetAttrMap<TGlobalSymbol>("TGlobalSymbol");

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -760,8 +760,14 @@ void CodeGenC::VisitStmt_(const StoreNode* op) {
 }
 
 void CodeGenC::VisitExpr_(const LetNode* op, std::ostream& os) {  // NOLINT(*)
+  auto it = let_binding_.find(op->var);
+  if (it != let_binding_.end()) {
+    CHECK(deep_equal_(it->second->value, op->value))
+        << "Let cannot bind the same var to two different values";
+  } else {
+    let_binding_[op->var] = op;
+  }
   std::string value = PrintExpr(op->value);
-  CHECK(!var_idmap_.count(op->var.get()));
   var_idmap_[op->var.get()] = value;
   os << PrintExpr(op->body);
 }

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -27,6 +27,7 @@
 #include <tvm/ir/op.h>
 #include <tvm/runtime/container.h>
 #include <tvm/target/codegen.h>
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/function.h>
@@ -269,6 +270,10 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
   bool print_ssa_form_{false};
   /*! \brief set of volatile buf access */
   std::unordered_set<const VarNode*> volatile_buf_;
+  // deep comparison of PrimExpr
+  ExprDeepEqual deep_equal_;
+  // binding of let variables. Enables duplicate var defs that map to same value
+  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
 };
 
 }  // namespace codegen

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -230,7 +230,13 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const SelectNode* op) {
 }
 
 spirv::Value CodeGenSPIRV::VisitExpr_(const LetNode* op) {
-  CHECK(!var_map_.count(op->var.get()));
+  auto it = let_binding_.find(op->var);
+  if (it != let_binding_.end()) {
+    CHECK(deep_equal_(it->second->value, op->value))
+        << "Let cannot bind the same var to two different values";
+  } else {
+    let_binding_[op->var] = op;
+  }
   var_map_[op->var.get()] = MakeValue(op->value);
   analyzer_->Bind(op->var, op->value);
   return MakeValue(op->body);

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -25,6 +25,7 @@
 #define TVM_TARGET_SPIRV_CODEGEN_SPIRV_H_
 
 #include <tvm/arith/analyzer.h>
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/function.h>
 #include <tvm/tir/stmt_functor.h>
@@ -140,6 +141,10 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
   std::unordered_map<const VarNode*, spirv::Value> var_map_;
   // The analyzer.
   std::unique_ptr<arith::Analyzer> analyzer_;
+  // deep comparison of PrimExpr
+  ExprDeepEqual deep_equal_;
+  // binding of let variables. Enables duplicate var defs that map to same value
+  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
 };
 
 }  // namespace codegen

--- a/src/tir/transforms/lower_intrin.cc
+++ b/src/tir/transforms/lower_intrin.cc
@@ -126,8 +126,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
 
         // floor(a / b)
         auto fdtype = DataType::Float(dtype.bits() * 2, dtype.lanes());
-        auto div = tir::CastNode::make(fdtype, op->a)
-              / tir::CastNode::make(fdtype, op->b);
+        auto div = tir::CastNode::make(fdtype, op->a) / tir::CastNode::make(fdtype, op->b);
         auto f = tvm::floor(div);
         return tir::CastNode::make(dtype, VisitExpr_(f.as<CallNode>()));
       } else {
@@ -138,7 +137,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         PrimExpr rdiv = truncdiv(op->a, op->b);
         PrimExpr rmod = truncmod(op->a, op->b);
         return tir::SelectNode::make((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0), rdiv,
-                                    rdiv - make_const(dtype, 1));
+                                     rdiv - make_const(dtype, 1));
       }
 >>>>>>> Improved uncommon case of floormod and floordiv. Removed dependence on np floor_div and fmod.
     }
@@ -199,8 +198,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
 
         // a - floor(a / b) * b
         auto fdtype = DataType::Float(dtype.bits() * 2, dtype.lanes());
-        auto div = tir::CastNode::make(fdtype, op->a)
-              / tir::CastNode::make(fdtype, op->b);
+        auto div = tir::CastNode::make(fdtype, op->a) / tir::CastNode::make(fdtype, op->b);
         auto f = tvm::floor(div);
         auto floor_lowered = tir::CastNode::make(dtype, VisitExpr_(f.as<CallNode>()));
 
@@ -214,7 +212,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         // b < 0 && rmod < 0 -> rmod
         // b < 0 && rmod > 0 -> rmod + b
         return tir::SelectNode::make((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0), rmod,
-                                    rmod + op->b);
+                                     rmod + op->b);
       }
 >>>>>>> Improved uncommon case of floormod and floordiv. Removed dependence on np floor_div and fmod.
     }

--- a/src/tir/transforms/lower_intrin.cc
+++ b/src/tir/transforms/lower_intrin.cc
@@ -116,9 +116,10 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         auto rdiv = tir::Var("rdiv", dtype);
         // b >= 0 => (rmod >=0 ? rdiv : rdiv - 1)
         // b < 0  => (rmod <= 0 ? rdiv : rdiv - 1)
-        PrimExpr let_rdiv = tir::Let(rdiv, truncdiv(op->a, op->b),
-          tir::Select((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0),
-            rdiv, rdiv - make_const(dtype, 1)));
+        PrimExpr let_rdiv =
+            tir::Let(rdiv, truncdiv(op->a, op->b),
+                     tir::Select((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0), rdiv,
+                                 rdiv - make_const(dtype, 1)));
         return Let(rmod, truncmod(op->a, op->b), let_rdiv);
       }
     }
@@ -170,8 +171,9 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         // b > 0 && rmod < 0  -> rmod + b
         // b < 0 && rmod < 0 -> rmod
         // b < 0 && rmod > 0 -> rmod + b
-        return Let(rmod, truncmod(op->a, op->b),
-          Select((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0), rmod, rmod + op->b));
+        return Let(
+            rmod, truncmod(op->a, op->b),
+            Select((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0), rmod, rmod + op->b));
       }
     }
   }

--- a/src/tir/transforms/split_host_device.cc
+++ b/src/tir/transforms/split_host_device.cc
@@ -99,14 +99,28 @@ class VarUseDefAnalysis : public StmtExprMutator {
   }
 
   PrimExpr VisitExpr_(const LetNode* op) final {
-    this->HandleDef(op->var.get());
+    // Weaker SSA condition
+    // A single var can be binded in multiple lets
+    // but they have to bind to the same value.
+    // This is used to allow cases when we reuse a single let
+    // expression to construct a nested expr.
+    // (let x = 1 in x + 1) * (let x = 1 in x + 1)
+    auto it = let_binding_.find(op->var);
+    PrimExpr value = this->VisitExpr(op->value);
+    if (it != let_binding_.end()) {
+      CHECK(deep_equal_(it->second->value, value))
+          << "Let cannot bind the same var to two different values";
+      return GetRef<PrimExpr>(it->second);
+    } else {
+      this->HandleDef(op->var.get());
+      let_binding_[op->var] = op;
+    }
     PrimExpr body = this->VisitExpr(op->body);
     // eliminate unreferenced let
     if (use_count_.at(op->var.get()) == 0 && SideEffect(op->value) <= CallEffectKind::kReadState &&
         simplify_let_) {
       return body;
     } else {
-      PrimExpr value = this->VisitExpr(op->value);
       if (body.same_as(op->body) && value.same_as(op->value)) {
         return GetRef<PrimExpr>(op);
       } else {
@@ -157,6 +171,10 @@ class VarUseDefAnalysis : public StmtExprMutator {
   Array<PrimExpr> thread_extent_;
   std::unordered_map<const VarNode*, int> use_count_;
   std::unordered_map<const VarNode*, int> def_count_;
+
+ private:
+  ExprDeepEqual deep_equal_;
+  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
 };
 
 Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& args) {


### PR DESCRIPTION
## Build times

I experienced hangs when attempting to build a compute statement that depended on deep TIR expressions involving the `tir.floormod` and `tir.floordiv` operaors. The build times can be reproduced  with the script [here](https://github.com/dpankratz/TVMFuzz/blob/master/bugs/floormod/measure_build_times.py). This is due to the very complicated TIR expression generated when FloorMod or FloorDiv are lowered. 

I was able to improve upon this by changing how these operators were lowered to use the `tir.floor` intrinsic which also has the benefit of matching the [definitions of the operators](https://www.geeksforgeeks.org/math-floormod-method-in-java/). 

## Topi testcase

There are existing tests for `tir.floormod` and `tir.floordiv` through the topi `test_topi_broadcast.py` file. However, I noticed that this files used `np.fmod` and `np.floor_divide` as points of reference which are not equivalent to `floormod` and `floordiv`.

I fixed the testcase to use a correct version of `floormod` and `floordiv`. 