### PR TITLE
In memory_plan, check if value is not None, instead of just checking value as boolean.

### DIFF
--- a/python/tvm/relay/transform/memory_plan.py
+++ b/python/tvm/relay/transform/memory_plan.py
@@ -243,7 +243,7 @@ class StorageCoalesce(ExprMutator):
         def _mk_let(bindings, body):
             for var, value in reversed(bindings):
                 assert var
-                assert value
+                assert value is not None
                 assert body
                 body = expr.Let(var, value, body)
                 if var in dynamic_regions:


### PR DESCRIPTION
Hi! I am having a trouble in file memory_plan (here: https://github.com/apache/incubator-tvm/blob/master/python/tvm/relay/transform/memory_plan.py#L246 ) when value is evaluated to False (for example if value is a `relay.Tuple([])`, so I suggest this quick fix: check `assert value is not None` instead of just `assert value`. What do you think ?