### PR TITLE
[MergeComposite] Fix InferType when module contains Prelude

### DIFF
--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -23,6 +23,7 @@ import tvm
 from tvm import te
 import tvm.relay as relay
 import tvm.relay.op as op
+from tvm.relay import Prelude
 
 
 from . import mlp
@@ -44,9 +45,11 @@ from .nat import add_nat_definitions, count, make_nat_value, make_nat_expr
 from .py_converter import to_python, run_as_python
 from ..transform import gradient
 
-def run_opt_pass(expr, opt_pass):
+def run_opt_pass(expr, opt_pass, import_prelude=False):
     assert isinstance(opt_pass, tvm.transform.Pass)
     mod = tvm.IRModule.from_expr(expr)
+    if import_prelude:
+        Prelude(mod)
     mod = opt_pass(mod)
     entry = mod["main"]
     return entry if isinstance(expr, relay.Function) else entry.body

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -163,9 +163,9 @@ def make_bn_relu_pattern():
     r = is_op('nn.relu')(tuple_get_item_node)
     return r
 
-def check_result(pattern_table, graph, expected_graph):
+def check_result(pattern_table, graph, expected_graph, import_prelude=False):
     """Utility function to check merge composite results."""
-    result = run_opt_pass(graph, relay.transform.MergeComposite(pattern_table))
+    result = run_opt_pass(graph, relay.transform.MergeComposite(pattern_table), import_prelude=import_prelude)
     assert not relay.analysis.free_vars(result), \
         "Found free vars in the result graph: {0}".format(str(result))
     expected = run_opt_pass(expected_graph, relay.transform.InferType())
@@ -213,7 +213,7 @@ def test_simple_merge():
         r = relay.Call(add_relu, [a, b])
         return relay.Function([a, b], r)
 
-    check_result(pattern_table, before(), expected())
+    check_result(pattern_table, before(), expected(), import_prelude=True)
 
 
 def test_branch_merge():


### PR DESCRIPTION
  A function may refer to other resources in the same module, so keep
  the content of original module when infering a function.

cc @mbaret @mbrookhart @comaniac