### PR TITLE
[AutoTVM, Relay] Clear compile engine after task extraction

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -137,6 +137,7 @@ def extract_from_multiple_program(mods, params, target, target_host=None, ops=No
                                             args=(mod, target, param))
             build_thread.start()
             build_thread.join()
+            relay.backend.compile_engine.get().clear()
 
         logger.disabled = old_state
 


### PR DESCRIPTION
We need to clear compiler engine cache after task extraction, otherwise after tuning, we have the compilation result for task extraction in the cache and we won't utilize the latest configs from after tuning.
This can be reproduced by running any AutoTVM tutorial such as https://github.com/apache/incubator-tvm/blob/master/tutorials/autotvm/tune_relay_cuda.py

cc @comaniac @merrymercy
