### PR TITLE
Fix the values for test_fmod since it fails way too often otherwise

### DIFF
--- a/tests/python/integration/test_ewise.py
+++ b/tests/python/integration/test_ewise.py
@@ -80,10 +80,15 @@ def test_fmod():
 
             # launch the kernel.
             n = 1024
-            # Make sure we don't get "bad" values
-            np.random.seed(1797)
-            a = tvm.nd.array((np.random.uniform(size=n) * 256).astype(A.dtype), ctx)
-            b = tvm.nd.array((np.random.uniform(size=n) * 256).astype(B.dtype), ctx)
+            a_np = (np.random.uniform(size=n) * 256).astype(A.dtype)
+            b_np = (np.random.uniform(size=n) * 256).astype(B.dtype)
+
+            # "fix" the values in a and b to avoid the result being too small
+            b_np += ((b_np < 2.0) * 2)
+            a_np[np.abs(np.fmod(a_np, b_np)) < 1] += 1
+
+            a = tvm.nd.array(a_np, ctx)
+            b = tvm.nd.array(b_np, ctx)
             c = tvm.nd.array(np.zeros(n, dtype=C.dtype), ctx)
             ftimer = fmod.time_evaluator(fmod.entry_name, ctx, number=1)
             tcost = ftimer(a, b, c).mean

--- a/tests/python/integration/test_ewise.py
+++ b/tests/python/integration/test_ewise.py
@@ -80,6 +80,8 @@ def test_fmod():
 
             # launch the kernel.
             n = 1024
+            # Make sure we don't get "bad" values
+            np.random.seed(1797)
             a = tvm.nd.array((np.random.uniform(size=n) * 256).astype(A.dtype), ctx)
             b = tvm.nd.array((np.random.uniform(size=n) * 256).astype(B.dtype), ctx)
             c = tvm.nd.array(np.zeros(n, dtype=C.dtype), ctx)


### PR DESCRIPTION
This fails more than 99% of the time on my machine with metal.

I've tested that seed on a couple of machines with OpenCL and CUDA to make sure they still work and the seem to do.

If there is a better way to approach this, I would love to hear it.