### PR TITLE
Add Binary Intrinsic ops to TIR Ops in C++

### DIFF
--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -583,9 +583,9 @@ TVM_DECLARE_INTRIN_UNARY(acosh);
 TVM_DECLARE_INTRIN_UNARY(asinh);
 TVM_DECLARE_INTRIN_UNARY(atanh);
 
-#define TVM_DECLARE_INTRIN_BINARY(OpName)                                       \
-  inline PrimExpr OpName(PrimExpr x, PrimExpr y) {                              \
-    static const Op& op = Op::Get("tir." #OpName);                      \
+#define TVM_DECLARE_INTRIN_BINARY(OpName)                                  \
+  inline PrimExpr OpName(PrimExpr x, PrimExpr y) {                         \
+    static const Op& op = Op::Get("tir." #OpName);                         \
     return tir::Call(x.dtype(), op, {x, y}, tir::CallNode::PureIntrinsic); \
   }
 

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -583,6 +583,18 @@ TVM_DECLARE_INTRIN_UNARY(acosh);
 TVM_DECLARE_INTRIN_UNARY(asinh);
 TVM_DECLARE_INTRIN_UNARY(atanh);
 
+#define TVM_DECLARE_INTRIN_BINARY(OpName)                                       \
+  inline PrimExpr OpName(PrimExpr x, PrimExpr y) {                              \
+    static const Op& op = Op::Get("tir." #OpName);                      \
+    return tir::Call(x.dtype(), op, {x, y}, tir::CallNode::PureIntrinsic); \
+  }
+
+TVM_DECLARE_INTRIN_BINARY(atan2);
+TVM_DECLARE_INTRIN_BINARY(nextafter);
+TVM_DECLARE_INTRIN_BINARY(copysign);
+TVM_DECLARE_INTRIN_BINARY(hypot);
+TVM_DECLARE_INTRIN_BINARY(ldexp);
+
 namespace tir {
 /*!
  * \brief Make a const value with certain data type.


### PR DESCRIPTION
@tqchen 

These ops are already registered and tested through python, this simply adds them to the C++ API. I don't see tests for the existing instrinsic unary ops outside of python, do we test this C++ API?

https://github.com/apache/incubator-tvm/blob/90b08f5e4ef5a40e1efb9a9ba2882df87b0a9391/tests/python/unittest/test_tir_intrin.py#L92-L134

