### PR TITLE
[PatternLang]Conditionally Embedding Constants in Partitioned Functions

### DIFF
--- a/docs/langref/relay_pattern.rst
+++ b/docs/langref/relay_pattern.rst
@@ -137,7 +137,7 @@ The next example is matching a pattern of batch_norm -> get(0) -> relu:
         pat.match(out)
 
 The next example is matching a constant node regarding its values. This is useful to check
-if a specific parameter in a subgraph has been bind or not.
+if a specific parameter in a subgraph has been bound or not.
 
 .. code-block:: python
 
@@ -266,10 +266,10 @@ Attribute Pattern
 
 Check that the operator matched by the pattern has an attribute with a particular value.
 
-Input
-*****
+Variable Pattern
+****************
 
-Check that the expression is an input, i.e has no parents and is a variable.
+Check that the expression is a relay Variable, and optional provide a name to match to the Variable name
 
 
 Alternate

--- a/docs/langref/relay_pattern.rst
+++ b/docs/langref/relay_pattern.rst
@@ -269,7 +269,7 @@ Check that the operator matched by the pattern has an attribute with a particula
 Variable Pattern
 ****************
 
-Check that the expression is a relay Variable, and optional provide a name to match to the Variable name
+Check that the expression is a relay Variable, and optional provide a name to match to the Variable name.
 
 
 Alternate

--- a/python/tvm/relay/dataflow_pattern/__init__.py
+++ b/python/tvm/relay/dataflow_pattern/__init__.py
@@ -318,15 +318,14 @@ class VarPattern(DFPattern):
     Parameters
     ----------
     name_hint: str
-        The name of the variable.
-        This name only acts as a hint, and is not used
-        for equality.
+        The name of the variable. Optional, if not provided,
+        the pattern will match any VarNode
 
     type_annotation: tvm.relay.Type, optional
         The type annotation on the variable.
     """
 
-    def __init__(self, name_hint: str, type_annotation=None):
+    def __init__(self, name_hint="", type_annotation=None):
         self.__init_handle_by_constructor__(
             ffi.VarPattern, name_hint, type_annotation)
 

--- a/python/tvm/relay/dataflow_pattern/__init__.py
+++ b/python/tvm/relay/dataflow_pattern/__init__.py
@@ -319,7 +319,7 @@ class VarPattern(DFPattern):
     ----------
     name_hint: str
         The name of the variable. Optional, if not provided,
-        the pattern will match any VarNode
+        the pattern will match any VarNode.
 
     type_annotation: tvm.relay.Type, optional
         The type annotation on the variable.

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -613,6 +613,17 @@ class PatternGrouper {
     CHECK_EQ(groups_[gid_].gid, gid_);
   }
 
+  /* \brief EmbedConst implements rules for embedding constants into partitioned functions or
+   * lifting them into the function arguments.
+   *
+   * The rules depend on what pattern the ConstantNode matched.
+   *
+   * The basic rules are:
+   *  If the constant matches ExprPattern(relay.const(*)) or a ConstantPattern(), embed the constant
+   * in the partitioned function. If the constant matched an AltPattern, recursively check the
+   * matched side of the pattern. For any other matching pattern (i.e, wildcard, VarPattern, etc),
+   * lift the constant into the arguments of the partitioned function.
+   */
   bool EmbedConst(const Expr& expr, const DFPattern pattern) {
     bool embed = false;
     if (expr.as<ConstantNode>()) {

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -562,7 +562,7 @@ class PatternGrouper {
           auto matches = node_map[node->ref_];
           for (auto match : matches) {
             if (fuzzy_matches.count(match) == 0 && match.as<OpNode>() == nullptr &&
-                match.as<FunctionNode>() == nullptr) {
+                match.as<FunctionNode>() == nullptr && !EmbedConst(match, node->ref_)) {
               inputs[match] = Var(
                   "FunctionVar_" + std::to_string(graph_number_) + "_" + std::to_string(var_number),
                   NullValue<Type>());
@@ -582,8 +582,8 @@ class PatternGrouper {
     auto extractor = MatchExtractor(inputs);
     auto body = extractor.Mutate(expr);
 
-    // Verify the pattern still holds, no longer valid if we're not embedding constants in the
-    // graph, keep here for future debug CHECK(DFPatternMatcher(body).Match(pattern_, body));
+    // Verify the pattern still holds
+    CHECK(DFPatternMatcher(body).Match(pattern_, body));
     group.function = Function(params, body, NullValue<Type>(), Array<TypeVar>());
     group.name = extractor.GetName();
     // Check to make sure we aren't overlapping with another group
@@ -613,6 +613,25 @@ class PatternGrouper {
     CHECK_EQ(groups_[gid_].gid, gid_);
   }
 
+  bool EmbedConst(const Expr& expr, const DFPattern pattern) {
+    bool embed = false;
+    if (expr.as<ConstantNode>()) {
+      if (pattern.as<ConstantPatternNode>() != nullptr) {
+        embed = true;
+      } else if (auto expr_pat = pattern.as<ExprPatternNode>()) {
+        if (expr_pat->expr.as<ConstantNode>()) {
+          embed = true;
+        }
+      } else if (auto alt_pat = pattern.as<AltPatternNode>()) {
+        if (matcher_->Match(alt_pat->left, expr)) {
+          embed = EmbedConst(expr, alt_pat->left);
+        } else {
+          embed = EmbedConst(expr, alt_pat->right);
+        }
+      }
+    }
+    return embed;
+  }
   // Internal State
   DFPattern pattern_;
   std::vector<Group> groups_;


### PR DESCRIPTION
Following up from conversation in #5689, this PR implements these rules for lifting or embedding constants in Partitioned Functions:

- Pattern input ExprPattern(relay.const):
     - Only match constant nodes that contain the same constant value and embed them in the partitioned functions. In this case, the arguments of partitioned functions will be reduced.
- Pattern input ConstantPattern:
     - Only match constant nodes and embed them in the partitioned functions. In this case, the arguments of partitioned functions will be reduced.
- Pattern input VarPattern('x'):
     - Match only the var node with an optional specified name hint. In this case, the arguments of partitioned function is fixed.
- Pattern input wildcard:
     - Match anything. In this case, the arguments of partitioned function is fixed.
- Pattern AltPattern:
     - Match either lhs or rhs. depending on which side matched, recursively apply this matching logic and embed constants appropriately based on the contained pattern.

cc @comaniac @mbaret @masahi 