### PR TITLE
[PYTORCH]floor_divide support for squeezenet

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1760,6 +1760,7 @@ def _get_convert_map(prelude):
         "aten::arange"                          : _arange(),
         "aten::div"                             : _elemwise("divide"),
         "aten::div_"                            : _elemwise("divide"),
+        "aten::floor_divide"                    : _elemwise("floor_divide"),
         "aten::addcdiv"                         : _addcdiv(),
         "aten::addcmul"                         : _addcmul(),
         "aten::ones"                            : _ones(),


### PR DESCRIPTION
`aten::floor_divide` support.
https://github.com/apache/incubator-tvm/issues/5133#issuecomment-636330705

Testcase, im not able to simulate floor_divide. 
@masahi Please help to review this.
