### PR TITLE
[Bugfix][Serialization] Fix runtime::String backward compatibility in JSON

### DIFF
--- a/python/tvm/ir/json_compact.py
+++ b/python/tvm/ir/json_compact.py
@@ -87,8 +87,9 @@ def create_updater_06_to_07():
         return _convert
 
     def _update_global_key(item, _):
-        item["repr_str"] = item["global_key"]
-        del item["global_key"]
+        if "global_key" in item:
+            item["repr_str"] = item["global_key"]
+            del item["global_key"]
         return item
 
     def _update_from_std_str(key):
@@ -111,8 +112,10 @@ def create_updater_06_to_07():
         "EnvFunc": _update_global_key,
         "relay.Op": [_update_global_key, _rename("Op")],
         "relay.TypeVar": [_ftype_var, _update_from_std_str("name_hint")],
+        "TypeVar": _update_from_std_str("name_hint"),
         "relay.Id": [_update_from_std_str("name_hint")],
         "relay.GlobalTypeVar": [_ftype_var, _update_from_std_str("name_hint")],
+        "GlobalTypeVar": _update_from_std_str("name_hint"),
         "relay.Type": _rename("Type"),
         "relay.TupleType": _rename("TupleType"),
         "relay.TypeConstraint": _rename("TypeConstraint"),
@@ -124,6 +127,7 @@ def create_updater_06_to_07():
         "relay.SourceName": _rename("SourceName"),
         "relay.Span": _rename("Span"),
         "relay.GlobalVar": [_rename("GlobalVar"), _update_from_std_str("name_hint")],
+        "GlobalVar": _update_from_std_str("name_hint"),
         "relay.Pass": _rename("transform.Pass"),
         "relay.PassInfo": _rename("transform.PassInfo"),
         "relay.PassContext": _rename("transform.PassContext"),

--- a/tests/python/relay/test_json_compact.py
+++ b/tests/python/relay/test_json_compact.py
@@ -145,6 +145,24 @@ def test_global_var():
     }
     tvar = tvm.ir.load_json(json.dumps(data))
     assert isinstance(tvar, tvm.ir.GlobalVar)
+    nodes = [
+        {"type_key": ""},
+        {"type_key": "GlobalVar",
+         "attrs": {
+             "_checked_type_": "0",
+             "name_hint": "x",
+             "span": "0"
+         }
+        }
+    ]
+    data = {
+        "root" : 1,
+        "nodes": nodes,
+        "attrs": {"tvm_version": "0.6.0"},
+        "b64ndarrays": [],
+    }
+    tvar = tvm.ir.load_json(json.dumps(data))
+    assert isinstance(tvar, tvm.ir.GlobalVar)
 
 
 def test_op():


### PR DESCRIPTION
@antinucleon sent me a JSON file which cannot be loaded in current HEAD on master. After bisecting around, I found that there are some missing parts (or just typos I think) in json_compact.py...

Also CC: @tqchen @jwfromm @ANSHUMAN87 if you guys are interested