### PR TITLE
[BACKPORT-0.6][Bugfix] fskip of EliminateCommonSubexpr cannot always return false

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -310,6 +310,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     pass_seqs.push_back(transform::SimplifyInference());
     PackedFunc fskip = PackedFunc([](TVMArgs args, TVMRetValue* rv) {
       Expr expr = args[0];
+      *rv = false;
       if (expr.as<CallNode>()) {
         auto call_node = expr.as<CallNode>();
         auto op_node = call_node->op.as<OpNode>();
@@ -320,7 +321,6 @@ class RelayBuildModule : public runtime::ModuleNode {
           }
         }
       }
-      *rv = false;
     });
     pass_seqs.push_back(transform::EliminateCommonSubexpr(fskip));
     pass_seqs.push_back(transform::CombineParallelConv2D(3));


### PR DESCRIPTION
#4620
