### PR TITLE
[PatternLang] Simplify Pattern API Implementations

### DIFF
--- a/docs/api/python/relay/dataflow_pattern.rst
+++ b/docs/api/python/relay/dataflow_pattern.rst
@@ -15,34 +15,10 @@
     specific language governing permissions and limitations
     under the License.
 
-Python API
-==========
+tvm.relay.dataflow_pattern
+--------------------------
 
-.. toctree::
-   :maxdepth: 2
-
-   runtime
-   ndarray
-   error
-   ir
-   target
-   tir
-   te
-   driver
-   relay/index
-   relay/frontend
-   relay/nn
-   relay/vision
-   relay/image
-   relay/transform
-   relay/analysis
-   relay/backend
-   relay/dataflow_pattern
-   relay/testing
-   autotvm
-   rpc
-   micro
-   contrib
-   graph_runtime
-   vta/index
-   topi
+.. automodule:: tvm.relay.dataflow_pattern
+    :members:
+    :imported-members:
+    :autosummary:

--- a/docs/api/python/relay/dataflow_pattern.rst
+++ b/docs/api/python/relay/dataflow_pattern.rst
@@ -21,4 +21,5 @@ tvm.relay.dataflow_pattern
 .. automodule:: tvm.relay.dataflow_pattern
     :members:
     :imported-members:
+    :exclude-members: Object, Node
     :autosummary:

--- a/python/tvm/relay/dataflow_pattern/__init__.py
+++ b/python/tvm/relay/dataflow_pattern/__init__.py
@@ -15,12 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """The Relay Pattern Language and tooling."""
-from tvm.relay.expr import RelayExpr as Expr
+# pylint: disable=no-member
+from typing import Callable, Dict, List, Optional
+
 import tvm._ffi
-from ...ir.base import Node
-from ...ir import make_node
-from ...runtime import Object
+from tvm.relay.expr import RelayExpr as Expr
+
 from ... import _ffi as tvm_ffi
+from ...ir import make_node
+from ...ir.base import Node
+from ...runtime import Object
 from ..op import get
 from . import _ffi as ffi
 
@@ -61,7 +65,7 @@ class DFPattern(Node):
     def __truediv__(self, other):
         return is_op("divide")(self, other)
 
-    def has_attr(self, attrs):
+    def has_attr(self, attrs: Dict[str, Object]):
         """
         Add an attribute constraint to this pattern
 
@@ -77,13 +81,13 @@ class DFPattern(Node):
         attrs = make_node("DictAttrs", **attrs)
         return AttrPattern(self, attrs)
 
-    def has_type(self, ttype):
+    def has_type(self, ttype: tvm.ir.type.Type):
         """
         Add a type constraint to this pattern
 
         Parameters
         ----------
-        ttype: tvm.relay.Type
+        ttype: tvm.ir.type.Type
             The type to match
 
         Returns
@@ -109,7 +113,10 @@ class DFPattern(Node):
         """
         return match(self, expr)
 
-    def partition(self, expr: Expr, attrs=None, check=lambda x: True) -> Expr:
+    def partition(self,
+                  expr: Expr,
+                  attrs: Optional[Dict[str, Object]] = None,
+                  check: Callable[[Expr], bool] = lambda x: True) -> Expr:
         """
         Parition the expression into functions defined by this pattern
 
@@ -119,7 +126,7 @@ class DFPattern(Node):
             The expression to match.
         attrs : Optional[Dict[str, Object]]
             A dictionary of Attribute name/values to add to the paritioned function
-        check : Function
+        check : Callable[[Expr], bool]
             A function to perform more complicated checks on the matched expression.
             Returns true if partitioning should proceed, false otherwise.
 
@@ -130,9 +137,9 @@ class DFPattern(Node):
         """
         return partition(self, expr, attrs, check)
 
-    def dominates(self, parent, path=None):
+    def dominates(self, parent: "DFPattern", path: "DFPattern" = None):
         """
-        Create a dominator for this pattern
+        Create a dominator for this pattern.
 
         Parameters
         ----------
