### PR TITLE
[Topi] pass-by-value -> pass-by-const-reference

### DIFF
--- a/topi/include/topi/generic/default.h
+++ b/topi/include/topi/generic/default.h
@@ -43,7 +43,7 @@ namespace generic {
  *
  * \return A schedule for the given ops.
  */
-inline Schedule default_schedule(const Target& target, Array<Tensor> outs) {
+inline Schedule default_schedule(const Target& target, const Array<Tensor>& outs) {
   Array<Operation> out_ops;
   for (auto t : outs) {
     out_ops.push_back(t->op);
@@ -61,7 +61,7 @@ inline Schedule default_schedule(const Target& target, Array<Tensor> outs) {
  *
  * \return A schedule for the given ops.
  */
-inline Schedule default_schedule_auto_inline(const Target& target, Array<Tensor> outs) {
+inline Schedule default_schedule_auto_inline(const Target& target, const Array<Tensor>& outs) {
   Array<Operation> out_ops;
   for (auto t : outs) {
     out_ops.push_back(t->op);

--- a/topi/include/topi/generic/extern.h
+++ b/topi/include/topi/generic/extern.h
@@ -44,7 +44,7 @@ namespace generic {
  *
  * \return A schedule for the op.
  */
-inline Schedule schedule_extern(const Target& target, Array<Tensor> outs) {
+inline Schedule schedule_extern(const Target& target, const Array<Tensor>& outs) {
   Array<Operation> out_ops;
   for (auto t : outs) {
     out_ops.push_back(t->op);


### PR DESCRIPTION
Mostly to unify the API of `schedule_injective`, `schedule_extern`, and `default_schedule` by moving to pass-by-const-reference.