### PR TITLE
Don't multiply by constant 1 uselessly in dense

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -995,11 +995,11 @@ def _dense():
         beta = inputs[3]
         alpha = inputs[4]
 
-        if not isinstance(alpha, _expr.Expr):
+        if not isinstance(alpha, _expr.Expr) and alpha != 1:
             alpha = _create_typed_const(alpha, data_type)
             data *= alpha
 
-        if not isinstance(beta, _expr.Expr):
+        if not isinstance(beta, _expr.Expr) and beta != 1:
             beta = _create_typed_const(beta, data_type)
             weight *= beta
 


### PR DESCRIPTION
PyTorch implements vanilla Linear (without broadcasting) though a function addmm that accepts scalar multipliers. These multipliers are constant 1 typically, so this patch skips the multiplication for this common case.

@siju-samuel @masahi 