@@ -144,15 +151,15 @@ class DFPattern(Node):
         Returns
         -------
         result: tvm.relay.dataflow_pattern.DFPattern
-            The resulting DominatorPattern
+            The resulting DominatorPattern.
         """
         if path is None:
             path = wildcard()
         return DominatorPattern(parent, path, self)
 
-    def optional(self, option_constructor):
+    def optional(self, option_constructor: Callable[["DFPattern"], "DFPattern"]):
         """
-        Create a optional user of this pattern
+        Create a optional user of this pattern.
 
         Parameters
         ----------
@@ -168,26 +175,60 @@ class DFPattern(Node):
         return self | option_constructor(self)
 
 
-def is_input(name: str = "") -> DFPattern:
+def is_var(name: str = "") -> "DFPattern":
     """
-    Syntatic sugar for creating an optionally named VarPattern
+    Syntatic sugar for creating an optionally named VarPattern.
 
     Parameters
     ----------
     name: str
-        The name of the input pattern to match
+        The name of the input pattern to match.
 
     Returns
     -------
     result: tvm.relay.dataflow_pattern.DFPattern
-        The resulting InputPattern
+        The resulting pattern.
     """
     return VarPattern(name)
 
 
-def is_op(op_name: str) -> DFPattern:
+def is_constant() -> "DFPattern":
     """
-    Syntatic sugar for creating an operator ExprPattern
+    Syntatic sugar for creating a ConstantPattern.
+
+    Parameters
+    ----------
+    name: str
+        The name of the input pattern to match.
+
+    Returns
+    -------
+    result: tvm.relay.dataflow_pattern.DFPattern
+        The resulting pattern.
+    """
+    return ConstantPattern()
+
+
+def is_expr(expr: Expr) -> "DFPattern":
+    """
+    Syntatic sugar for creating an ExprPattern.
+
+    Parameters
+    ----------
+    expr: Expr
+        The Relay expression to match.
+
+    Returns
+    -------
+    result: tvm.relay.dataflow_pattern.DFPattern
+        The resulting pattern.
+    """
+    return ExprPattern(expr)
+
+
+def is_op(op_name: str) -> "DFPattern":
+    """
+    Syntatic sugar for creating an operator ExprPattern.
 
     Parameters
     ----------
@@ -203,19 +244,56 @@ def is_op(op_name: str) -> DFPattern:
     return ExprPattern(op)
 
 
-def wildcard() -> DFPattern:
+def is_tuple(fields: tvm.ir.container.Array) -> "DFPattern":
     """
-    Syntatic sugar for creating a WildcardPattern
+    Syntatic sugar for creating an ExprPattern.
+
+    Parameters
+    ----------
+    fields : Array[tvm.relay.dataflow_pattern.DFPattern]
+        The fields in the tuple.
 
     Returns
     -------
     result: tvm.relay.dataflow_pattern.DFPattern
-        The resulting WildcardPattern
+        The resulting pattern.
+    """
+    return TuplePattern(fields)
+
+
+def is_tuple_get_item(tuple_value: "DFPattern", index: int) -> "DFPattern":
+    """
+    Syntatic sugar for creating an ExprPattern.
+
+    Parameters
+    ----------
+    tuple_value: tvm.relay.dataflow_pattern.DFPattern
+        The input tuple expression.
+
+    index: int
+        The index.
+
+    Returns
+    -------
+    result: tvm.relay.dataflow_pattern.DFPattern
+        The resulting pattern.
+    """
+    return TupleGetItemPattern(tuple_value, index)
+
+
+def wildcard() -> "DFPattern":
+    """
+    Syntatic sugar for creating a WildcardPattern.
+
+    Returns
+    -------
+    result: tvm.relay.dataflow_pattern.DFPattern
+        The resulting pattern.
     """
     return WildcardPattern()
 
 
-def has_type(ttype, pattern: DFPattern = None) -> DFPattern:
+def has_type(ttype, pattern: "DFPattern" = None) -> "DFPattern":
     """
     Syntatic sugar for creating a TypePattern
 
