### PR TITLE
[TensorFlow] Don't add cast for batch norm when type isn't changing

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1227,7 +1227,7 @@ def _fused_batch_norm():
             attr['data_format'] = attr['data_format'].decode("utf-8")
             if attr['data_format'] == 'NCHW':
                 axis = 1
-        if 'U' in attr:
+        if 'U' in attr and attr['U'].name != attr['T'].name:
             need_cast = True
             inputs[0] = _op.cast(inputs[0], dtype=attr['U'].name)
         # Check if mean and variance are empty


### PR DESCRIPTION
TensorFlow batch norm op has two type attributes:
`U` which is the type of the parameters scale, offset, mean, and variance.
`T` which is the type of the input and output.

The TF importer currently adds casts the input from `T` type to `U` type so that the computation is done in `U` type, and then casts the output back to `T`. However, it adds these casts even when `U` and `T` are the same. There ends up being many casts from float to float throughout the model which introduces issues for BYOCG.
