### PR TITLE
Two small fixes to AMDCPU codegen for LLVM 10+ and ROCm 3.5+

### DIFF
--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -45,7 +45,8 @@ enum DeviceAttrKind : int {
   kMultiProcessorCount = 7,
   kMaxThreadDimensions = 8,
   kMaxRegistersPerBlock = 9,
-  kGcnArch = 10
+  kGcnArch = 10,
+  kApiVersion = 11
 };
 
 /*! \brief Number of bytes each allocation must align to */

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -98,6 +98,10 @@ class CUDADeviceAPI final : public DeviceAPI {
       }
       case kGcnArch:
         return;
+      case kApiVersion: {
+        *rv = CUDA_VERSION;
+        return;
+      }
     }
     *rv = value;
   }

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -69,6 +69,8 @@ void MetalWorkspace::GetAttr(TVMContext ctx, DeviceAttrKind kind, TVMRetValue* r
       return;
     case kGcnArch:
       return;
+    case kApiVersion:
+      return;
   }
 }
 

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -111,6 +111,8 @@ void OpenCLWorkspace::GetAttr(TVMContext ctx, DeviceAttrKind kind, TVMRetValue* 
       return;
     case kGcnArch:
       return;
+    case kApiVersion:
+      return;
   }
 }
 

--- a/src/runtime/rocm/rocm_common.h
+++ b/src/runtime/rocm/rocm_common.h
@@ -25,6 +25,7 @@
 #define TVM_RUNTIME_ROCM_ROCM_COMMON_H_
 
 #include <hip/hip_runtime_api.h>
+#include <hip/hip_version.h>
 #include <tvm/runtime/packed_func.h>
 
 #include <string>

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -103,11 +103,17 @@ class ROCMDeviceAPI final : public DeviceAPI {
         return;
       }
       case kMaxRegistersPerBlock:
-        return;
+        ROCM_CALL(
+            hipDeviceGetAttribute(&value, hipDeviceAttributeMaxRegistersPerBlock, ctx.device_id));
+        break;
       case kGcnArch: {
         hipDeviceProp_t prop;
         ROCM_CALL(hipGetDeviceProperties(&prop, ctx.device_id));
         *rv = prop.gcnArch;
+        return;
+      }
+      case kApiVersion: {
+        *rv = HIP_VERSION;
         return;
       }
     }

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -417,6 +417,8 @@ void VulkanDeviceAPI::GetAttr(TVMContext ctx, DeviceAttrKind kind, TVMRetValue* 
       return;
     case kGcnArch:
       return;
+    case kApiVersion:
+      return;
   }
 }
 


### PR DESCRIPTION
- LLVM 10+ got stricter and fails hard when Aligning to 0 bytes, so we don't.
- ROCm 3.5 apparently deprecates code object v2. So if we have the new ROCm, we use the (default) v3.