@@ -224,7 +302,7 @@ def has_type(ttype, pattern: DFPattern = None) -> DFPattern:
     pattern: tvm.relay.dataflow_pattern.DFPattern
         The pattern that needs type annotation
 
-    ttype: tvm.relay.Type
+    ttype: tvm.ir.type.Type
         The type to match
 
     Returns
@@ -237,7 +315,7 @@ def has_type(ttype, pattern: DFPattern = None) -> DFPattern:
     return TypePattern(pattern, ttype)
 
 
-def has_attr(attrs, pattern=None) -> DFPattern:
+def has_attr(attrs, pattern=None) -> "DFPattern":
     """
     Syntatic sugar for creating an AttrPattern
 
@@ -259,7 +337,7 @@ def has_attr(attrs, pattern=None) -> DFPattern:
     return pattern.has_attr(attrs)
 
 
-def dominates(parent: DFPattern, path: DFPattern, child: DFPattern) -> DFPattern:
+def dominates(parent: "DFPattern", path: "DFPattern", child: "DFPattern") -> "DFPattern":
     """
     Syntatic sugar for creating an Dominator pattern
 
@@ -275,12 +353,12 @@ def dominates(parent: DFPattern, path: DFPattern, child: DFPattern) -> DFPattern
     Returns
     -------
     result: tvm.relay.dataflow_pattern.DFPattern
-        The resulting DominatorPattern
+        The resulting DominatorPattern.
     """
     return DominatorPattern(parent, path, child)
 
 
-def match(pattern: DFPattern, expr: Expr) -> bool:
+def match(pattern: "DFPattern", expr: Expr) -> bool:
     """
     Match a pattern to an expression
 
@@ -321,13 +399,12 @@ class VarPattern(DFPattern):
         The name of the variable. Optional, if not provided,
         the pattern will match any VarNode.
 
-    type_annotation: tvm.relay.Type, optional
+    type_annotation: tvm.ir.type.Type, optional
         The type annotation on the variable.
     """
 
-    def __init__(self, name_hint="", type_annotation=None):
-        self.__init_handle_by_constructor__(
-            ffi.VarPattern, name_hint, type_annotation)
+    def __init__(self, name_hint: str = "", type_annotation: Optional[tvm.ir.type.Type] = None):
+        self.__init_handle_by_constructor__(ffi.VarPattern, name_hint, type_annotation)
 
 
 @register_df_node
@@ -350,19 +427,22 @@ class CallPattern(DFPattern):
     args: List[realy.dataflow_pattern.DFPattern]
         The arguments to the call.
 
-    attrs: Optional[tvm.Attrs]
+    attrs: Optional[tvm.ir.attrs.Attrs]
         Attributes to the call, can be None
 
-    type_args: Optional[List[tvm.relay.Type]]
+    type_args: Optional[List[tvm.ir.type.Type]]
         The additional type arguments, this is only
         used in advanced usecase of template functions.
     """
 
-    def __init__(self, op, args, attrs=None, type_args=None):
+    def __init__(self,
+                 op: "DFPattern",
+                 args: List["DFPattern"],
+                 attrs: Optional[tvm.ir.attrs.Attrs] = None,
+                 type_args: Optional[List[tvm.ir.type.Type]] = None):
         if not type_args:
             type_args = []
-        self.__init_handle_by_constructor__(
-            ffi.CallPattern, op, args, attrs, type_args)
+        self.__init_handle_by_constructor__(ffi.CallPattern, op, args, attrs, type_args)
 
 
 @register_df_node
@@ -371,14 +451,14 @@ class TuplePattern(DFPattern):
 
     Parameters
     ----------
-    fields : List[tvm.relay.dataflow_pattern.DFPattern]
+    fields : Array[tvm.relay.dataflow_pattern.DFPattern]
         The fields in the tuple.
     """
 
-    def __init__(self, fields):
+    def __init__(self, fields: tvm.ir.container.Array):
         self.__init_handle_by_constructor__(ffi.TuplePattern, fields)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         if index >= len(self):
             raise IndexError("TuplePattern index out of range")
         return self.fields[index]
@@ -403,9 +483,8 @@ class TupleGetItemPattern(DFPattern):
         The index.
     """
 
