### PR TITLE
[Relay] Keep fixed dim when unifying dynamic shape

### DIFF
--- a/src/relay/analysis/type_solver.cc
+++ b/src/relay/analysis/type_solver.cc
@@ -175,6 +175,17 @@ class TypeSolver::Unifier : public TypeFunctor<Type(const Type&, const Type&)> {
     if (ulhs.same_as(urhs)) {
       return ulhs;
     }
+
+    if (ulhs.as<AnyNode>() && urhs.as<tvm::IntImmNode>()) {
+      solver_->shape_uf_.Set(urhs, ulhs);
+      return urhs;
+    }
+
+    if (ulhs.as<tvm::IntImmNode>() && urhs.as<AnyNode>()) {
+      solver_->shape_uf_.Set(ulhs, urhs);
+      return ulhs;
+    }
+
     if (ulhs.as<AnyNode>() || urhs.as<AnyNode>()) {
       return Any();
     }

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -721,9 +721,7 @@ def test_recursive_concat():
     mod["main"] = func
     data = np.array(0.0, dtype='int32')
     ref = np.array([0] + list(range(10))).reshape((11, 1)).astype("int32")
-    # TODO(@jroesch): After LambdaLift pass, TypeInfer pass will fail
-    # so currently we cannot run this test case on VM
-    for kind in ["debug"]:
+    for kind in ["debug", "vm"]:
         ex = relay.create_executor(kind, mod=mod, ctx=tvm.cpu(), target="llvm")
         result = ex.evaluate()(data)
         np.testing.assert_allclose(result.asnumpy(), ref)


### PR DESCRIPTION
For this function:

```
fn (%True: Tensor[(?, 1), float32], %False: Tensor[(?, ?), float32]) {
  free_var %f: fn () -> bool
  %0 = %f();
  if (%0) {
    %True
  } else {
    %False
  }
}
```

Original type inference result:

```
fn (%True: Tensor[(?, ?), float32], %False: Tensor[(?, ?), float32], %f: fn () -> bool) -> Tensor[(?, ?), float32] {
  %0 = %f() /* ty=bool */;
  if (%0) {
    %True
  } else {
    %False
  }
}
```

Type inference result with this patch, which keeps the fixed dim

```
fn (%True: Tensor[(?, 1), float32], %False: Tensor[(?, 1), float32], %f: fn () -> bool) -> Tensor[(?, 1), float32] {
  %0 = %f() /* ty=bool */;
  if (%0) {
    %True
  } else {
    %False
  }
}
```

cc @icemelon9 @kevinthesun @zhiics  Could you please review?