### PR TITLE
[OpenCL] Fix OpenCL get_valid_counts errors due to intrinsic atomic_add

### DIFF
--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -62,6 +62,8 @@ class CodeGenOpenCL final : public CodeGenC {
   // whether enable fp16 and fp64 extension
   bool enable_fp16_{false};
   bool enable_fp64_{false};
+  // Whether to enable atomics extension.
+  bool enable_atomics_{false};
 };
 
 }  // namespace codegen

--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -54,6 +54,7 @@ class CodeGenOpenCL final : public CodeGenC {
   std::string CastFromTo(std::string value, DataType from, DataType target);  // NOLINT(*)
 
   // overload visitor
+  void VisitExpr_(const CallNode* op, std::ostream& os) final;       // NOLINT(*)
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final;  // NOLINT(*)
   void VisitExpr_(const FloatImmNode* op, std::ostream& os) final;   // NOLINT(*)
 

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -270,8 +270,8 @@ def test_get_valid_counts():
             intrp = relay.create_executor("debug", ctx=ctx, target=target)
             out = intrp.evaluate(func)(np_data)
             tvm.testing.assert_allclose(out[0].asnumpy(), np_out1, rtol=1e-3, atol=1e-04)
-            # get_valid_count for cuda doesn't do data rearrangement
-            if target == 'cuda':
+            # get_valid_count for cuda, opencl doesn't do data rearrangement
+            if target in ['cuda', 'opencl']:
                 return
             tvm.testing.assert_allclose(out[1].asnumpy(), np_out2, rtol=1e-3, atol=1e-04)
             tvm.testing.assert_allclose(out[2].asnumpy(), np_out3, rtol=1e-3, atol=1e-04)

--- a/topi/python/topi/cuda/nms.py
+++ b/topi/python/topi/cuda/nms.py
@@ -34,9 +34,16 @@ def cuda_atomic_add_rule(op):
         return tvm.tir.call_pure_extern("int32", "atomicAdd", op.args[0], op.args[1])
     raise RuntimeError("only support int32, float32 and float64")
 
+def opencl_atomic_add_rule(op):
+    if op.dtype == "int32":
+        return tvm.tir.call_pure_extern("int32", "atomic_add", op.args[0], op.args[1])
+    raise RuntimeError("only support int32")
 
 tvm.target.intrin.register_intrin_rule(
     "cuda", "atomic_add", cuda_atomic_add_rule, override=True)
+
+tvm.target.intrin.register_intrin_rule(
+    "opencl", "atomic_add", opencl_atomic_add_rule, override=True)
 
 tvm.ir.register_op_attr("tir.atomic_add", "TCallEffectKind", tvm.tir.CallEffectKind.Opaque)
 


### PR DESCRIPTION
Some fixes a few months ago to the `get_valid_counts` CUDA implementation broke OpenCL  because of the atomic add intrinsic which was added.

This PR fixes `get_valid_counts` for OpenCL with the following changes:

1. Register intrinsic atomic add for OpenCL. 
2. Override `intrinsic::tvm_address_of` to include storage scope (e.g.` __global`).
3. Enable `cl_khr_global_int32_base_atomics`. This isn't required for [OpenCL 1.1+ because atomic_add became a core feature](https://www.khronos.org/registry/OpenCL/specs/2.2/html/OpenCL_Ext.html#cl_khr_int32_atomics). I'm happy to remove this if we don't care about OpenCL 1.0. Alternatively we can override `op->call_type == CallNode::PureExtern` and set a flag to enable this only when `atomic_add` is actually used.


Original error messages before this fix:

1. During compilation:

  ```
  Unresolved intrinsic atomic_add with return type int32
  ```

2. During runtime:

  ```
  <source>:6922:43: error: casting '__global void *' to type 'int *' changes address space of pointer
        atomic_add_return[(0)] = atomic_add(((int *)get_valid_counts_v0 + 0), 1);
  ```
