### PR TITLE
[clflush] Enable x86 cpu cache flush

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -181,7 +181,11 @@ class RPCRunner(Runner):
         call your template and get the reference output.
         This can work for TOPI templates, but may not work for your custom template.
     enable_cpu_cache_flush: bool
-        Whether to enable cpu cache flush, which only has effect on CPU task.
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     """
     def __init__(self,
                  key, host, port, priority=1,
@@ -314,7 +318,11 @@ class LocalRunner(RPCRunner):
         call your template and get the reference output.
         This can work for TOPI templates, but may not work for your custom template.
     enable_cpu_cache_flush: bool
-        Whether to enable cpu cache flush, which only has effect on CPU task.
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     Note
     ----
     This is a "fake" local mode. We start a silent rpc tracker and rpc server
@@ -462,7 +470,11 @@ def run_through_rpc(measure_input, build_result,
     ref_output: List of np.ndarray
         The reference output used for checking correctness
     enable_cpu_cache_flush: bool
-        Whether to enable cpu cache flush, which only has effect on CPU task.
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     """
     if isinstance(build_result, MeasureResult):
         return build_result

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -473,8 +473,10 @@ def run_through_rpc(measure_input, build_result,
         remote.upload(build_result.filename)
         func = remote.load_module(os.path.split(build_result.filename)[1])
         ctx = remote.context(str(measure_input.target), 0)
+        cache_flush_packed = remote.get_function("runtime.cpu_cache_flush")(1)
         time_f = func.time_evaluator(
-            func.entry_name, ctx, number=number, repeat=repeat, min_repeat_ms=min_repeat_ms)
+            func.entry_name, ctx, number=number, repeat=repeat, min_repeat_ms=min_repeat_ms,
+            f_prepare=cache_flush_packed)
 
         # set input
         if ref_input:

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -163,7 +163,7 @@ class Module(object):
         """
         _ffi_api.ModuleSaveToFile(self, file_name, fmt)
 
-    def time_evaluator(self, func_name, ctx, number=10, repeat=1, min_repeat_ms=0, f_prepare=None):
+    def time_evaluator(self, func_name, ctx, number=10, repeat=1, min_repeat_ms=0, f_prepare=''):
         """Get an evaluator that measures time cost of running function.
 
         Parameters
@@ -192,6 +192,8 @@ class Module(object):
             minimum duration requirement of one `repeat`.
             i.e., When the run time of one `repeat` falls below this time, the `number` parameter
             will be automatically increased.
+        f_prepare: str, optional
+            The prepared function name we want to execute before executing the time evaluator.
 
         Note
         ----

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -163,7 +163,7 @@ class Module(object):
         """
         _ffi_api.ModuleSaveToFile(self, file_name, fmt)
 
-    def time_evaluator(self, func_name, ctx, number=10, repeat=1, min_repeat_ms=0, f_prepare=''):
+    def time_evaluator(self, func_name, ctx, number=10, repeat=1, min_repeat_ms=0, f_preproc=''):
         """Get an evaluator that measures time cost of running function.
 
         Parameters
@@ -192,8 +192,8 @@ class Module(object):
             minimum duration requirement of one `repeat`.
             i.e., When the run time of one `repeat` falls below this time, the `number` parameter
             will be automatically increased.
-        f_prepare: str, optional
-            The prepared function name we want to execute before executing the time evaluator.
+        f_preproc: str, optional
+            The preprocess function name we want to execute before executing the time evaluator.
 
         Note
         ----
@@ -209,7 +209,7 @@ class Module(object):
         try:
             feval = _ffi_api.RPCTimeEvaluator(
                 self, func_name, ctx.device_type, ctx.device_id,
-                number, repeat, min_repeat_ms, f_prepare)
+                number, repeat, min_repeat_ms, f_preproc)
 
             def evaluator(*args):
                 """Internal wrapped evaluator."""

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -163,7 +163,7 @@ class Module(object):
         """
         _ffi_api.ModuleSaveToFile(self, file_name, fmt)
 
-    def time_evaluator(self, func_name, ctx, number=10, repeat=1, min_repeat_ms=0):
+    def time_evaluator(self, func_name, ctx, number=10, repeat=1, min_repeat_ms=0, f_prepare=None):
         """Get an evaluator that measures time cost of running function.
 
         Parameters
