### PR TITLE
[FIX] Recover global state after test_util.py

### DIFF
--- a/tests/python/contrib/test_util.py
+++ b/tests/python/contrib/test_util.py
@@ -39,6 +39,7 @@ def test_tempdir():
   assert os.path.exists(temp_dir.temp_dir)
 
   old_debug_mode = util.TempDirectory._KEEP_FOR_DEBUG
+  old_tempdirs = util.TempDirectory.TEMPDIRS
   try:
     for temp_dir_number in range(0, 3):
       with util.TempDirectory.set_keep_for_debug():
@@ -80,6 +81,7 @@ def test_tempdir():
 
   finally:
     util.TempDirectory.DEBUG_MODE = old_debug_mode
+    util.TempDirectory.TEMPDIRS = old_tempdirs
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In test_util.py, a program exit is simulated to test that the error throwing behaviour is accurate. Unforunately, this also deletes necessary global state and so all subsequent tests that run and use tempdir throw the same error.

This patch is a simple fix to restore the global state at the end of the test.
