### PR TITLE
fix typo: anchor windoes should be anchor windows

### DIFF
--- a/python/tvm/relay/op/vision/rcnn.py
+++ b/python/tvm/relay/op/vision/rcnn.py
@@ -101,10 +101,10 @@ def proposal(cls_prob,
         [im_height, im_width, im_scale]
 
     scales : list/tuple of float
-        Scales of anchor windoes.
+        Scales of anchor windows.
 
     ratios : list/tuple of float
-        Ratios of anchor windoes.
+        Ratios of anchor windows.
 
     feature_stride : int
         The size of the receptive field each unit in the convolution layer of the rpn, for example

--- a/topi/python/topi/cuda/rcnn/proposal.py
+++ b/topi/python/topi/cuda/rcnn/proposal.py
@@ -43,10 +43,10 @@ def predict_bbox_ir(cls_prob_buf, bbox_pred_buf, im_info_buf, out_buf, scales, r
         The last dimension is in format of [w_start, h_start, w_end, h_end, score]
 
     scales : list/tuple of float
-        Scales of anchor windoes.
+        Scales of anchor windows.
 
     ratios : list/tuple of float
-        Ratios of anchor windoes.
+        Ratios of anchor windows.
 
     feature_stride : int
         The size of the receptive field each unit in the convolution layer of the rpn, for example
@@ -325,10 +325,10 @@ def proposal(cls_prob, bbox_pred, im_info, scales, ratios, feature_stride, thres
         2-D with shape [batch, 3]
 
     scales : list/tuple of float
-        Scales of anchor windoes.
+        Scales of anchor windows.
 
     ratios : list/tuple of float
-        Ratios of anchor windoes.
+        Ratios of anchor windows.
 
     feature_stride : int
         The size of the receptive field each unit in the convolution layer of the rpn, for example

--- a/topi/python/topi/vision/rcnn/proposal.py
+++ b/topi/python/topi/vision/rcnn/proposal.py
@@ -82,10 +82,10 @@ def predict_bbox_ir(cls_prob_buf, bbox_pred_buf, im_info_buf, out_buf, scales, r
         The last dimension is in format of [w_start, h_start, w_end, h_end, score]
 
     scales : list/tuple of float
-        Scales of anchor windoes.
+        Scales of anchor windows.
 
     ratios : list/tuple of float
-        Ratios of anchor windoes.
+        Ratios of anchor windows.
 
     feature_stride : int
         The size of the receptive field each unit in the convolution layer of the rpn, for example
@@ -335,10 +335,10 @@ def proposal(cls_prob, bbox_pred, im_info, scales, ratios, feature_stride, thres
         2-D with shape [batch, 3]
 
     scales : list/tuple of float
-        Scales of anchor windoes.
+        Scales of anchor windows.
 
     ratios : list/tuple of float
-        Ratios of anchor windoes.
+        Ratios of anchor windows.
 
     feature_stride : int
         The size of the receptive field each unit in the convolution layer of the rpn, for example


### PR DESCRIPTION
Happen to see the typo in https://tvm.apache.org/docs/api/python/relay/vision.html#tvm.relay.vision.proposal.