-    def __init__(self, tuple_value: DFPattern, index):
-        self.__init_handle_by_constructor__(
-            ffi.TupleGetItemPattern, tuple_value, index)
+    def __init__(self, tuple_value: "DFPattern", index: int):
+        self.__init_handle_by_constructor__(ffi.TupleGetItemPattern, tuple_value, index)
 
 
 @register_df_node
@@ -415,14 +494,13 @@ class AltPattern(DFPattern):
     Parameters
     ----------
     left: tvm.relay.dataflow_pattern.DFPattern
-        One possible matching Pattern
+        One possible matching pattern.
     right: tvm.relay.dataflow_pattern.DFPattern
-        One possible matching Pattern
+        One possible matching pattern.
     """
 
-    def __init__(self, left: DFPattern, right: DFPattern):
-        self.__init_handle_by_constructor__(
-            ffi.AltPattern, left, right)
+    def __init__(self, left: "DFPattern", right: "DFPattern"):
+        self.__init_handle_by_constructor__(ffi.AltPattern, left, right)
 
 
 @register_df_node
@@ -441,34 +519,32 @@ class TypePattern(DFPattern):
     Parameters
     ----------
     pattern: tvm.relay.dataflow_pattern.DFPattern
-        The input pattern that needs type annotation
+        The input pattern that needs type annotation.
 
-    ttype: tvm.relay.Type
-        The type to match
+    ttype: tvm.ir.type.Type
+        The type to match.
     """
 
-    def __init__(self, pattern: DFPattern, ttype):
-        self.__init_handle_by_constructor__(
-            ffi.TypePattern, pattern, ttype)
+    def __init__(self, pattern: "DFPattern", ttype: tvm.ir.type.Type):
+        self.__init_handle_by_constructor__(ffi.TypePattern, pattern, ttype)
 
 
 @register_df_node
 class AttrPattern(DFPattern):
     """Get match an expression with a certain attributes.
-    Currently only supports Op Attributes, not call Attributes
+    Currently only supports Op Attributes, not call Attributes.
 
     Parameters
     ----------
     pattern: tvm.relay.dataflow_pattern.DFPattern
         The input pattern.
 
-    attrs: tvm.Attrs
-        The attributes to match
+    attrs: tvm.ir.attrs.Attrs
+        The attributes to match.
     """
 
-    def __init__(self, pattern: DFPattern, attrs):
-        self.__init_handle_by_constructor__(
-            ffi.AttrPattern, pattern, attrs)
+    def __init__(self, pattern: "DFPattern", attrs: tvm.ir.attrs.Attrs):
+        self.__init_handle_by_constructor__(ffi.AttrPattern, pattern, attrs)
 
 
 @register_df_node
@@ -479,22 +555,21 @@ class DominatorPattern(DFPattern):
     ----------
     parent: tvm.relay.dataflow_pattern.DFPattern
         The parent, i.e., the single node which produces something,
-        later aggregated by the child
+        later aggregated by the child.
     path: tvm.relay.dataflow_pattern.DFPattern
         The fuzzy path pattern between parent and child,
-        typically matches elementwise ops
+        typically matches elementwise ops.
     child: tvm.relay.dataflow_pattern.DFPattern
         The last node in the domination which is the end user
-        for all nodes in the path and the parent
+        for all nodes in the path and the parent.
     """
 
-    def __init__(self, parent: DFPattern, path: DFPattern, child: DFPattern):
-        self.__init_handle_by_constructor__(
-            ffi.DominatorPattern, parent, path, child)
+    def __init__(self, parent: "DFPattern", path: "DFPattern", child: "DFPattern"):
+        self.__init_handle_by_constructor__(ffi.DominatorPattern, parent, path, child)
 
 
 class DFPatternCallback:
-    """A Callback for Pattern Rewriting
+    """A Callback for Pattern Rewriting.
 
     When rewrite is called on this DFPatternCallback, the backend will find matches for the
     pattern, call the callback function, and replace the matched expression with whatever
@@ -515,11 +590,11 @@ class DFPatternCallback:
         Returns
         -------
         result : tvm.relay.Expr
-            The Expression with matched subgraphs rewritten by the callbacks
+            The Expression with matched subgraphs rewritten by the callbacks.
         """
         return rewrite(self, expr)
 
