### PR TITLE
[Relay] Support for ADT in Lazy Gradient Init Pass

### DIFF
--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -86,6 +86,11 @@ class IRModuleNode : public Object {
   TVM_DLL void AddUnchecked(const GlobalVar& var, const BaseFunc& func);
 
   /*!
+   * \brief Infer the type of all global functions
+   */
+  TVM_DLL void Check();
+
+  /*!
    * \brief Add a type-level definition to the global environment.
    * \param var The var of the global type definition.
    * \param type The ADT.

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -89,6 +89,8 @@ class StructuralEqual : public BaseValueEqual {
    * \return The comparison result.
    */
   TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs) const;
+
+  TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars) const;
 };
 
 /*!

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -256,7 +256,7 @@ void IRModuleNode::Check() {
                    << " in function: " << AsText(func, false) << std::endl;
     }
     auto func_copy = relay::Function(concat(func->params, fv), func->body, func->ret_type,
-                          concat(func->type_params, ftv), func->attrs);
+                                     concat(func->type_params, ftv), func->attrs);
 
     func_copy->checked_type_ = func_copy->func_type_annotation();
     mod->AddUnchecked(var, func_copy);

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -236,6 +236,45 @@ void IRModuleNode::AddUnchecked(const GlobalVar& var, const BaseFunc& func) {
   global_var_map_.Set(var->name_hint, var);
 }
 
+void IRModuleNode::Check() {
+  const auto& mod = GetRef<IRModule>(this);
+  const auto& globalvars = this->GetGlobalVars();
+
+  // first pass: fill in type for all functions
+  for (const auto& var : globalvars) {
+    relay::Function f = Downcast<relay::Function>(this->Lookup(var));
+    auto func = Downcast<relay::Function>(relay::DeDup(std::move(f)));
+
+    auto fv = relay::FreeVars(func);
+    auto ftv = relay::FreeTypeVars(func, mod);
+    if (fv.size() != 0) {
+      LOG(WARNING) << "There are free variables: " << fv << " in function: " << AsText(func, false)
+                   << std::endl;
+    }
+    if (ftv.size() != 0) {
+      LOG(WARNING) << "There are free type variables: " << ftv
+                   << " in function: " << AsText(func, false) << std::endl;
+    }
+    auto func_copy = relay::Function(concat(func->params, fv), func->body, func->ret_type,
+                          concat(func->type_params, ftv), func->attrs);
+
+    func_copy->checked_type_ = func_copy->func_type_annotation();
+    mod->AddUnchecked(var, func_copy);
+  }
+
+  // second pass: type inference on every function
+  for (const auto& var : globalvars) {
+    auto func = Downcast<relay::Function>(this->Lookup(var));
+    relay::Function checked_func = InferType(func, mod, var);
+
+    Type type = checked_func->checked_type();
+    CHECK(type.as<relay::IncompleteTypeNode>() == nullptr) << "NULL";
+
+    var->checked_type_ = type;
+    mod->AddUnchecked(var, func);
+  }
+}
+
 void IRModuleNode::RegisterConstructors(const GlobalTypeVar& var, const TypeData& type) {
   // We hash the global type var name to use as a globally unique prefix for tags.
   // The hash will be used as the most significant byte of the tag, with the index of

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -231,4 +231,10 @@ bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs) con
   return RemapVarSEqualHandler(false).Equal(lhs, rhs, false);
 }
 
+bool StructuralEqual::operator()(const ObjectRef& lhs,
+                                 const ObjectRef& rhs,
+                                 bool map_free_vars) const {
+  return RemapVarSEqualHandler(false).Equal(lhs, rhs, map_free_vars);
+}
+
 }  // namespace tvm

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -231,8 +231,7 @@ bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs) con
   return RemapVarSEqualHandler(false).Equal(lhs, rhs, false);
 }
 
-bool StructuralEqual::operator()(const ObjectRef& lhs,
-                                 const ObjectRef& rhs,
+bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs,
                                  bool map_free_vars) const {
   return RemapVarSEqualHandler(false).Equal(lhs, rhs, map_free_vars);
 }

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -182,6 +182,9 @@ bool ExpandDimsRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     return false;
   }
   const auto* param = attrs.as<ExpandDimsAttrs>();
+  if (param == nullptr) {
+    return false;
+  }
   const int ndim = static_cast<int>(data->shape.size());
   const int axis = param->axis;
   const int num_newaxis = param->num_newaxis;

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -59,6 +59,9 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   }
 
   const auto* param = attrs.as<AttrType>();
+  if (param == nullptr) {
+    return false;
+  }
   if (tensor_tuple->fields[0].as<IncompleteTypeNode>()) {
     return false;
   }

--- a/src/relay/transforms/lazy_gradient_init.cc
+++ b/src/relay/transforms/lazy_gradient_init.cc
@@ -692,7 +692,7 @@ class LazyGradientInitializer : public ExprMutator, public TypeMutator, public P
       Expr tensorOutput = grad_cell_unwrapper_->VisitExpr(transformedExpr, transformed->ret_type);
       return Function(f->params, tensorOutput, f->ret_type, f->type_params);
     }
-    LOG(FATAL) << "GlobalVar does not map to a function";
+    throw std::runtime_error("GlobalVar does not map to a function");
   }
 
   Expr VisitExpr_(const ConstantNode* op) final {

--- a/src/relay/transforms/lazy_gradient_init.cc
+++ b/src/relay/transforms/lazy_gradient_init.cc
@@ -35,10 +35,10 @@
  *
  * It also overloads + and * operation which can increase performance when doing
  * operations involving tensors with values of only 0 or 1.
- *
- * Note: this pass can only be used with functions where the input/output types are
- * a combination of TupleTypes and TensorTypes
- *
+ * 
+ * Note: this pass can only be used with functions where the input/output types are a
+ * combination of TupleTypes, TensorTypes, non mutually-recursive ADTs, and non-nested FuncTypes
+ * 
  * This pass optimizes 6 ops:
  * - add
  * - multiply
@@ -46,143 +46,667 @@
  * - ones_like
  * - zeros
  * - zeros_like
- *
- * This pass makes use of three visitor. The most important one visits the entire function,
- * one is used for wrap inputs and one to unwrap outputs.
- *
- * For example:
- * fn: TensorType[(10,10), float32] -> TensorType[(10,10), float32]
- *
- * After this pass
- * fn: GradCell[TensorType[(10,10), float32]] -> GradCell[TensorType[(10,10), float32]]
- *
- * Thus, it is necessary to wrap this outer function so that the input/output types remain the same
+ * 
+ * This module level pass adds a new "GradCell" datatype for each existing datatype.
+ * This is the case to propogate the new GradCell datatype through ADTs such as Lists.
+ * For each function, a new function is created that accepts the "GradCell-version" of the arguments
+ * of the original function. That is, inputs to the function are converted to their GradCell-version,
+ * passed to the newly created "GradCell_Function".
+ * The output is then necessarily converted from the GradCell version to the original return type.
+ * 
+ * To support ADTs, we use functions that convert between an instance of an ADT to its 
+ * respective GradCell version
+ * by matching constructors to the constructor of the "GradCell" datatype.
+ * 
+ * A transformation function is required for different type arguments.
+ * For example the ADT List may be List[int32] or List[List[int32]], which should be handled separately.
+ * 
+ * This pass uses 4 primary mutators:
+ * - LazyGradientInitializer to create the "GradCell_Function" of a given function.
+ * - GradCellWrapper mutates expr into its respective GradCell expr
+ * - GradCellWrapper mutates expr into its respective non-GradCell expr
+ * - ADTTransform creates a ADT for each unique ADT
  */
 
 #include <tvm/ir/type_functor.h>
 #include <tvm/node/structural_equal.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr_functor.h>
