### PR TITLE
Fix generating types like float44 and float88

### DIFF
--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -937,7 +937,7 @@ void CodeGenC::PrintVecElemLoadExpr(DataType t, int i, const std::string& value,
   if (i == 0) {
     os << "((";
     PrintType(t, os);
-    os << t.lanes() << ")(";
+    os << ")(";
   }
   os << value;
   if (i != t.lanes() - 1) {


### PR DESCRIPTION
This fixes #5704 and #5710.

The existing tests already fail before this patch so I did not add any new tests.