### PR TITLE
[RELAY] Allow non-CSourceModules to compile

### DIFF
--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -58,9 +58,10 @@ runtime::Module CreateMetadataModule(
   // Wrap all submodules in the initialization wrapper.
   std::unordered_map<std::string, std::vector<std::string>> sym_metadata;
   for (runtime::Module it : modules) {
-    CHECK_EQ(it->type_key(), "c") << "Only csource submodule is handled for now";
+    auto pf = it.GetFunction("get_const_vars");
+    if (pf == nullptr) continue;
+    Array<String> variables = pf();
     String symbol = it.GetFunction("get_symbol")();
-    Array<String> variables = it.GetFunction("get_const_vars")();
     std::vector<std::string> arrays;
     for (size_t i = 0; i < variables.size(); i++) {
       arrays.push_back(variables[i].operator std::string());


### PR DESCRIPTION
A recent patch added a check so that external modules must be a CSourceModule. Generally that's not the case, so this patch instead queries whether or not the external module implements "get_const_vars".
