### PR TITLE
Fix string argument mismatch in GraphRuntimeCodegen

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -56,7 +56,9 @@ def _lower(mod,
         opt_mod, _ = relay.optimize(mod, target, params)
         grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
         grc.codegen(opt_mod["main"])
-    except tvm.TVMError:
+    except tvm.TVMError as e:
+        print("Get errors with GraphRuntimeCodegen for task extraction. "
+              "Fallback to VMCompiler. Error details:\n%s" % str(e))
         compiler = relay.vm.VMCompiler()
         if params:
             compiler.set_params(params)

--- a/src/relay/backend/graph_runtime_codegen.cc
+++ b/src/relay/backend/graph_runtime_codegen.cc
@@ -587,7 +587,7 @@ class GraphRuntimeCodegenModule : public runtime::ModuleNode {
       });
     } else if (name == "get_param_by_name") {
       return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-        std::string key = args[0];
+        String key = args[0];
         CHECK_GT(this->output_.params.count(key), 0);
         *rv = this->output_.params[key];
       });


### PR DESCRIPTION
During autotvm task extraction, the following error occurred.

```
Extract tasks...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/home/ubuntu/incubator-tvm/python/tvm/autotvm/task/relay_integration.py", line 58, in _lower
    grc.codegen(opt_mod["main"])
  File "/home/ubuntu/incubator-tvm/python/tvm/relay/backend/graph_runtime_codegen.py", line 88, in codegen
    arr = self._get_param_by_name(key)
  File "/home/ubuntu/incubator-tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 225, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  [bt] (3) /home/ubuntu/incubator-tvm/build/libtvm.so(TVMFuncCall+0x65) [0x7fba4b96bac5]
  [bt] (2) /home/ubuntu/incubator-tvm/build/libtvm.so(std::_Function_handler<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::relay::backend::GraphRuntimeCodegenModule::GetFunction(std::__cxx11::basic_string<char, std::cha
r_traits<char>, std::allocator<char> > const&, tvm::runtime::ObjectPtr<tvm::runtime::Object> const&)::{lambda(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)#5}>::_M_invoke(std::_Any_data const&, tvm::runtime::TVMArgs&&, tvm::runtime
::TVMRetValue*&&)+0x67) [0x7fba4b803b77]
  [bt] (1) /home/ubuntu/incubator-tvm/build/libtvm.so(tvm::runtime::TVMArgValue::operator std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >[abi:cxx11]() const+0x13c) [0x7fba4af6c52c]
  [bt] (0) /home/ubuntu/incubator-tvm/build/libtvm.so(+0x3ea6e2) [0x7fba4af636e2]
  File "/home/ubuntu/incubator-tvm/include/tvm/runtime/packed_func.h", line 491
TVMError: Check failed: type_code_ == kTVMStr (8 vs. 11) : expected str but get Object
```

This was introduced by the recent std::string->String update.

To prevent future errors, should we allow implicit conversion from python str to tvm String when calling packed function?