### PR TITLE
fix small bug about dense_grad

### DIFF
--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -472,9 +472,10 @@ def bias_add_grad(orig, grad):
 def dense_grad(orig, grad):
     """Returns [grad' @ weight, data @ grad']"""
     data, weight = orig.args
-    return [collapse_sum_like(transpose(grad) * weight, data),
-            collapse_sum_like(data * transpose(grad), weight)]
-
+    return [collapse_sum_like(_nn.dense(grad, transpose(weight),
+                                        units=weight.checked_type.shape[1]), data),
+            collapse_sum_like(_nn.dense(transpose(grad), transpose(data),
+                                        units=data.checked_type.shape[1]), weight)]
 
 @register_gradient("reshape")
 def reshape_grad(orig, grad):

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -162,6 +162,7 @@ def verify_dense_grad(d_shape, w_shape):
 def test_dense_grad():
     verify_dense_grad((1, 8), (16, 8))
     verify_dense_grad((1, 4), (3, 4))
+    verify_dense_grad((5, 4), (3, 4))
 
 
 def verify_batch_flatten_grad(d_shape):


### PR DESCRIPTION
To whom it may concern,
    Hello, I am learning tvm and trying to write some training model with relay when I got an error in `dense_grad()` with the size of data(`5*4`) and weight(`3*4`). Furthermore, I found that it may be caused by a small bug in dense_grad():

the present dense_grad() is:
```python
@register_gradient("nn.dense")
def dense_grad(orig, grad):
    """Returns [grad' @ weight, data @ grad']"""
    data, weight = orig.args
    return [collapse_sum_like(transpose(grad) * weight, data),
            collapse_sum_like(data * transpose(grad), weight)]
```
in a common situation, when we calculate the gradient of `dense(A(i * j), weight(k * j))`, we get grad matrix with size `i * k`, so in above `dense_grad()`, the first multiply operator get parameters with size `k * i` and `k * j`, the second one get paramenters with size `i * j` and `k * i`, so we can only avoid conflict when `i == j == k` or some of them are `1`. 
To increase the robustness of the function, maybe we can modify it to:
```python
@register_gradient("nn.dense")
def dense_grad(orig, grad):
    """Returns [grad' @ weight, data @ grad']"""
    data, weight = orig.args
    return [collapse_sum_like(_nn.dense(grad, transpose(weight)), data),
            collapse_sum_like(_nn.dense(transpose(grad), transpose(data)), weight)]
```
we change multiply(`*`) to `_nn.dense` so that it can handel matrix multiply as well. For above assumption, the first `_nn.dense()` get parameters with size `i * k` and `j * k` and give a result with size `i * j`, which is the same as `data`; the second one get parameters with size `k * i` and `j * i` and give a result with size `k * j`, which is the same as `weight`. We add an extra test case in test_dense_grad() to test its correctness.
I am just starting to learn about tvm, so I apologize if I miss some obvious things. Thank you very much!