### PR TITLE
[BACKPORT-0.6] Fix Python syntax error in start_rpc_server_to_tracker.py

### DIFF
--- a/apps/vta_rpc/start_rpc_server_to_tracker.py
+++ b/apps/vta_rpc/start_rpc_server_to_tracker.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-PROJROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
+PROJROOT="$( cd '$( dirname "${BASH_SOURCE[0]}" )/../../' && pwd )"
 
 # Derive target specified by vta_config.json
 VTA_CONFIG=${PROJROOT}/vta/config/vta_config.py


### PR DESCRIPTION
Co-authored-by: Christian Clauss <cclauss@me.com>
#4682

