### PR TITLE
[CI] Install DNNL (OneDNN) to CI Environment

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -33,6 +33,9 @@ RUN bash /install/ubuntu_install_python_package.sh
 COPY install/ubuntu1804_install_llvm.sh /install/ubuntu1804_install_llvm.sh
 RUN bash /install/ubuntu1804_install_llvm.sh
 
+COPY install/ubuntu_install_dnnl.sh /install/ubuntu_install_dnnl.sh
+RUN bash /install/ubuntu_install_dnnl.sh
+
 # Rust env (build early; takes a while)
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
 RUN bash /install/ubuntu_install_rust.sh

--- a/docker/install/ubuntu_install_dnnl.sh
+++ b/docker/install/ubuntu_install_dnnl.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+cd /usr/local/
+wget -q https://github.com/oneapi-src/oneDNN/releases/download/v1.5/dnnl_lnx_1.5.0_cpu_gomp.tgz
+tar -xzf dnnl_lnx_1.5.0_cpu_gomp.tgz
+mv dnnl_lnx_1.5.0_cpu_gomp/include/* /usr/local/include/
+mv dnnl_lnx_1.5.0_cpu_gomp/lib/libdnnl* /usr/local/lib/
+rm -rf dnnl_lnx_1.5.0_cpu_gomp.tgz dnnl_lnx_1.5.0_cpu_gomp
+cd -


### PR DESCRIPTION
The current BYOC flow uses DNNL as an example backend to demonstrate and test its functionality, but all related tests are currently skipped in CI due to the lack of DNNL in the environment. In this PR, we add scripts to deploy pre-built DNNL to the docker image so that the unit tests in #5919 for example can be effective.

I've built a docker image locally and passed unit tests of #5919 with it.

cc @zhiics @tqchen 