### PR TITLE
[Bugfix] Fix Python debugger segfaults with TVM built with LLVM

### DIFF
--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -52,7 +52,7 @@ def _load_lib():
     return lib, os.path.basename(lib_path[0])
 
 try:
-    import readline
+    import readline  # pylint: disable=unused-import
 except ImportError:
     pass
 

--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -51,6 +51,11 @@ def _load_lib():
     lib.TVMGetLastError.restype = ctypes.c_char_p
     return lib, os.path.basename(lib_path[0])
 
+try:
+    import readline
+except ImportError:
+    pass
+
 # version number
 __version__ = libinfo.__version__
 # library instance


### PR DESCRIPTION
This is a pretty long discussion [thread](https://discuss.tvm.ai/t/python-debugger-segfaults-with-tvm/843/9?u=junrushao1994).

We are finally able to narrow down the root cause: some pre-build libLLVM.so are usually linked with libedit.so (e.g. ones from apt-get); when libtvm.so is linked against libLLVM.so, the libedit.so conflicts with readline used in pdb/ipdb. This causes the entire program to crash.

Two workarounds:
1) import readline before loading libtvm.so. (this PR)
2) build TVM with static LLVM, so that unused linkage in libLLVM.so are ignored. ``set(USE_LLVM "/path/to/llvm-config --ignore-libllvm")``

Some personal experience about pre-built LLVM: [clangdev](https://anaconda.org/conda-forge/clangdev/files) and [llvmdev](https://anaconda.org/conda-forge/llvmdev/files) from conda-forge works best with python, and have the most comprehensive versions. llvmdev is used to build llvmlite. which is used in numba JIT; clangdev comes with extra toolchain including clang, clang-format, etc.

```
conda install -c conda-forge clangdev=$VERSION
```

CC: @jwfromm @icemelon9 @gussmith23 