### PR TITLE
ffi (Object): make class dict visible in instances

### DIFF
--- a/python/tvm/runtime/object.py
+++ b/python/tvm/runtime/object.py
@@ -46,9 +46,10 @@ class Object(ObjectBase):
         return _ffi_node_api.AsRepr(self)
 
     def __dir__(self):
+        class_names = dir(self.__class__)
         fnames = _ffi_node_api.NodeListAttrNames(self)
         size = fnames(-1)
-        return [fnames(i) for i in range(size)]
+        return sorted([fnames(i) for i in range(size)] + class_names)
 
     def __getattr__(self, name):
         try:

--- a/tests/python/unittest/test_node_reflection.py
+++ b/tests/python/unittest/test_node_reflection.py
@@ -130,6 +130,12 @@ def test_pass_config():
             "tir.UnrollLoop": 1
         })
 
+def test_dict():
+    x = tvm.tir.const(1) # a class that has Python-defined methods
+    # instances should see the full class dict
+    assert set(dir(x.__class__)) <= set(dir(x))
+
+
 if __name__ == "__main__":
     test_string()
     test_env_func()
@@ -138,3 +144,4 @@ if __name__ == "__main__":
     test_const_saveload_json()
     test_make_sum()
     test_pass_config()
+    test_dict()


### PR DESCRIPTION
In Python, generic objects (i.e. non-types/classes) inherit the `__dir__` elements from their class.
This enable tab completion in interactive environments like Jupyter notebooks.

Reference for this behaviour is Python's `__dir__` for objects:
https://github.com/python/cpython/blob/8f192d12af82c4dc40730bf59814f6a68f68f950/Objects/typeobject.c#L4854-L4899

I'll readily admit that I don't know whether the location for the test I offer is a good one. It seemed to be a place where low-level stuff is tested and where this can blend in.
