### PR TITLE
Fail early before running invalid dynamic graphs

### DIFF
--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -258,7 +258,7 @@ class VMExecutor(Executor):
             if type_has_any(ret_type) and "llvm" not in str(self.target) and "arm" not in str(
                     self.target):
                 raise ValueError(
-                    "Virtual Machine only supports static graphs on CPU, got output type",
+                    "Virtual Machine only supports dynamic graphs on CPU, got output type",
                     ret_type, "on target", self.target)
             return self.vm.run(*args)
 

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -27,6 +27,7 @@ import tvm.runtime.ndarray as _nd
 import tvm.runtime.vm as vm_rt
 from tvm import autotvm
 from tvm.relay import expr as _expr
+from tvm.relay.ty import type_has_any
 from tvm.relay.backend.interpreter import Executor
 from . import _vm
 
@@ -253,6 +254,12 @@ class VMExecutor(Executor):
 
         def _vm_wrapper(*args, **kwargs):
             args = self._convert_args(main, args, kwargs)
+            ret_type = self.mod["main"].checked_type.ret_type
+            if type_has_any(ret_type) and "llvm" not in str(self.target) and "arm" not in str(
+                    self.target):
+                raise ValueError(
+                    "Virtual Machine only supports static graphs on CPU, got output type",
+                    ret_type, "on target", self.target)
             return self.vm.run(*args)
 
         return _vm_wrapper

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -354,6 +354,9 @@ class GraphExecutor(_interpreter.Executor):
         if expr:
             self.mod["main"] = expr
         ret_type = self.mod["main"].checked_type.ret_type
+        if _ty.type_has_any(ret_type):
+            raise ValueError("Graph Runtime only supports static graphs, got output type",
+                             ret_type)
         num_outputs = len(ret_type.fields) if isinstance(ret_type, _ty.TupleType) else 1
         graph_json, mod, params = build(self.mod, target=self.target)
         gmodule = _graph_rt.create(graph_json, mod, self.ctx)


### PR DESCRIPTION
@zhiics 

In testing dynamic graphs, I've run into some pretty gnarly error messages deep in the memory planner for graph runtime or deep in nested packed function calls in the VM. In a "fail early" philosphy, This PR adds an earlier check for dynamic shapes and throws with a hopefully more useful error message. Once we have heterogenous execution working on the VM, we can relax the check on the VM side.

Thanks!
