### PR TITLE
[AutoTVM] Suppress the warning messages when compile engine selects impls

### DIFF
--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -25,5 +25,6 @@ class AutotvmGlobalScope(object):
 
         self.cuda_target_arch = None
         self.in_tuning = False
+        self.silent = False
 
 GLOBAL_SCOPE = AutotvmGlobalScope()

--- a/tests/python/integration/test_winograd_nnpack.py
+++ b/tests/python/integration/test_winograd_nnpack.py
@@ -106,7 +106,7 @@ def test_conv2d_nchw():
         skip("nnpack is not available")
 
     devices = ['llvm -device=arm_cpu']
-    autotvm.DispatchContext.current.silent = True
+    autotvm.GLOBAL_SCOPE.silent = True
     with WinogradFallback():
         # resnet 18 workloads
         verify_conv2d_nchw(1, 64, 56, 64, 3, 1, 1, devices=devices)
@@ -137,8 +137,9 @@ def test_conv2d_nchw():
         # werid workloads
         verify_conv2d_nchw(1, 3, 3, 3, 3, 1, 1, devices=devices)
         verify_conv2d_nchw(1, 13, 71, 59, 3, 1, 1, devices=devices)
+    autotvm.GLOBAL_SCOPE.silent = False
 
 
 if __name__ == "__main__":
     import pytest
-    pytest.main()
+    pytest.main([__file__])

--- a/topi/tests/python/test_topi_group_conv2d_NCHWc_int8.py
+++ b/topi/tests/python/test_topi_group_conv2d_NCHWc_int8.py
@@ -61,7 +61,7 @@ def verify_group_conv2d_NCHWc_int8(batch, in_channel, groups, in_size, num_filte
             break
 
     ic_block = 8
-    autotvm.DispatchContext.current.silent = True
+    autotvm.GLOBAL_SCOPE.silent = True
     A = te.placeholder((batch, in_channel//ic_block, in_height, in_width, ic_block), name='A', dtype='uint8')
     W = te.placeholder((num_filter//oc_block, in_channel//ic_block//groups, kernel, kernel, ic_block//4, oc_block, 4), name='W', dtype='int8')
 
@@ -103,6 +103,7 @@ def verify_group_conv2d_NCHWc_int8(batch, in_channel, groups, in_size, num_filte
     for device in ["llvm -mcpu=skylake-avx512"]:
         with autotvm.tophub.context(device):  # load tophub pre-tuned parameters
             check_device(device)
+    autotvm.GLOBAL_SCOPE.silent = False
 
 @pytest.mark.skip
 def test_conv2d_NCHWc():


### PR DESCRIPTION
Currently compile engine compares all valid implementations and creates many warning messages that potentially confuses the users. This PR suppresses the excessive warning messages and only displays the fallback warning message if the selected implementation uses a fallback config.