### PR TITLE
[BUGFIX] Add cuda 11 to contrib.nvcc.find_libdevice_path()

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -173,7 +173,7 @@ def find_libdevice_path(arch):
     selected_ver = 0
     selected_path = None
     cuda_ver = get_cuda_version(cuda_path)
-    if cuda_ver in (9.0, 9.1, 10.0):
+    if cuda_ver in (9.0, 9.1, 10.0, 11.0):
         path = os.path.join(lib_path, "libdevice.10.bc")
     else:
         for fn in os.listdir(lib_path):


### PR DESCRIPTION
The following code will fail when using CUDA 11 and causes test cases of `nvptx` target to fail. This PR fixed this issue.
```
tvm.contrib.nvcc.find_libdevice_path('7.0')
ValueError: Traceback (most recent call last):
  [bt] (1) /home/ubuntu/src/tvm/build/libtvm.so(TVMFuncCall+0x65) [0x7fc26a6064b5]
  [bt] (0) /home/ubuntu/src/tvm/build/libtvm.so(+0xe10dbb) [0x7fc26a602dbb]
  File "/home/ubuntu/src/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 78, in cfun
    rv = local_pyfunc(*pyargs)
  File "/home/ubuntu/src/tvm/python/tvm/contrib/nvcc.py", line 182, in find_libdevice_path
    ver = int(fn.split(".")[-3].split("_")[-1])
ValueError: invalid literal for int() with base 10: 'libdevice'
```