### PR TITLE
[BACKPORT-0.6] Fix NDArray SaveDLTensor declaration and implementation signature different

### DIFF
--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -228,7 +228,7 @@ struct array_type_info<NDArray> {
  * \param strm The outpu stream
  * \param tensor The tensor to be saved.
  */
-inline bool SaveDLTensor(dmlc::Stream* strm, const DLTensor* tensor);
+inline bool SaveDLTensor(dmlc::Stream* strm, DLTensor* tensor);
 
 /*!
  * \brief Reference counted Container object used to back NDArray.


### PR DESCRIPTION
Port https://github.com/apache/incubator-tvm/pull/4586/

@yzhliu