-    def callback(self, pre, post, node_map):
+    def callback(self, pre: Expr, post: Expr, node_map: tvm.ir.container.Map) -> Expr:
         """
         Callback function to use when we found a match to the pattern
 
@@ -529,7 +604,7 @@ class DFPatternCallback:
             The matching expression from the original graph.
         post : tvm.relay.Expr
             The matching expression with rewritten inputs
-        node_map : Map(DFPattern, List(Expr))
+        node_map : tvm.ir.container.Map[DFPattern, List[Expr]]
             The map between patterns and matched expressions
 
         Returns
@@ -542,13 +617,12 @@ class DFPatternCallback:
 class _DFPatternCallback(Object):
     """C++ implemenation"""
     def __init__(self, pattern, callback):
-        self.__init_handle_by_constructor__(
-            ffi.DFPatternCallback, pattern, callback)
+        self.__init_handle_by_constructor__(ffi.DFPatternCallback, pattern, callback)
 
 
 def rewrite(callbacks, expr: Expr) -> Expr:
     """
-    Rewrite expression with the given callbacks
+    Rewrite expression with the given callbacks.
 
     Parameters
     ----------
@@ -560,7 +634,7 @@ def rewrite(callbacks, expr: Expr) -> Expr:
     Returns
     -------
     result : tvm.relay.Expr
-        The Expression with matched subgraphs rewritten by the callbacks
+        The Expression with matched subgraphs rewritten by the callbacks.
     """
     if isinstance(callbacks, DFPatternCallback):
         tmp = [_DFPatternCallback(callbacks.pattern, callbacks.callback)]
@@ -571,7 +645,11 @@ def rewrite(callbacks, expr: Expr) -> Expr:
 
     return ffi.rewrite(tmp, expr)
 
-def partition(pattern: DFPattern, expr: Expr, attrs=None, check=lambda x: True) -> Expr:
+
+def partition(pattern: "DFPattern",
+              expr: Expr,
+              attrs: Optional[Dict[str, Object]] = None,
+              check: Callable[[Expr], bool] = lambda x: True) -> Expr:
     """
     Parition the expression into a series of functions that match the pattern
 
@@ -583,7 +661,7 @@ def partition(pattern: DFPattern, expr: Expr, attrs=None, check=lambda x: True) 
         The expression to split into functions
     attrs : Optional[Dict[str, Object]]
         A dict of attributes to apply to the partitioned function
-    check : Function
+    check : Callable[[Expr], bool]
         A function to perform more complicated checks on the matched expression.
         Returns true if partitioning should proceed, false otherwise.
 


### PR DESCRIPTION
Per discussion in this PR, here is the current changelog:

- Add `is_expr`, `is_constant`, `is_tuple`, and `is_tuple_get_item` APIs. As a result, users will not directly call `XXPattern` anymore.
- Rename `is_input` to `is_var` to against `is_constant`.
- Add dataflow pattern to doc/api.
- Fix all type annotations in `__init__.py`.

=== ORIGINAL DESCRIPTION ===

For each pattern node, we define `XXPattern` Python class for the FFI connection. We also define a user-friendly API such as `is_op` to have better user experience. Since `is_XX` APIs are just wrappers to the corresponding `XXPattern` class, this PR simplifies their implementations by turning the APIs to function aliases.

In addition, this PR also makes the following changes:

1. Add `is_expr`, `is_constant`, `is_tuple`, and `is_tuple_get_item` APIs. As a result, users will not directly call `XXPattern` anymore.
2. Rename `is_input` to `is_var` to against `is_constant`.

@mbrookhart I'm not quite sure if the second change makes sense to you or not so I intentionally separate it to the second commit. If you prefer `is_input`, I could just simply revert it.

Also cc @masahi 