### PR TITLE
[TFLite] QNN support for TFLite 2.1.0 quantized models

### DIFF
--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -61,9 +61,19 @@ bool QnnConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   CHECK(IsScalarType(types[3], DataType::Int(32)));    // kernel_zero_point
   CHECK(IsScalarType(types[4], DataType::Float(32)));  // input_scale
   // Kernel scale can be a vector of length output_channels or a scalar.
-  size_t axis = param->kernel_layout.find('O');
-  CHECK(axis != std::string::npos) << "Kernel layout attribute is not defined";
-  AssignType(types[5], DataType::Float(32), weight->shape[axis], reporter);  // kernel scale
+  if (param->groups == 1) {
+    size_t axis = param->kernel_layout.find('O');
+    CHECK(axis != std::string::npos) << "Kernel layout attribute is not defined";
+    AssignType(types[5], DataType::Float(32), weight->shape[axis], reporter);  // kernel scale
+  } else {
+    // Here, total number of output channels depend on depth multiplier.
+    size_t o_axis = param->kernel_layout.find('O');
+    size_t i_axis = param->kernel_layout.find('I');
+    CHECK(o_axis != std::string::npos || i_axis != std::string::npos)
+        << "Kernel layout attribute is not defined";
+    AssignType(types[5], DataType::Float(32), weight->shape[i_axis] * weight->shape[o_axis],
+               reporter);  // kernel scale
+  }
 
   // Collect the input tensor and output tensor devoid of scale and zero points to reuse Relay
   // Conv2D infer type function.

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -39,7 +39,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import nn_impl
 from tensorflow.python.ops import variables
-import tensorflow_hub as hub
 try:
     from tensorflow import lite as interpreter_wrapper
 except ImportError:

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -87,11 +87,8 @@ def pre_processed_image(height, width):
             image = tf.image.convert_image_dtype(image, dtype=tf.float32)
         image = tf.image.central_crop(image, central_fraction=0.875)
     # Resize the image to the specified height and width.
-    image = tf.expand_dims(image, 0)
     image = tf.image.resize(image, [height, width],
                             align_corners=False)
-    image = tf.image.resize(image, [height, width])
-    image = tf.squeeze(image, [0])
     image = tf.expand_dims(image, axis=0)
     return image
 
@@ -2493,8 +2490,8 @@ def test_forward_qnn_mobilenet_v3_net():
     tvm.testing.assert_allclose(tvm_sorted_labels, tflite_sorted_labels)
 
 
-
 def _quantize_tf_hub_keras_model(url, height, width):
+    """Utility function to quantize a Keras model using TFLite converter."""
     keras_model = tf.keras.Sequential([hub.KerasLayer(url, output_shape=[1001])])
     data = pre_processed_image(height, width)
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -137,7 +137,6 @@ def _quantize_keras_model(keras_model, representative_data_gen):
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
     converter.inference_input_type = tf.uint8
     converter.inference_output_type = tf.uint8
-    converter = interpreter_wrapper.TFLiteConverter.from_keras_model(keras_model)
     return converter.convert()
 
 
@@ -903,7 +902,7 @@ def test_forward_convolution():
         _test_convolution([4, 17, 17, 124], [1, 1, 124, 1], [1, 1], [1, 1], 'SAME', 'NHWC', True, quantized=quantized)
         _test_convolution([4, 17, 17, 12], [3, 3, 12, 1], [1, 1], [2, 2], 'VALID', 'NHWC', True, quantized=quantized)
         _test_convolution([4, 17, 17, 12], [3, 3, 12, 2], [1, 1], [2, 2], 'VALID', 'NHWC', True, quantized=quantized)
-        # dephtwise convolution with single input channel
+        # depthwise convolution with single input channel
         _test_convolution([1, 76, 64, 1], [9, 5, 1, 96], [1, 1], [1, 1], 'SAME', 'NHWC', True, quantized=quantized)
 
     # TFLite2 quantized convolution testing
@@ -1814,7 +1813,7 @@ def _test_quantize_dequantize(data):
 
     # Keras model to force TFLite converter to insert 2 TFLite quantize ops.
     # First TFLite quantize op converts float32 tensor to int8 tensor - Qnn quantize.
-    # Second TLite quantize op converts int8 tensor to int8 tensor - Qnn requantize.
+    # Second TFLite quantize op converts int8 tensor to int8 tensor - Qnn requantize.
     data_in = tf.keras.layers.Input(shape=data.shape[1:])
     relu = tf.keras.layers.ReLU()(data_in)
     add = tf.keras.layers.Add()([data_in, relu])

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -1820,6 +1820,7 @@ def _test_quantize_dequantize(data):
     add = tf.keras.layers.Add()([data_in, relu])
     concat = tf.keras.layers.Concatenate(axis=0)([relu, add])
     keras_model = tf.keras.models.Model(inputs=data_in, outputs=concat)
+    input_name = data_in.name.split(":")[0]
 
     # To create quantized values with dynamic range of activations, needs representative dataset
     def representative_data_gen():
@@ -1829,7 +1830,7 @@ def _test_quantize_dequantize(data):
     tflite_model_quant = _quantize_keras_model(keras_model, representative_data_gen)
 
     tflite_output = run_tflite_graph(tflite_model_quant, data)
-    tvm_output = run_tvm_graph(tflite_model_quant, data, 'input_1')
+    tvm_output = run_tvm_graph(tflite_model_quant, data, input_name)
     tvm.testing.assert_allclose(np.squeeze(tvm_output[0]), np.squeeze(tflite_output[0]),
                                 rtol=1e-5, atol=1e-2)
 
@@ -2074,6 +2075,7 @@ def _test_relu(data, quantized=False):
         data_in = tf.keras.layers.Input(shape=data.shape[1:])
         relu =  tf.keras.layers.ReLU()(data_in)
         keras_model = tf.keras.models.Model(inputs=data_in, outputs=relu)
+        input_name = data_in.name.split(":")[0]
 
         # To create quantized values with dynamic range of activations, needs representative dataset
         def representative_data_gen():
@@ -2083,7 +2085,7 @@ def _test_relu(data, quantized=False):
         tflite_model_quant = _quantize_keras_model(keras_model, representative_data_gen)
 
         tflite_output = run_tflite_graph(tflite_model_quant, data)
-        tvm_output = run_tvm_graph(tflite_model_quant, data, 'input_1')
+        tvm_output = run_tvm_graph(tflite_model_quant, data, input_name)
         tvm.testing.assert_allclose(np.squeeze(tvm_output[0]), np.squeeze(tflite_output[0]),
                                     rtol=1e-5, atol=1e-5)
     else:


### PR DESCRIPTION
TFLite 2.1.0 has changed the quantization specs from older TFLite versions. The specs are present at - https://www.tensorflow.org/lite/performance/quantization_spec

### Key changes
* No TFLite2.0 hosted models. Need a way to create quantized models. Dependency on tensorflow_hub package (@tqchen 
 please advise here).
* Per-axis (aka channel) quantization
* Int8 datatypes
* Extra restrictions per op regarding scale and zero points
* Quantize TFLite op also works as Requantize

