### PR TITLE
[Relay]Allow every runtime module to handle constants

### DIFF
--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -58,15 +58,18 @@ runtime::Module CreateMetadataModule(
   // Wrap all submodules in the initialization wrapper.
   std::unordered_map<std::string, std::vector<std::string>> sym_metadata;
   for (runtime::Module it : modules) {
-    CHECK_EQ(it->type_key(), "c") << "Only csource submodule is handled for now";
-    String symbol = it.GetFunction("get_symbol")();
-    Array<String> variables = it.GetFunction("get_const_vars")();
-    std::vector<std::string> arrays;
-    for (size_t i = 0; i < variables.size(); i++) {
-      arrays.push_back(variables[i].operator std::string());
+    auto pf_sym = it.GetFunction("get_symbol");
+    auto pf_var = it.GetFunction("get_const_vars");
+    if (pf_sym != nullptr && pf_var != nullptr) {
+      String symbol = pf_sym();
+      Array<String> variables = pf_var();
+      std::vector<std::string> arrays;
+      for (size_t i = 0; i < variables.size(); i++) {
+        arrays.push_back(variables[i].operator std::string());
+      }
+      CHECK_EQ(sym_metadata.count(symbol), 0U) << "Found duplicated symbol: " << symbol;
+      sym_metadata[symbol] = arrays;
     }
-    CHECK_EQ(sym_metadata.count(symbol), 0U) << "Found duplicated symbol: " << symbol;
-    sym_metadata[symbol] = arrays;
   }
 
   // Wrap the modules.
@@ -119,7 +122,6 @@ class CSourceModuleNode : public runtime::ModuleNode {
       return PackedFunc(
           [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->const_vars_; });
     } else {
-      LOG(FATAL) << "Unknown packed function: " << name;
       return PackedFunc(nullptr);
     }
   }

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -122,6 +122,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
       return PackedFunc(
           [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->const_vars_; });
     } else {
+      LOG(FATAL) << "Unknown packed function: " << name;
       return PackedFunc(nullptr);
     }
   }


### PR DESCRIPTION
Per discussion in #5884, this PR makes the following improvements:
* Allow any runtime with `get_symbol` and `get_const_vars` to use the unified mechanism of constant processing.
* We will have a JSON runtime PR later this week to demonstrate how a customized runtime works with this mechanism.

cc @zhiics @mbaret 