### PR TITLE
[C++ RPC] Fix C++ RPC build problem on Linux

### DIFF
--- a/apps/cpp_rpc/Makefile
+++ b/apps/cpp_rpc/Makefile
@@ -47,7 +47,7 @@ all: tvm_rpc
 # Build rule for all in one TVM package library
 tvm_rpc: *.cc
 	@mkdir -p $(@D)
-	$(CXX) $(PKG_CFLAGS) -o $@ $(filter %.cc %.o %.a, $^) $(PKG_LDFLAGS)
+	$(CXX) $(PKG_CFLAGS) -o $@ $(filter-out win32_process.cc, $(filter %.cc %.o %.a, $^)) $(PKG_LDFLAGS)
 
 clean:
 	-rm -f tvm_rpc

--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -69,7 +69,7 @@ namespace runtime {
 RPCEnv::RPCEnv() {
 #ifndef _WIN32
   char cwd[PATH_MAX];
-  if (char* rc = getcwd(cwd, sizeof(cwd))) {
+  if (getcwd(cwd, sizeof(cwd))) {
     base_ = std::string(cwd) + "/rpc";
   } else {
     base_ = "./rpc";


### PR DESCRIPTION
We can not build C++ rpc on Linux because of `win32_process.cc`. Current fix is to exclude `win32_process.cc` on Makefile because we build C++ rpc on Windows using CMake. 

Another fix is to remove unnecessary variable of `getcwd` return value.

@jmorrill @kparzysz-quic Please review it.