### PR TITLE
[Doc] Misc doc fix

### DIFF
--- a/docs/dev/convert_layout.rst
+++ b/docs/dev/convert_layout.rst
@@ -246,7 +246,7 @@ In order to specify the layouts to convert to, we create a mapping of heavily-la
     # RemoveUnunsedFunctions is used to clean up the graph.
     seq = tvm.transform.Sequential([relay.transform.RemoveUnusedFunctions(),
                                     relay.transform.ConvertLayout(desired_layouts)])
-    with relay.transform.PassContext(opt_level=3):
+    with tvm.transform.PassContext(opt_level=3):
         mod = seq(mod)
 
     # Call relay compilation

--- a/tutorials/frontend/deploy_prequantized_tflite.py
+++ b/tutorials/frontend/deploy_prequantized_tflite.py
@@ -18,6 +18,7 @@
 Deploy a Framework-prequantized Model with TVM - Part 3 (TFLite)
 ================================================================
 **Author**: `Siju Samuel <https://github.com/siju-samuel>`_
+
 Welcome to part 3 of the Deploy Framework-Prequantized Model with TVM tutorial.
 In this part, we will start with a Quantized TFLite graph and then compile and execute it via TVM.
 


### PR DESCRIPTION
This pr fixes two doc of our tvm.

1. Convert Layout.
We have `tvm.transform.PassContext`, not `relay.transform.PassContext`

2. tutorials/frontend/deploy_prequantized_tflite.py
No newline between author and content so that mix them into one line
![image](https://user-images.githubusercontent.com/7287321/82885528-dfa0bf80-9f77-11ea-93c8-2fde8d067d6b.png)

@anijain2305 @siju-samuel Please review it.