+#include <tvm/ir/type_functor.h>
+#include <tvm/relay/pattern_functor.h>
 #include <tvm/relay/transform.h>
-
+#include <tvm/relay/analysis.h>
 #include "let_list.h"
 
 namespace tvm {
 namespace relay {
 
-/*!
- * \brief Visitor appropriately wraps tensors with Raw constructor
- *
- * Recursively looks at the type of the expression (TensorType or TupleType are only supported for
- * now) and either call the GradCell constructor if TensorType or unfold and recursively visit if
- * TupleType
- */
-class InputVisitor : public ExprFunctor<Expr(const Expr&, const Type&)> {
- public:
-  explicit InputVisitor(IRModule module) : module_(module) {}
+const std::string GradCell_Header = "_GradCell_";
+const std::string GradCell_TransFunc = "_GradCell_TransFunc_";
+const std::string GradCell_ReverseTransFunc = "_GradCell_ReverseTransFunc_";
+const std::string GradCell_Func = "_GradCell_Func_";
 
-  Expr VisitExpr_(const VarNode* op, const Type& t) final {
-    std::cout << op->type_annotation << std::endl;
-    return WrapExpr(GetRef<Var>(op), op->type_annotation);
-  }
-
-  Expr VisitExpr_(const TupleGetItemNode* op, const Type& t) final {
-    return WrapExpr(GetRef<TupleGetItem>(op), t);
-  }
-
- private:
-  IRModule module_;
-
-  Expr WrapExpr(const Expr expr, const Type& type) {
-    if (type.as<TensorTypeNode>()) {
-      return Call(module_->GetConstructor("GradCell", "Raw"), {expr}, Attrs(), {type});
-    } else if (auto* type_anno = type.as<TupleTypeNode>()) {
-      tvm::Array<Expr> fields;
-      for (size_t i = 0; i < type_anno->fields.size(); i++) {
-        const Type& t = type_anno->fields[i];
-        fields.push_back(this->VisitExpr(TupleGetItem(expr, i), t));
-      }
-      Expr tuple = Tuple(fields);
-      return tuple;
-    }
-
-    return expr;
+struct TypeCallHash {
+  size_t operator()(const TypeCall& typecall) const {
+    return ObjectHash()(typecall->func);
   }
 };
 
 /*!
- * \brief Visitor appropriately unwraps expressions with GradCell type into Tensors
- *
- * Recursively looks at the type of the expression
- * and either use the FromGradCell function if TypeCall to GradCell
- * or unfold and recursively visit if TupleType
+ * \brief Check if two ADT instances are equal,
+ * check for dataflow equivalence allow for mapping between TypeVars
+ * i.e GradCell[TypeVar(A)] = GradCell[TypeVar(B)]
  */
-class OutputVisitor : public ExprFunctor<Expr(const Expr&, const Type&)> {
- public:
-  explicit OutputVisitor(IRModule module) : module_(module) {}
-
-  Expr VisitExpr_(const CallNode* op, const Type& t) final {
-    return UnwrapExpr(GetRef<Call>(op), t);
-  }
-
-  Expr VisitExpr_(const TupleGetItemNode* op, const Type& t) final {
-    return UnwrapExpr(GetRef<TupleGetItem>(op), t);
-  }
-
- private:
-  IRModule module_;
-
-  Expr UnwrapExpr(const Expr expr, const Type& type) {
-    if (auto* type_call = type.as<TypeCallNode>()) {
-      if (type_call->func.same_as(module_->GetGlobalTypeVar("GradCell"))) {
-        return Call(module_->GetGlobalVar("FromGradCell"), {expr});
-      }
-      return expr;
-    } else if (auto* type_anno = type.as<TupleTypeNode>()) {
-      tvm::Array<Expr> fields;
-      for (size_t i = 0; i < type_anno->fields.size(); i++) {
-        const Type& t = type_anno->fields[i];
-        fields.push_back(this->VisitExpr(TupleGetItem(expr, i), t));
-      }
-      Expr tuple = Tuple(fields);
-      return tuple;
+struct TypeCallEqual {
+  bool operator()(const TypeCall& l, const TypeCall& r) const {
+    if (!(l->func.same_as(r->func))) {
+      return false;
     }
 
-    return expr;
+    if (l->args.size() != r->args.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < l->args.size(); i++) {
+      if (!GraphEqual(l->args[i], r->args[i])) {
+        return false;
+      }
+    }
+
+    return true;
   }
 };
 
-class LazyGradientInitializer : public ExprMutator, public TypeMutator {
+/*!
+ * \brief ADTTransform creates a new ADT named 
+ * GradCell_Header + name_hint for each unique ADT.
+ * 
+ * This is necessary to handle ADTs.
+ */ 
+class ADTTransform: public TypeMutator, public PatternMutator {
  public:
-  explicit LazyGradientInitializer(IRModule module) : module_(module) {
-    module_->ImportFromStd("gradient.rly");
+  explicit ADTTransform(IRModule module):
+    module_(module) { }
+  
+  Type VisitType(const Type& t) final {
+    return TypeMutator::VisitType(t);
+  }
+
+  Type VisitType_(const TensorTypeNode* op) final {
+    GlobalTypeVar gradCell = module_->GetGlobalTypeVar("GradCell");
+    tvm::Array<Type> args;
+    args.push_back(GetRef<TensorType>(op));
+    return TypeCall(gradCell, args);
+  }
+  
+  Type VisitType_(const GlobalTypeVarNode* op) final {
+    GlobalTypeVar t = GetRef<GlobalTypeVar>(op);
+    if (op->kind == kAdtHandle) {
+      
+      if (adt_mapping_.count(t) != 0) {
+        return adt_mapping_.at(t);
+      }
+      
+      TypeData adt = module_->LookupTypeDef(t);
+      this->VisitType(adt);
+
+      return adt_mapping_.at(t);
+    }
+
+    return GetRef<Type>(op);
+  }
+
+  Type VisitType_(const TypeDataNode* op) final {
+    auto type_data = GetRef<TypeData>(op);
+    std::string transformed_adt_name = GradCell_Header + op->header->name_hint;
+
+    // add new ADT to map to handle recursive definitions 
+    GlobalTypeVar new_adt = GlobalTypeVar(transformed_adt_name,
+                                          op->header->kind);
+    adt_mapping_[type_data->header] = new_adt;
+    reverse_adt_mapping_[new_adt] = type_data->header;
+
+    // define transformed ADT
+    Array<Constructor> constructors;
+    for (Constructor con : op->constructors) {
+      Array<Type> inputs;
+      for (Type t : con->inputs) {
+        inputs.push_back(this->VisitType(t));
+      }
+      Constructor transformed_cons = Constructor(GradCell_Header + con->name_hint,
+                                        inputs, new_adt);
+      constructors.push_back(transformed_cons);
+    }
+    
+    TypeData new_datatype = TypeData(new_adt, op->type_vars, constructors);
+    module_->AddTypeDef(new_adt, new_datatype);
+    return new_datatype;
+  }
+
+  Pattern VisitPattern(const Pattern& c) final {
+    return PatternMutator::VisitPattern(c);
+  }
+
+  Constructor VisitConstructor(const Constructor& c) final {
+    this->VisitType(c->belong_to);
+    return module_->GetConstructor(GradCell_Header + c->belong_to->name_hint,
+                                  GradCell_Header + c->name_hint);
   }
 
   /*!
-   * \brief apply LazyGradientInit transformation and wrap function
-   * so that function type stays the same
-   *
-   * input/output types should only be a combination of TupleTypes and TensorTypes
+   * \brief Given a transformed ADT, returned the original ADT.
+   * Useful for GradCellUnWrapper which needs to map transformed ADT constructors
+   * to the original ADT constructors.
+   * 
+   * \param transformed_adt_handle GlobalTypeVar of "GradCell-version" of ADT
+   * \return ADT
    */
-  Expr Transform(const Expr& e) {
-    auto* f = (e).as<FunctionNode>();
-    auto* transformed = this->Mutate(e).as<FunctionNode>();
+  GlobalTypeVar GetReverseADT(GlobalTypeVar transformed_adt_handle) {
+    auto it = reverse_adt_mapping_.find(transformed_adt_handle);
 
-    if (e.same_as(GetRef<Function>(transformed))) {
-      return GetRef<Function>(transformed);
+    // reverse mapping should always be found
+    CHECK(it != reverse_adt_mapping_.end()) << "Reverse mapping of ADT transformation not found";
+    return it->second;
+  }
+
+ private:
+  // Module
+  IRModule module_;
+  // ADT -> transformed ADT
+  std::unordered_map<GlobalTypeVar, GlobalTypeVar, ObjectHash, ObjectEqual> adt_mapping_;
+  // transformed ADT -> ADT
+  std::unordered_map<GlobalTypeVar, GlobalTypeVar, ObjectHash, ObjectEqual> reverse_adt_mapping_;
+};
+
+/*!
+ * \brief Helper for TypeCallMutator.
+ * Replace TypeVar with type arguments
+ */
+class TypeVarSolver: public TypeMutator {
+ public:
+  explicit TypeVarSolver(std::unordered_map<TypeVar, TypeVar, ObjectHash, ObjectEqual> &type_var_map,
+                        std::unordered_map<TypeVar, Type, ObjectHash, ObjectEqual> &type_call_map):
+    type_var_map_(type_var_map), type_call_map_(type_call_map) {}
+  Type VisitType_(const TypeVarNode* op) final {
+    TypeVar type = GetRef<TypeVar>(op);
+    
+    if (type_call_map_.count(type) != 0) {
+      // recursively visit Type argument to replace possible nested TypeVar
+      return VisitType(type_call_map_.at(type));
     }
 
-    // wrap inputs of Tensor type using InputVisitor class
-    tvm::Array<Expr> args;
-    for (Var var : f->params) {
-      Expr wrappedInput = InputVisitor(module_).VisitExpr(var, var->checked_type());
-      args.push_back(wrappedInput);
+    if (type_var_map_.count(type) != 0) {
+      return type_var_map_.at(type);
     }
-    Expr transformedExpr = Call(GetRef<Function>(transformed), args);
 
-    // unwrap outputs of GradCell type into Tensor type using OutputVisitor class
-    Expr tensorOutput = OutputVisitor(module_).VisitExpr(transformedExpr, transformed->ret_type);
-    return Function(f->params, tensorOutput, f->ret_type, Array<TypeVar>());
+    return type;
+  }
+ private:
+  // 
+  std::unordered_map<TypeVar, TypeVar, ObjectHash, ObjectEqual> &type_var_map_;
+  std::unordered_map<TypeVar, Type, ObjectHash, ObjectEqual> &type_call_map_;
+};
+
+/*!
+ * \brief Find and replace TypeVars within arguments of a TypeCall
+ * This is used in GradCellWrapper and GradCellUnwrapper to extract the type_args
+ * to be passed in to the function that converts the ADT and the type_params of the
+ * new function.
+ */
+class TypeCallMutator: public TypeVisitor {
+ public:
+  // TypeVars that have to be passed to function as type_args
+  Array<Type> args;
+  // TypeVar params of new function
+  Array<TypeVar> params;
+  explicit TypeCallMutator(IRModule module, const TypeCallNode* op): module_(module) {
+    for (Type t : op->args) {
+      // visit each type argument
+      VisitType(t);
+    }
+    for (auto const& x : type_var_map) {
+      args.push_back(x.first);
+      params.push_back(x.second);
+    }
+  }
+
+  /*!
+   * \brief Solve for input type to function. Replace TypeVars of ADT with argumuents from TypeCall
+   * and replace TypeVars with newly created TypeVars of function.
+   * 
+   * \param t TypeCall
+   * \param map TypeVar of ADT -> type argument
+   * 
+   * \return type after replacing ADT TypeVar with arguments and TypeVar of arguments with TypeVar
+   * of functions
+   */
+
+  Type InputType(Type t, std::unordered_map<TypeVar, Type, ObjectHash, ObjectEqual>& map) {
+    return TypeVarSolver(type_var_map, map).VisitType(t);
+  }
+
+  void VisitType_(const TypeVarNode* op) final {
+    TypeVar tv = GetRef<TypeVar>(op);
+    if (type_var_map.count(tv) == 0) {
+      TypeVar replacement = TypeVar(tv->name_hint + "_", tv->kind);
+      type_var_map.insert({tv, replacement});
+    }
+  }
+
+ private:
+  IRModule module_;
+  // TypeVar in argument -> TypeVar of polymorphic function
+  std::unordered_map<TypeVar, TypeVar, ObjectHash, ObjectEqual> type_var_map;
+};
+
+typedef class GradCellUnWrapper GradCellUnWrapper;
+
+/*!
+ * \brief Mutate a given expression into its "GradCell-version".
+ * TensorTypes are wrapped with the Raw constructor of GradCell.
+ * TupleTypes are recursively visited.
+ * ADTTypes are converted to its appropriate transformed ADT
+ * FuncTypes are wrapped with a function that appropriates wraps/unwraps input and output
+ */
+class GradCellWrapper: public ExprFunctor<Expr(const Expr&, const Type&, GradCellUnWrapper*)>, 
+                       public TypeMutator {
+ public:
+  explicit GradCellWrapper(IRModule module, ADTTransform* adt_transformer): 
+    module_(module), adt_transformer_(adt_transformer), unique(0) {}
+  Expr VisitExpr_(const VarNode* op, const Type& t, GradCellUnWrapper* unwrapper) final;
+  Expr VisitExpr_(const TupleGetItemNode* op, const Type& t, GradCellUnWrapper* unwrapper) final;
+  Expr VisitExpr_(const CallNode* op, const Type& t, GradCellUnWrapper* unwrapper) final;
+ private:
+  // Module
+  IRModule module_;
+  // ADTTransform
+  ADTTransform* adt_transformer_;
+  // TypeCall -> Function to transform an ADT Instance into GradCell version
+  std::unordered_map<TypeCall, GlobalVar, TypeCallHash, TypeCallEqual> adt_wrapper_map_;
+  // TypeVar of ADT call -> Type argument
+  std::unordered_map<TypeVar, Type, ObjectHash, ObjectEqual> type_var_map;
+  // create unique strings for ADT wrapper functions
+  unsigned long unique;
+
+  Expr WrapExpr(const Expr expr, const Type& type, GradCellUnWrapper* unwrapper);
+  // Return function to wrap ADT
+  Expr GetADTFunction(const TypeCallNode* op, TypeCallMutator& type_args, 
+                      GradCellUnWrapper* unwrapper);
+  Type VisitType_(const GlobalTypeVarNode* op) final;
+  Type VisitType_(const TensorTypeNode* op) final;
+};
+
+/*!
+ * \brief Mutate a given "GradCell-version" expression into its nonGradCell-version.
+ * TypeCalls to GradCell are wrapped with FromGradCell function
+ * TupleTypes are recursively visited.
+ * Transformed ADTs are converted to its appropriate normal ADT
+ */
+class GradCellUnWrapper: public ExprFunctor<Expr(const Expr&, const Type&)>, 
+                         public TypeMutator {
+ public:
+  explicit GradCellUnWrapper(IRModule module, ADTTransform* adt_transformer): 
+    module_(module), adt_transformer_(adt_transformer), unique(0) {}
+  Expr VisitExpr_(const VarNode* op, const Type& t) final;
+  Expr VisitExpr_(const TupleGetItemNode* op, const Type& t) final;
+  Expr VisitExpr_(const CallNode* op, const Type& t) final;
+  Expr VisitExpr_(const TupleNode* op, const Type& t) final;
+  Expr VisitExpr_(const ConstantNode* op, const Type& t) final;
+ private:
+  // Module
+  IRModule module_;
+  // ADTTransform
+  ADTTransform* adt_transformer_;
+  // TypeCall -> Function an GradCell_ADT into ADT
+  std::unordered_map<TypeCall, GlobalVar, TypeCallHash, TypeCallEqual> adt_unwrapper_map_;
+  // TypeVar of GradCell_ADT call -> Type argument
+  std::unordered_map<TypeVar, Type, ObjectHash, ObjectEqual> type_var_map;
+  // create unique strings for ADT unwrapper functions
+  unsigned long unique;
+
+  Expr UnwrapExpr(const Expr expr, const Type& type);
+  // Return function to unwrap ADT
+  Expr GetReverseADTFunction(const TypeCallNode* op, TypeCallMutator& type_args);
+  Type VisitType_(const TypeCallNode* op) final;
+  Type VisitType_(const GlobalTypeVarNode* op) final;
+};
+
+/* GradCellWrapper */
+Expr GradCellWrapper::VisitExpr_(const VarNode* op, const Type& t, 
+                                GradCellUnWrapper* unwrapper) {
+  return WrapExpr(GetRef<Var>(op), op->type_annotation, unwrapper);
+}
+
+Expr GradCellWrapper::VisitExpr_(const TupleGetItemNode* op, const Type& t, 
+                                GradCellUnWrapper* unwrapper) {
+  return WrapExpr(GetRef<TupleGetItem>(op), t, unwrapper);
+}
+
+Expr GradCellWrapper::VisitExpr_(const CallNode* op, const Type& t, 
+                                GradCellUnWrapper* unwrapper) {
+  return WrapExpr(GetRef<Call>(op), t, unwrapper);
+}
+
+Expr GradCellWrapper::WrapExpr(const Expr expr, const Type& type, 
+                              GradCellUnWrapper* unwrapper) {
+  if (type.as<TensorTypeNode>()) {
+    return Call(module_->GetConstructor("GradCell", "Raw"),
+                        {expr}, Attrs(), {type});
+  } 
+  
+  if (auto* type_anno = type.as<TupleTypeNode>()) {
+    tvm::Array<Expr> fields;
+    for (size_t i = 0; i < type_anno->fields.size(); i++) {
+      const Type& t = type_anno->fields[i];
+      // recursively visit each item of tuple
+      fields.push_back(this->VisitExpr(TupleGetItem(expr, i), t, unwrapper));
+    }
+    Expr tuple = Tuple(fields);
+    return tuple;
+  } 
+  
+  if (auto* type_anno = type.as<TypeCallNode>()) {
+    // create GradCell_ADT if not already created
+    adt_transformer_->VisitType(type_anno->func);
+    auto tvs = TypeCallMutator(module_, type_anno);
+
+    return Call(GetADTFunction(type_anno, tvs, unwrapper), {expr}, Attrs(), tvs.args);
+  } 
+  
+  if (auto* type_anno = type.as<FuncTypeNode>()) {
+    Array<Var> funcVars;
+    Array<Expr> args;
+    for (Type t : type_anno->arg_types) {
+      Type visited = this->VisitType(t);
+      Var v = Var("v", visited);
+      funcVars.push_back(v);
+      // unwrap arguments
+      args.push_back(unwrapper->VisitExpr(v, visited));
+    }
+    // call original expr with unwrapped arguments
+    Call call = Call(expr, args);
+    // wrap results of the call
+    Expr result = this->WrapExpr(call, type_anno->ret_type, unwrapper);
+    // return new function with GradCell-version types, wrapping original function
+    return Function(funcVars, result, 
+                    this->VisitType(type_anno->ret_type), type_anno->type_params);
+  }
+
+  return expr;
+}
+
+Expr GradCellWrapper::GetADTFunction(const TypeCallNode* op, TypeCallMutator &type_args, 
+                                    GradCellUnWrapper* unwrapper) {
+  auto type = GetRef<TypeCall>(op);
+  GlobalTypeVar adt_handle = Downcast<GlobalTypeVar>(op->func);
+  if (adt_wrapper_map_.count(type) != 0) {
+    // ADT already wrapped previously
+    return adt_wrapper_map_.at(type);
+  }
+
+  // handle recursive ADT which require recursive calls to transform
+  GlobalVar func_var = GlobalVar(GradCell_Header + GradCell_TransFunc + adt_handle->name_hint +
+    std::to_string(unique++));
+  adt_wrapper_map_[type] = func_var;
+
+  TypeData adt_data = module_->LookupTypeDef(adt_handle);
+  TypeData new_adt_data = module_->LookupTypeDef(GradCell_Header + adt_handle->name_hint);
+
+  // solve for input type wrap ADT function
+  for (size_t i = 0; i < adt_data->type_vars.size(); i++) {
+    type_var_map[adt_data->type_vars[i]] = op->args[i];
+  }
+  auto input_type = type_args.InputType(type, type_var_map);
+
+  CHECK(adt_data->constructors.size() == new_adt_data->constructors.size()) <<
+    "ADT and transformed ADT have different number of constructors";
+
+  /*
+   * Pattern match each constructor of the ADT to the respective constructor
+   * in the transformed ADT. PatternVars then need to be recursively wrapped,
+   * and passed as argument to the constructor of the transformed ADT
+   */
+  Array<Clause> clauses;
+  for (size_t i = 0; i < adt_data->constructors.size(); i++) {
+    // get Constructor to pattern match against
+    Array<Pattern> patternVars;
+    Array<Expr> c_args;
+    Constructor c = adt_data->constructors[i];
+    for (Type t : c->inputs) {
+      // solve for type of PatternVar
+      Type pattern_var_type = type_args.InputType(t, type_var_map);
+      Var v = Var("var", pattern_var_type);
+      patternVars.push_back(PatternVar(v));
+      // recursively wrap
+      c_args.push_back(this->VisitExpr(v, pattern_var_type, unwrapper));
+    }
+    Pattern p = PatternConstructor(c, patternVars);
+    // return Constructor of new ADT with wrapped arguments
+    Expr e = Call(new_adt_data->constructors[i], c_args);
+
+    clauses.push_back(Clause(p, e));
+  }
+
+  Var v = Var("v", input_type);
+  Expr match = Match(v, clauses);
+
+  Function func = Function({v}, match, this->VisitType(input_type), type_args.params); 
+  module_->Add(func_var, func);
+  return func;
+}
+
+Type GradCellWrapper::VisitType_(const GlobalTypeVarNode* op) {
+  GlobalTypeVar t = GetRef<GlobalTypeVar>(op);
+  if (op->kind == kAdtHandle) {
+    return adt_transformer_->VisitType(t);
+  }
+
+  return GetRef<Type>(op);
+}
+
+Type GradCellWrapper::VisitType_(const TensorTypeNode* op) {
+  GlobalTypeVar gradCell = module_->GetGlobalTypeVar("GradCell");
+  tvm::Array<Type> args;
+  args.push_back(GetRef<TensorType>(op));
+  return TypeCall(gradCell, args);
+}
+
+/* GradCellUnWrapper */
+Expr GradCellUnWrapper::VisitExpr_(const CallNode* op, const Type& t) {
+  return UnwrapExpr(GetRef<Call>(op), t);
+}
+
+Expr GradCellUnWrapper::VisitExpr_(const TupleGetItemNode* op, const Type& t) {
+  return UnwrapExpr(GetRef<TupleGetItem>(op), t);
+}
+
+Expr GradCellUnWrapper::VisitExpr_(const VarNode* op, const Type& t) {
+  return UnwrapExpr(GetRef<Var>(op), op->type_annotation);
+}
+
+Expr GradCellUnWrapper::VisitExpr_(const TupleNode* op, const Type& t) {
+  return UnwrapExpr(GetRef<Tuple>(op), t);
+}
+
+Expr GradCellUnWrapper::VisitExpr_(const ConstantNode* op, const Type& t) {
+  return UnwrapExpr(GetRef<Constant>(op), t);
+}
+
+Expr GradCellUnWrapper::UnwrapExpr(const Expr expr, const Type& type) {
+  if (auto* type_call = type.as<TypeCallNode>()) {
+    if (type_call->func.same_as(module_->GetGlobalTypeVar("GradCell"))) {
+      // if TypeCall to GradCell, simply wrap with FromGradCell function
+      return Call(module_->GetGlobalVar("FromGradCell"), {expr}, Attrs(), type_call->args);
+    }
+
+    // convert transformed ADT to ADT
+    auto tvs = TypeCallMutator(module_, type_call);
+    return Call(GetReverseADTFunction(type_call, tvs), {expr}, Attrs(), tvs.args);
+  } 
+  
+  if (auto* type_anno = type.as<TupleTypeNode>()) {
+    tvm::Array<Expr> fields;
+    for (size_t i = 0; i < type_anno->fields.size(); i++) {
+      // recursively unwrap items of tuple
+      const Type& t = type_anno->fields[i];
+      fields.push_back(this->VisitExpr(TupleGetItem(expr, i), t));
+    }
+    Expr tuple = Tuple(fields);
+    return tuple;
+  }
+  return expr;
+}
+
+Expr GradCellUnWrapper::GetReverseADTFunction(const TypeCallNode* op, 
+                                              TypeCallMutator& type_args) {
+  TypeCall type = GetRef<TypeCall>(op);
+  GlobalTypeVar transformed_adt_handle = Downcast<GlobalTypeVar>(op->func);
+  GlobalTypeVar adt_handle = adt_transformer_->GetReverseADT(transformed_adt_handle);
+
+  // sanity check
+  CHECK(transformed_adt_handle->name_hint.rfind(GradCell_Header, 0) == 0) 
+                                  << "Output ADT is not a transformed ADT";
+
+  if (adt_unwrapper_map_.count(type)) {
+    // transformed ADT unwrapped previously
+    return adt_unwrapper_map_.at(type);
+  }
+
+  // handle recursive ADTs
+  GlobalVar func_var = GlobalVar(GradCell_Header + GradCell_ReverseTransFunc + 
+                                adt_handle->name_hint + std::to_string(unique++));
+  adt_unwrapper_map_[type] = func_var;
+
+  TypeData adt_data = module_->LookupTypeDef(adt_handle);
+  TypeData transformed_adt_data = module_->LookupTypeDef(transformed_adt_handle);
+
+  CHECK(adt_data->type_vars.size() == transformed_adt_data->type_vars.size()) 
+                  << "ADT and transformed ADT have different # of type args";
+  
+  // solve for TypeVars of ADT to solve for input type of function
+  for (size_t i = 0; i < transformed_adt_data->type_vars.size(); i++) {
+    type_var_map[adt_data->type_vars[i]] = op->args[i];
+  }
+  auto input_type = type_args.InputType(type, type_var_map);
+
+  CHECK(adt_data->constructors.size() == transformed_adt_data->constructors.size()) <<
+    "ADT and transformed ADT have different number of constructors";
+
+  // use same logic as wrapping expression
+  // Pattern match with each Constructor of the transformed ADT,
+  // return respective Constructor with arguments of unwrapped PatternVars
+  Array<Clause> clauses;
+  for (size_t i = 0; i < transformed_adt_data->constructors.size(); i++) {
+    // Get Constructor of transformed ADT
+    Array<Pattern> patternVars;
+    Array<Expr> c_args;
+    Constructor c = transformed_adt_data->constructors[i];
+    for (Type t : c->inputs) {
+      // solve for type of pattern var
+      Type pattern_var_type = type_args.InputType(t, type_var_map);
+      Var v = Var("var", pattern_var_type);
+      // bind PatternVar to Var passed to constructor
+      patternVars.push_back(PatternVar(v));
+      // recursively unwrap
+      c_args.push_back(this->VisitExpr(v, pattern_var_type));
+    }
+    Pattern p = PatternConstructor(c, patternVars);
+    // Call appropriate Constructor
+    Expr e = Call(adt_data->constructors[i], c_args);
+
+    clauses.push_back(Clause(p, e));
+  }
+
+  Var v = Var("v", input_type);
+  Expr match = Match(v, clauses);
+
+  Function func = Function({v}, match, this->VisitType(input_type), type_args.params); 
+  module_->Add(func_var, func);
+  return func;
+}
+
+Type GradCellUnWrapper::VisitType_(const TypeCallNode* op) {
+  if (op->func.same_as(module_->GetGlobalTypeVar("GradCell"))) {
+    return op->args[0];
+  }
+  return TypeMutator::VisitType_(op);
+}
+
+Type GradCellUnWrapper::VisitType_(const GlobalTypeVarNode* op) {
+  GlobalTypeVar t = GetRef<GlobalTypeVar>(op);
+  if (op->kind == kAdtHandle) {
+    return adt_transformer_->GetReverseADT(t);
+  }
+
+  return GetRef<Type>(op);
+}
+
+
+class LazyGradientInitializer: public ExprMutator, 
+                               public TypeMutator, 
+                               public PatternMutator {
+ public:
+  explicit LazyGradientInitializer(IRModule module):
+    module_(module) {
+      // setup
+      adt_transformer_ = new ADTTransform(module_);
+      grad_cell_wrapper_ = new GradCellWrapper(module_, adt_transformer_);
+      grad_cell_unwrapper_ = new GradCellUnWrapper(module_, adt_transformer_);
+
+      // import GradCell and GradCell functions
+      module_->ImportFromStd("gradient.rly");
+
+      // ignore these functions when transforming
+      GlobalVar from_grad_cell = module_->GetGlobalVar("FromGradCell");
+      GlobalVar mul_grad_cell = module_->GetGlobalVar("MultiplyGradCell");
+      GlobalVar add_grad_cell = module_->GetGlobalVar("AddGradCell");
+      
+      func_map_[from_grad_cell] = from_grad_cell;
+      func_map_[mul_grad_cell] = mul_grad_cell;
+      func_map_[add_grad_cell] = add_grad_cell;
+    }
+  
+  /*!
+  * \brief Given a global function, create new global function
+  * that mirrors the functionality however using GradCell type.
+  * Original function will wrap inputs, call the mirrored function, unwrap the ouput,
+  * and return.
+  */
+  BaseFunc VisitGlobalVar(const GlobalVar& gv) {
+    auto base_func = module_->Lookup(gv);
+    if (auto* e = base_func.as<FunctionNode>()) {
+      auto f = GetRef<Function>(e);
+      if (func_map_.count(gv) == 0) {
+        // create GlobalVar handle for function
+        func_map_[gv] = GlobalVar(GradCell_Func + gv->name_hint);
+      }
+      GlobalVar func_var = func_map_.at(gv);
+      if (module_->ContainGlobalVar(func_var->name_hint)) {
+        // transformed function already contained in IRModule, return
+        return module_->Lookup(func_var);
+      }
+      // create transformed function and add definition to IRModule
+      auto* transformed = ExprMutator::Mutate(f).as<FunctionNode>();
+      module_->Add(func_var, GetRef<Function>(transformed));
+
+      // sanity check
+      CHECK(f->params.size() == transformed->params.size()) 
+          << "Transformed function doesn't have same number of args";
+
+      // wrap inputs of Tensor type using GradCellWrapper class
+      tvm::Array<Expr> args;
+      for (Var var : f->params) {
+        Expr wrappedInput = grad_cell_wrapper_->VisitExpr(var, var->checked_type(), 
+                                                          grad_cell_unwrapper_);
+        args.push_back(wrappedInput);
+      }
+      Expr transformedExpr = Call(func_var, args);
+
+      // unwrap outputs of GradCell type into Tensor type using OutputVisitor class
+      Expr tensorOutput = grad_cell_unwrapper_->VisitExpr(transformedExpr, transformed->ret_type);
+      return Function(f->params, tensorOutput, f->ret_type, f->type_params);
+    }
+    return module_->Lookup(gv);
   }
 
   Expr VisitExpr_(const ConstantNode* op) final {
@@ -226,26 +750,131 @@ class LazyGradientInitializer : public ExprMutator, public TypeMutator {
       // handle all other ops
       Expr result = CallPrimitiveOp(call_node);
       // wrap result with Raw constructor
-      return Call(module_->GetConstructor("GradCell", "Raw"), {result}, Attrs(),
-                  {call_node->checked_type()});
+      return grad_cell_wrapper_->VisitExpr(result, call_node->checked_type(), grad_cell_unwrapper_);
     }
-    // not an op
+    if (auto* op = (call_node->op).as<ConstructorNode>()) {
+      // create "GradCell-version" of ADT if not already created 
+      adt_transformer_->VisitType(op->belong_to);
+      // call Constructor of transformed ADT
+      Constructor c = module_->GetConstructor(GradCell_Header + op->belong_to->name_hint,
+                                              GradCell_Header + op->name_hint);
+      Array<Expr> args;
+      for (Expr e : call_node->args) {
+        args.push_back(this->VisitExpr(e));
+      }
+
+      Array<Type> type_args;
+      for (Type t : call_node->type_args) {
+        type_args.push_back(this->VisitType(t));
+      }
+      return Call(c, args, Attrs(), type_args);
+    }
+
     return ExprMutator::VisitExpr_(call_node);
   }
 
-  Type VisitType(const Type& t) final { return TypeMutator::VisitType(t); }
+  Expr VisitExpr_(const ConstructorNode* op) final {
+    Constructor c = module_->GetConstructor(GradCell_Header + op->belong_to->name_hint,
+                                              GradCell_Header + op->name_hint);
+    return c;
+  }
 
-  Type VisitType_(const TensorTypeNode* op) {
+  Expr VisitExpr_(const IfNode* op) final {
+    auto true_b = VisitExpr(op->true_branch);
+    auto false_b = VisitExpr(op->false_branch);
+
+    // guard is bool type which will become GradCell[bool], so necessary to unwrap
+    auto guard = grad_cell_unwrapper_->VisitExpr(VisitExpr(op->cond), 
+                                                VisitType(op->cond->checked_type()));
+    return If(guard, true_b, false_b);
+  }
+
+  Expr VisitExpr_(const VarNode* op) final {
+    auto var = GetRef<Var>(op);
+    if (var_map_.count(var) != 0) {
+      return var_map_.at(var);
+    }
+
+    return ExprMutator::VisitExpr_(op);
+  }
+
+  Expr VisitExpr_(const GlobalVarNode* op) final {
+    // GlobalVar is a handle to a global function
+    GlobalVar gv = GetRef<GlobalVar>(op);
+    if (func_map_.count(gv) == 0) {
+      // create handle to transformed function
+      func_map_[gv] = GlobalVar(GradCell_Func + op->name_hint);
+      // define transformed function
+      this->VisitGlobalVar(gv);
+    }
+    return func_map_.at(gv);
+  }
+
+  Type VisitType(const Type& t) final {
+    return TypeMutator::VisitType(t);
+  }
+
+  Type VisitType_(const GlobalTypeVarNode* op) final {
+    GlobalTypeVar t = GetRef<GlobalTypeVar>(op);
+    if (module_->GetGlobalTypeVar("GradCell").same_as(t)) {
+      return t;
+    }
+    if (op->kind == kAdtHandle) {
+      // handle to ADT, define GradCell version of ADT is not already created
+      return adt_transformer_->VisitType(t);
+    }
+
+    return t;
+  }
+
+  Var VisitVar(const Var& v) final {
+    // used for PatternMutator
+    if (var_map_.count(v) == 0) {
+      var_map_.insert(std::pair<Var, Var>(v,
+                                          Var(v->name_hint(),
+                                                        VisitType(v->type_annotation))));
+    }
+    return var_map_.at(v);
+  }
+
+  Type VisitType_(const TensorTypeNode* op) final {
     GlobalTypeVar gradCell = module_->GetGlobalTypeVar("GradCell");
     tvm::Array<Type> args;
     args.push_back(GetRef<TensorType>(op));
     return TypeCall(gradCell, args);
   }
 
+  Pattern VisitPattern(const Pattern& c) final {
+    return PatternMutator::VisitPattern(c);
+  }
+
+  Constructor VisitConstructor(const Constructor& c) final {
+    adt_transformer_->VisitType(c->belong_to);
+    return module_->GetConstructor(GradCell_Header + c->belong_to->name_hint,
+                                  GradCell_Header + c->name_hint);
+  }
+
+  ~LazyGradientInitializer() {
+    // destructors
+    delete grad_cell_wrapper_;
+    delete grad_cell_unwrapper_;
+    delete adt_transformer_;
+  }
+
  private:
   // Module
   IRModule module_;
 
+  // pass single instance of ADTTransform to save state of ADTs transformed
+  ADTTransform* adt_transformer_;
+  // pass single instance of ADTTransform to save state of ADTs wrapped
+  GradCellWrapper* grad_cell_wrapper_;
+  // pass single instance of ADTTransform to save state of ADTs unwrapped
+  GradCellUnWrapper* grad_cell_unwrapper_;
+  // var map used for transforming a Clause
+  std::unordered_map<Var, Var, ObjectHash, ObjectEqual> var_map_;
+  // handle of function -> handle of transformed function
+  std::unordered_map<GlobalVar, GlobalVar, ObjectHash, ObjectEqual> func_map_;
   /*!
    * \brief Convert call_node to add/multiply op to use overloaded functions for GradCell type
    */
@@ -283,26 +912,36 @@ class LazyGradientInitializer : public ExprMutator, public TypeMutator {
   Expr CallPrimitiveOp(const CallNode* call_node) {
     const auto fromFunc = module_->GetGlobalVar("FromGradCell");
     tvm::Array<Expr> args;
-    // use FromGradCell to convert args to Tensor
+
+    // unwrap arguments
     for (Expr expr : call_node->args) {
-      args.push_back(Call(fromFunc, {VisitExpr(expr)}, Attrs(), {expr->checked_type()}));
+      args.push_back(grad_cell_unwrapper_->VisitExpr(VisitExpr(expr), 
+                                                    VisitType(expr->checked_type())));
     }
     // result of operation
     return Call(call_node->op, args, call_node->attrs);
   }
 };
 
-Expr LazyGradientInit(const Expr& e, IRModule mod) {
-  return LazyGradientInitializer(mod).Transform(e);
+IRModule LazyGradientInit(const IRModule& m) {
+  LazyGradientInitializer lgi = LazyGradientInitializer(m);
+  std::vector<GlobalVar> gvs;
+  for (const auto& p : m->functions) {
+    gvs.push_back(p.first);
+  }
+  for (const auto& gv : gvs) {
+    m->Add(gv, lgi.VisitGlobalVar(gv));
+  }
+  return m;
 }
 
 namespace transform {
 Pass LazyGradientInit() {
-  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
-      [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(LazyGradientInit(f, m));
-      };
-  return CreateFunctionPass(pass_func, 2, "LazyGradientInit", {});
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+    [=](IRModule m, PassContext pc) {
+      return relay::LazyGradientInit(m);
+    };
+    return CreateModulePass(pass_func, 1, "LazyGradientInit", {});
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.LazyGradientInit").set_body_typed(LazyGradientInit);

--- a/tests/python/relay/test_pass_lazy_gradient_init.py
+++ b/tests/python/relay/test_pass_lazy_gradient_init.py
@@ -21,6 +21,7 @@ from tvm import relay
 from tvm.relay import create_executor, transform
 from tvm.relay.testing import rand, run_infer_type
 from tvm.testing import assert_allclose
+from tvm.relay.prelude import Prelude
 import pytest
 
 def test_tc():
@@ -80,7 +81,6 @@ def test_add_tuple():
 
   mod["main"] = y
   mod = transform.LazyGradientInit()(mod)
-  mod = tvm.transform.PrintIR(show_meta_data=True)(mod)
   y = mod["main"]
 
   assert mod["main"].checked_type == relay.FuncType([t], tensor_type)


### PR DESCRIPTION
Lazy Gradient Initialization currently only worked on tensor types. This adds functionality to potentially recursive ADTs, functions, and TupleTypes.

Also:
- added `Check` function to IRModule to easily type infer potentially mutually recursive functions
- exposed `map_free_vars` argument in StructuralEqual

I would really appreciate a review @MarisaKirisame @altanh @joshpoll @slyubomirsky 

Thanks!