@@ -207,7 +207,7 @@ class Module(object):
         try:
             feval = _ffi_api.RPCTimeEvaluator(
                 self, func_name, ctx.device_type, ctx.device_id,
-                number, repeat, min_repeat_ms)
+                number, repeat, min_repeat_ms, f_prepare)
 
             def evaluator(*args):
                 """Internal wrapped evaluator."""

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <memory>
 #if defined(_M_X64) || defined(__x86_64__)
-#include <x86intrin.h>
+#include <immintrin.h>
 #endif
 
 #include "rpc_endpoint.h"

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -324,10 +324,11 @@ struct RemoteSpace {
  *        minimum duration requirement of one `repeat`.
  *        i.e., When the run time of one `repeat` falls below this time,
  *        the `number` parameter will be automatically increased.
+ * \param f_prepare The function to be executed before we excetute time evaluator.
  * \return f_timer A timer function.
  */
 PackedFunc WrapTimeEvaluator(PackedFunc f, TVMContext ctx, int number, int repeat,
-                             int min_repeat_ms, PackedFunc f_prepare);
+                             int min_repeat_ms, PackedFunc f_prepare = nullptr);
 
 /*!
  * \brief Create a Global RPC module that refers to the session.

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -327,7 +327,7 @@ struct RemoteSpace {
  * \return f_timer A timer function.
  */
 PackedFunc WrapTimeEvaluator(PackedFunc f, TVMContext ctx, int number, int repeat,
-                             int min_repeat_ms);
+                             int min_repeat_ms, PackedFunc f_prepare);
 
 /*!
  * \brief Create a Global RPC module that refers to the session.

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -324,11 +324,11 @@ struct RemoteSpace {
  *        minimum duration requirement of one `repeat`.
  *        i.e., When the run time of one `repeat` falls below this time,
  *        the `number` parameter will be automatically increased.
- * \param f_prepare The function to be executed before we excetute time evaluator.
+ * \param f_preproc The function to be executed before we excetute time evaluator.
  * \return f_timer A timer function.
  */
 PackedFunc WrapTimeEvaluator(PackedFunc f, TVMContext ctx, int number, int repeat,
-                             int min_repeat_ms, PackedFunc f_prepare = nullptr);
+                             int min_repeat_ms, PackedFunc f_preproc = nullptr);
 
 /*!
  * \brief Create a Global RPC module that refers to the session.

--- a/tests/python/unittest/test_autotvm_measure.py
+++ b/tests/python/unittest/test_autotvm_measure.py
@@ -56,7 +56,6 @@ def test_check_correctness():
 
     def _callback_correct(tuner, measure_inputs, measure_results):
         for _, res in zip(measure_inputs, measure_results):
-            print(res)
             assert res.error_no == 0
 
     tuner = autotvm.tuner.RandomTuner(task)
@@ -80,5 +79,5 @@ def test_check_correctness():
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
 
-    # test_task_tuner_without_measurement()
+    test_task_tuner_without_measurement()
     test_check_correctness()

--- a/tests/python/unittest/test_autotvm_measure.py
+++ b/tests/python/unittest/test_autotvm_measure.py
@@ -56,6 +56,7 @@ def test_check_correctness():
 
     def _callback_correct(tuner, measure_inputs, measure_results):
         for _, res in zip(measure_inputs, measure_results):
+            print(res)
             assert res.error_no == 0
 
     tuner = autotvm.tuner.RandomTuner(task)
@@ -79,5 +80,5 @@ def test_check_correctness():
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
 
-    test_task_tuner_without_measurement()
+    # test_task_tuner_without_measurement()
     test_check_correctness()

--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -115,16 +115,10 @@ os.environ["TVM_NUM_THREADS"] = str(num_threads)
 # mode can be setup similarly to the approach in
 # :ref:`tune_relay_arm` tutorial.
 #
-# In the measure option, we turn on enable_cpu_cache_flush to
-# get more precise measurement. When we turn it on, we don't
-# need to set min_repeat_ms to dynamically adjust to run op
-# many times so that we get precise measurement as when we
-# have cache flush, we could get precise measurement even we
-# run serveral times. So, we could just set number be 1 and
-# repeat be 10 to run only 10 times. The reason we set number be 1
-# is we will turn on cache flush before every repeat run in
-# internal implementation. So if number is greater than 1, the
-# cache flush effect will be probably invalid.
+# To perform a precise measurement, we should repeat the measurement several
+# times and use the average of results. In addition, we need to flush the cache
+# for the weight tensors between repeated measurements. This can make the measured
+# latency of one operator closer to its actual latency during end-to-end inference.
 
 tuning_option = {
     'log_filename': log_file,

--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -35,6 +35,7 @@ from tvm.relay import testing
 from tvm.autotvm.tuner import XGBTuner, GATuner, RandomTuner, GridSearchTuner
 from tvm.autotvm.graph_tuner import DPTuner, PBQPTuner
 import tvm.contrib.graph_runtime as runtime
+# from tvm.contrib.debugger import debug_runtime as runtime
 
 #################################################################
 # Define network
@@ -84,12 +85,12 @@ def get_network(name, batch_size):
 # Platinum 8000 series, the target should be "llvm -mcpu=skylake-avx512".
 # For AWS EC2 c4 instance with Intel Xeon E5-2666 v3, it should be
 # "llvm -mcpu=core-avx2".
-target = "llvm"
+target = "llvm -mcpu=skylake-avx512"
 
 batch_size = 1
 dtype = "float32"
 model_name = "resnet-18"
-log_file = "%s.log" % model_name
+log_file = "%s.dense.log" % model_name
 graph_opt_sch_file = "%s_graph_opt.log" % model_name
 
 # Set the input name of the graph
@@ -186,15 +187,17 @@ def tune_and_evaluate(tuning_opt):
     # set TVM_AUTO_CACHE_FLUSH environment value be 1 to enable flush
     # the cache during tuning kernel so that we could get more accurate
     # performance when we run e2e testing.
-    os.environ["TVM_AUTO_CACHE_FLUSH"] = "1"
+    # os.environ["TVM_AUTO_CACHE_FLUSH"] = "1"
     tune_kernels(tasks, **tuning_opt)
     tune_graph(mod["main"], data_shape, log_file, graph_opt_sch_file)
 
     # compile kernels with graph-level best records
+    # graph_opt_sch_file = 'resnet-18_graph_opt_clflush.log'
     with autotvm.apply_graph_best(graph_opt_sch_file):
         print("Compile...")
+        # os.environ["TVM_BIND_MASTER_CORE_0"] = "1"
         # when we run e2e testing, we could enable the cache back.
-        os.environ["TVM_AUTO_CACHE_FLUSH"] = "0"
+        # os.environ["TVM_AUTO_CACHE_FLUSH"] = "0"
         with tvm.transform.PassContext(opt_level=3):
             graph, lib, params = relay.build_module.build(
                 mod, target=target, params=params)
@@ -212,11 +215,12 @@ def tune_and_evaluate(tuning_opt):
         prof_res = np.array(ftimer().results) * 1000  # convert to millisecond
         print("Mean inference time (std dev): %.2f ms (%.2f ms)" %
               (np.mean(prof_res), np.std(prof_res)))
+        # module.run()
 
 # We do not run the tuning in our webpage server since it takes too long.
 # Uncomment the following line to run it by yourself.
 
-# tune_and_evaluate(tuning_option)
+tune_and_evaluate(tuning_option)
 
 ######################################################################
 # Sample Output

--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -114,6 +114,17 @@ os.environ["TVM_NUM_THREADS"] = str(num_threads)
 # We will use local mode for tuning configuration. RPC tracker
 # mode can be setup similarly to the approach in
 # :ref:`tune_relay_arm` tutorial.
+#
+# In the measure option, we turn on enable_cpu_cache_flush to
+# get more precise measurement. When we turn it on, we don't
+# need to set min_repeat_ms to dynamically adjust to run op
+# many times so that we get precise measurement as when we
+# have cache flush, we could get precise measurement even we
+# run serveral times. So, we could just set number be 1 and
+# repeat be 10 to run only 10 times. The reason we set number be 1
+# is we will turn on cache flush before every repeat run in
+# internal implementation. So if number is greater than 1, the
+# cache flush effect will be probably invalid.
 
 tuning_option = {
     'log_filename': log_file,


### PR DESCRIPTION
When we are in the tuning of TVM, we will make TVM occupy the cache fully and doesn't flush it during iteration. This has problems then in e2e testing, since arrays that we assume exist in cache (ie. weights) are evicted during e2e runs,
which leads to lower performance. This has been demonstrated in Ansor. 

@merrymercy @tqchen @jcf94 @minminsun 
