### PR TITLE
[PatternLang] Don't rewrite expressions used outside of the pattern

### DIFF
--- a/tests/python/relay/test_dataflow_pattern.py
+++ b/tests/python/relay/test_dataflow_pattern.py
@@ -1133,6 +1133,37 @@ def test_partition_double_batchnorm():
     reference = f2(gamma, f1(gamma, x, mean, var, beta), mean, var, beta)
     assert tvm.ir.structural_equal(partitioned, reference)
 
+def test_overlappting_partitions():
+    x = wildcard()
+    gamma = wildcard()
+    beta = wildcard()
+    moving_mean = wildcard()
+    moving_var = wildcard()
+    bn_node = is_op('nn.batch_norm')(x, gamma, beta, moving_mean, moving_var)
+    tuple_get_item_node = TupleGetItemPattern(bn_node, 0)
+
+    x = relay.var('x')
+    var = relay.var('var')
+    mean = relay.var('mean')
+    beta = relay.var('beta')
+    gamma = relay.var('gamma')
+    BN = relay.op.nn.batch_norm(x, gamma, beta, mean, var, epsilon=1e-5)
+    T1 = BN[0]
+    T2 = BN[0]
+    add = T1 + T2
+
+    assert tuple_get_item_node.partition(add) == add
+
+def test_partition_overused():
+    pattern = is_op("nn.relu")(is_op("nn.conv2d")(wildcard(), wildcard()))
+
+    x = relay.var('input')
+    w = relay.var('weight')
+    conv2d = relay.op.nn.conv2d(x, w)
+    relu = relay.op.nn.relu(conv2d)
+    out = relu + conv2d
+    
+    assert pattern.partition(out) == out
 
 def test_partition_check():
     pattern = is_op("nn.relu")(is_op("nn.conv2d")(wildcard(), wildcard()))


### PR DESCRIPTION
@comaniac 

While investigating #5928, I discovered an issue where the pattern language would rewrite expressions used outside of the pattern, this prevents that issue, but doesn't fix #5928 