### PR TITLE
[RELAY] Add resnet-3d & Update network definitions for NHWC layout

### DIFF
--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -28,6 +28,7 @@ from tvm.relay import Prelude
 
 from . import mlp
 from . import resnet
+from . import resnet_3d
 from . import dqn
 from . import dcgan
 from . import mobilenet

--- a/python/tvm/relay/testing/dcgan.py
+++ b/python/tvm/relay/testing/dcgan.py
@@ -30,7 +30,7 @@ from tvm import relay
 from . import layers
 from .init import create_workload
 
-def deconv2d(data, ishape, oshape, kshape, name, stride=(2, 2)):
+def deconv2d(data, ishape, oshape, kshape, layout, name, stride=(2, 2)):
     """a deconv layer that enlarges the feature map"""
     target_shape = (oshape[-2], oshape[-1])
 
@@ -39,12 +39,21 @@ def deconv2d(data, ishape, oshape, kshape, name, stride=(2, 2)):
     adj_y = (target_shape[0] + 2 * pad_y - kshape[0]) % stride[0]
     adj_x = (target_shape[1] + 2 * pad_x - kshape[1]) % stride[1]
 
+    if layout == "NCHW":
+        kernel_layout = "OIHW"
+    elif layout == "NHWC":
+        kernel_layout = "HWOI"
+    else:
+        raise ValueError("Invalid layout: " + layout)
+
     net = layers.conv2d_transpose(data,
                                   kernel_size=kshape,
                                   strides=stride,
                                   channels=oshape[0],
                                   padding=(pad_y, pad_x),
                                   output_padding=(adj_y, adj_x),
+                                  data_layout=layout,
+                                  kernel_layout=kernel_layout,
                                   name=name)
     return net
 
@@ -52,11 +61,14 @@ def deconv2d_bn_relu(data, prefix, **kwargs):
     """a block of deconv + batch norm + relu"""
     eps = 1e-5 + 1e-12
     net = deconv2d(data, name="%s_deconv" % prefix, **kwargs)
-    net = layers.batch_norm_infer(net, epsilon=eps, scale=False, name="%s_batch_norm" % prefix)
+    bn_axis = kwargs.get('layout', "NCHW").index('C')
+    net = layers.batch_norm_infer(net, epsilon=eps, scale=False, axis=bn_axis,
+                                  name="%s_batch_norm" % prefix)
     net = relay.nn.relu(net)
     return net
 
-def get_net(batch_size, random_len=100, oshape=(3, 64, 64), ngf=128, code=None, dtype="float32"):
+def get_net(batch_size, random_len=100, oshape=(3, 64, 64), ngf=128, code=None,
+            layout='NCHW', dtype="float32"):
     """get net of dcgan generator"""
     assert oshape[-1] == 64, "Only support 64x64 image"
     assert oshape[-2] == 64, "Only support 64x64 image"
@@ -66,26 +78,32 @@ def get_net(batch_size, random_len=100, oshape=(3, 64, 64), ngf=128, code=None, 
     dense = relay.nn.dense(code, weight=dense_weight, units=4*4*ngf*8)
     relu = relay.nn.relu(dense)
     # 4 x 4
-    reshape = relay.reshape(relu, newshape=(-1, ngf * 8, 4, 4))
+    if layout == "NCHW":
+        reshape = relay.reshape(relu, newshape=(-1, ngf * 8, 4, 4))
+    elif layout == "NHWC":
+        reshape = relay.reshape(relu, newshape=(-1, 4, 4, ngf * 8))
+    else:
+        raise ValueError("Invalid layout: " + layout)
     # 8 x 8
-    dc8 = deconv2d_bn_relu(
-        reshape, ishape=(ngf * 8, 4, 4), oshape=(ngf * 4, 8, 8), kshape=(4, 4), prefix="g2")
+    dc8 = deconv2d_bn_relu(reshape, ishape=(ngf * 8, 4, 4), oshape=(ngf * 4, 8, 8), kshape=(4, 4),
+                           layout=layout, prefix="g2")
     # 16x16
-    dc16 = deconv2d_bn_relu(
-        dc8, ishape=(ngf * 4, 8, 8), oshape=(ngf * 2, 16, 16), kshape=(4, 4), prefix="g3")
+    dc16 = deconv2d_bn_relu(dc8, ishape=(ngf * 4, 8, 8), oshape=(ngf * 2, 16, 16), kshape=(4, 4),
+                            layout=layout, prefix="g3")
     # 32x32
-    dc32 = deconv2d_bn_relu(
-        dc16, ishape=(ngf * 2, 16, 16), oshape=(ngf, 32, 32), kshape=(4, 4), prefix="g4")
+    dc32 = deconv2d_bn_relu(dc16, ishape=(ngf * 2, 16, 16), oshape=(ngf, 32, 32), kshape=(4, 4),
+                            layout=layout, prefix="g4")
     # 64x64
-    dc64 = deconv2d(
-        dc32, ishape=(ngf, 32, 32), oshape=oshape[-3:], kshape=(4, 4), name="g5_deconv")
+    dc64 = deconv2d(dc32, ishape=(ngf, 32, 32), oshape=oshape[-3:], kshape=(4, 4),
+                    layout=layout, name="g5_deconv")
     tanh = relay.tanh(dc64)
 
     args = relay.analysis.free_vars(tanh)
     return relay.Function(args, tanh)
 
 
-def get_workload(batch_size, oshape=(3, 64, 64), ngf=128, random_len=100, dtype="float32"):
+def get_workload(batch_size, oshape=(3, 64, 64), ngf=128, random_len=100,
+                 layout='NCHW', dtype="float32"):
     """Get benchmark workload for a DCGAN generator
 
     Parameters
@@ -98,6 +116,8 @@ def get_workload(batch_size, oshape=(3, 64, 64), ngf=128, random_len=100, dtype=
         The number of final feature maps in the generator
     random_len : int, optional
         The length of random input
+    layout: str, optional
+        The layout of conv2d transpose
     dtype : str, optional
         The data type
 
@@ -108,5 +128,5 @@ def get_workload(batch_size, oshape=(3, 64, 64), ngf=128, random_len=100, dtype=
     params : dict of str to NDArray
         The parameters.
     """
-    net = get_net(batch_size, random_len, oshape=oshape, ngf=ngf, dtype=dtype)
+    net = get_net(batch_size, random_len, oshape=oshape, ngf=ngf, layout=layout, dtype=dtype)
     return create_workload(net)

--- a/python/tvm/relay/testing/dqn.py
+++ b/python/tvm/relay/testing/dqn.py
@@ -26,27 +26,32 @@ from tvm import relay
 from . import layers
 from .init import create_workload
 
-def get_net(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="float32"):
+def get_net(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="float32", layout="NCHW"):
     """get symbol of nature dqn"""
     data_shape = (batch_size,) + image_shape
     data = relay.var("data", shape=data_shape, dtype=dtype)
 
+    bias_axis = layout.index('C')
+
     conv1_bias = relay.var("conv1_bias")
     conv1 = layers.conv2d(data, kernel_size=(8, 8), strides=(4, 4), padding=(0, 0),
-                          channels=32, name="conv1")
-    conv1 = relay.nn.bias_add(conv1, conv1_bias)
+                          channels=32, name="conv1", data_layout=layout,
+                          kernel_layout=layers.conv_kernel_layout(layout))
+    conv1 = relay.nn.bias_add(conv1, conv1_bias, bias_axis)
     relu1 = relay.nn.relu(conv1)
 
     conv2_bias = relay.var("conv2_bias")
     conv2 = layers.conv2d(relu1, kernel_size=(4, 4), strides=(2, 2), padding=(0, 0),
-                          channels=64, name="conv2")
-    conv2 = relay.nn.bias_add(conv2, conv2_bias)
+                          channels=64, name="conv2", data_layout=layout,
+                          kernel_layout=layers.conv_kernel_layout(layout))
+    conv2 = relay.nn.bias_add(conv2, conv2_bias, bias_axis)
     relu2 = relay.nn.relu(conv2)
 
     conv3_bias = relay.var("conv3_bias")
     conv3 = layers.conv2d(relu2, kernel_size=(3, 3), strides=(1, 1), padding=(0, 0),
-                          channels=64, name="conv3")
-    conv3 = relay.nn.bias_add(conv3, conv3_bias)
+                          channels=64, name="conv3", data_layout=layout,
+                          kernel_layout=layers.conv_kernel_layout(layout))
+    conv3 = relay.nn.bias_add(conv3, conv3_bias, bias_axis)
     relu3 = relay.nn.relu(conv3)
 
     bf1 = relay.nn.batch_flatten(relu3)
@@ -58,7 +63,8 @@ def get_net(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="float32"
     return relay.Function(args, dense2)
 
 
-def get_workload(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="float32"):
+def get_workload(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="float32",
+                 layout="NCHW"):
     """Get benchmark workload for a Deep Q Network
     Parameters
     ----------
@@ -72,10 +78,11 @@ def get_workload(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="flo
         The data type
     Returns
     -------
-    mod : tvm.IRModule
+    mod : tvm.relay.Module
         The relay module that contains a DQN network.
     params : dict of str to NDArray
         The parameters.
     """
-    net = get_net(batch_size, num_actions=num_actions, image_shape=image_shape, dtype=dtype)
+    net = get_net(batch_size, num_actions=num_actions, image_shape=image_shape, dtype=dtype,
+                  layout=layout)
     return create_workload(net)

--- a/python/tvm/relay/testing/dqn.py
+++ b/python/tvm/relay/testing/dqn.py
@@ -78,7 +78,7 @@ def get_workload(batch_size, num_actions=18, image_shape=(4, 84, 84), dtype="flo
         The data type
     Returns
     -------
-    mod : tvm.relay.Module
+    mod : tvm.IRModule
         The relay module that contains a DQN network.
     params : dict of str to NDArray
         The parameters.

--- a/python/tvm/relay/testing/layers.py
+++ b/python/tvm/relay/testing/layers.py
@@ -96,6 +96,27 @@ def conv2d(data, weight=None, **kwargs):
         weight = relay.var(name + "_weight")
     return relay.nn.conv2d(data, weight, **kwargs)
 
+def conv3d(data, weight=None, **kwargs):
+    """Wrapper of conv3d which automatically creates weights if not given.
+    Parameters
+    ----------
+    data : relay.Expr
+        The input expression.
+    weight : relay.Expr
+        The weight to conv3d.
+    kwargs : dict
+        Additional arguments.
+    Returns
+    -------
+    result : relay.Expr
+        The result.
+    """
+    name = kwargs.get("name")
+    kwargs.pop("name")
+    if not weight:
+        weight = relay.var(name + "_weight")
+    return relay.nn.conv3d(data, weight, **kwargs)
+
 def conv2d_transpose(data, weight=None, **kwargs):
     """Wrapper of conv2d_transpose which automatically creates weights if not given.
 

--- a/python/tvm/relay/testing/resnet_3d.py
+++ b/python/tvm/relay/testing/resnet_3d.py
@@ -14,14 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Adapted from https://github.com/tornadomeet/ResNet/blob/master/symbol_resnet.py
-Original author Wei Wu
 
-Implemented the following paper:
-
-Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun. "Identity Mappings in Deep Residual Networks"
-"""
 # pylint: disable=unused-argument
 from tvm import relay
 from .init import create_workload
@@ -33,8 +26,8 @@ def residual_unit(data,
                   dim_match,
                   name,
                   bottle_neck=True,
-                  data_layout="NCHW",
-                  kernel_layout="IOHW"
+                  data_layout="NCDHW",
+                  kernel_layout="OIDHW"
                   ):
     """Return ResNet Unit symbol for building ResNet
 
@@ -59,61 +52,59 @@ def residual_unit(data,
     name : str
         Base name of the operators
     """
-    bn_axis = data_layout.index('C')
     if bottle_neck:
         bn1 = layers.batch_norm_infer(data=data,
                                       epsilon=2e-5,
-                                      axis=bn_axis,
                                       name=name + '_bn1')
         act1 = relay.nn.relu(data=bn1)
-        conv1 = layers.conv2d(
+        conv1 = layers.conv3d(
             data=act1,
             channels=int(num_filter*0.25),
-            kernel_size=(1, 1),
+            kernel_size=(1, 1, 1),
             strides=stride,
-            padding=(0, 0),
+            padding=(0, 0, 0),
             name=name + '_conv1',
             data_layout=data_layout,
             kernel_layout=kernel_layout)
-        bn2 = layers.batch_norm_infer(data=conv1, epsilon=2e-5, axis=bn_axis, name=name + '_bn2')
+        bn2 = layers.batch_norm_infer(data=conv1, epsilon=2e-5, name=name + '_bn2')
         act2 = relay.nn.relu(data=bn2)
-        conv2 = layers.conv2d(
-            data=act2, channels=int(num_filter*0.25), kernel_size=(3, 3),
-            strides=(1, 1), padding=(1, 1), name=name + '_conv2',
+        conv2 = layers.conv3d(
+            data=act2, channels=int(num_filter*0.25), kernel_size=(3, 3, 3),
+            strides=(1, 1, 1), padding=(1, 1, 1), name=name + '_conv2',
             data_layout=data_layout, kernel_layout=kernel_layout)
-        bn3 = layers.batch_norm_infer(data=conv2, epsilon=2e-5, axis=bn_axis, name=name + '_bn3')
+        bn3 = layers.batch_norm_infer(data=conv2, epsilon=2e-5, name=name + '_bn3')
         act3 = relay.nn.relu(data=bn3)
-        conv3 = layers.conv2d(
-            data=act3, channels=num_filter, kernel_size=(1, 1),
-            strides=(1, 1), padding=(0, 0), name=name + '_conv3',
+        conv3 = layers.conv3d(
+            data=act3, channels=num_filter, kernel_size=(1, 1, 1),
+            strides=(1, 1, 1), padding=(0, 0, 0), name=name + '_conv3',
             data_layout=data_layout, kernel_layout=kernel_layout)
         if dim_match:
             shortcut = data
         else:
-            shortcut = layers.conv2d(
-                data=act1, channels=num_filter, kernel_size=(1, 1),
+            shortcut = layers.conv3d(
+                data=act1, channels=num_filter, kernel_size=(1, 1, 1),
                 strides=stride, name=name+'_sc',
                 data_layout=data_layout, kernel_layout=kernel_layout)
         return relay.add(conv3, shortcut)
 
-    bn1 = layers.batch_norm_infer(data=data, epsilon=2e-5, axis=bn_axis, name=name + '_bn1')
+    bn1 = layers.batch_norm_infer(data=data, epsilon=2e-5, name=name + '_bn1')
     act1 = relay.nn.relu(data=bn1)
-    conv1 = layers.conv2d(
-        data=act1, channels=num_filter, kernel_size=(3, 3),
-        strides=stride, padding=(1, 1), name=name + '_conv1',
+    conv1 = layers.conv3d(
+        data=act1, channels=num_filter, kernel_size=(3, 3, 3),
+        strides=stride, padding=(1, 1, 1), name=name + '_conv1',
         data_layout=data_layout, kernel_layout=kernel_layout)
-    bn2 = layers.batch_norm_infer(data=conv1, epsilon=2e-5, axis=bn_axis, name=name + '_bn2')
+    bn2 = layers.batch_norm_infer(data=conv1, epsilon=2e-5, name=name + '_bn2')
     act2 = relay.nn.relu(data=bn2)
-    conv2 = layers.conv2d(
-        data=act2, channels=num_filter, kernel_size=(3, 3),
-        strides=(1, 1), padding=(1, 1), name=name + '_conv2',
+    conv2 = layers.conv3d(
+        data=act2, channels=num_filter, kernel_size=(3, 3, 3),
+        strides=(1, 1, 1), padding=(1, 1, 1), name=name + '_conv2',
         data_layout=data_layout, kernel_layout=kernel_layout)
 
     if dim_match:
         shortcut = data
     else:
-        shortcut = layers.conv2d(
-            data=act1, channels=num_filter, kernel_size=(1, 1),
+        shortcut = layers.conv3d(
+            data=act1, channels=num_filter, kernel_size=(1, 1, 1),
             strides=stride, name=name+'_sc',
             data_layout=data_layout, kernel_layout=kernel_layout)
     return relay.add(conv2, shortcut)
@@ -125,7 +116,7 @@ def resnet(units,
            num_classes,
            data_shape,
            bottle_neck=True,
-           layout="NCHW",
+           layout="NCDHW",
            dtype="float32"):
     """Return ResNet Program.
 
@@ -150,53 +141,52 @@ def resnet(units,
         Whether apply bottleneck transformation.
 
     layout: str
-        The data layout for conv2d
+        The data layout for conv3d
 
     dtype : str
         The global data type.
     """
 
     data_layout = layout
-    kernel_layout = "OIHW" if layout == "NCHW" else "HWIO"
-    bn_axis = data_layout.index('C')
+    kernel_layout = "OIDHW" if layout == "NCDHW" else "DHWIO"
 
     num_unit = len(units)
     assert num_unit == num_stages
     data = relay.var("data", shape=data_shape, dtype=dtype)
-    data = layers.batch_norm_infer(data=data, epsilon=2e-5, axis=bn_axis, scale=False,
-                                   name='bn_data')
-    (_, _, height, _) = data_shape
-    if layout == "NHWC":
-        (_, height, _, _) = data_shape
+    data = layers.batch_norm_infer(data=data, epsilon=2e-5, scale=False, name='bn_data')
+    if layout=="NCDHW":
+        (_, _, _, height, _) = data_shape
+    else:
+        (_, _, height, _, _) = data_shape
     if height <= 32:            # such as cifar10
-        body = layers.conv2d(
-            data=data, channels=filter_list[0], kernel_size=(3, 3),
-            strides=(1, 1), padding=(1, 1), name="conv0",
+        body = layers.conv3d(
+            data=data, channels=filter_list[0], kernel_size=(3, 3, 3),
+            strides=(1, 1, 1), padding=(1, 1, 1), name="conv0",
             data_layout=data_layout, kernel_layout=kernel_layout)
     else:                       # often expected to be 224 such as imagenet
-        body = layers.conv2d(
-            data=data, channels=filter_list[0], kernel_size=(7, 7),
-            strides=(2, 2), padding=(3, 3), name="conv0",
+        body = layers.conv3d(
+            data=data, channels=filter_list[0], kernel_size=(3, 7, 7),
+            strides=(1, 2, 2), padding=(1, 3, 3), name="conv0",
             data_layout=data_layout, kernel_layout=kernel_layout)
-        body = layers.batch_norm_infer(data=body, epsilon=2e-5, axis=bn_axis, name='bn0')
+        body = layers.batch_norm_infer(data=body, epsilon=2e-5, name='bn0')
         body = relay.nn.relu(data=body)
-        body = relay.nn.max_pool2d(data=body, pool_size=(3, 3), strides=(2, 2), padding=(1, 1),
-                                   layout=data_layout)
+        #body = relay.nn.max_pool3d(data=body, pool_size=(3, 3), strides=(2, 2), padding=(1, 1),
+        #                           layout=data_layout)
 
     for i in range(num_stages):
         body = residual_unit(
-            body, filter_list[i+1], (1 if i == 0 else 2, 1 if i == 0 else 2),
+            body, filter_list[i+1], (1 if i == 0 else 2, 1 if i == 0 else 2, 1 if i == 0 else 2),
             False, name='stage%d_unit%d' % (i + 1, 1), bottle_neck=bottle_neck,
             data_layout=data_layout, kernel_layout=kernel_layout)
         for j in range(units[i]-1):
             body = residual_unit(
-                body, filter_list[i+1], (1, 1), True,
+                body, filter_list[i+1], (1, 1, 1), True,
                 name='stage%d_unit%d' % (i + 1, j + 2), bottle_neck=bottle_neck,
                 data_layout=data_layout, kernel_layout=kernel_layout)
-    bn1 = layers.batch_norm_infer(data=body, epsilon=2e-5, axis=bn_axis, name='bn1')
+    bn1 = layers.batch_norm_infer(data=body, epsilon=2e-5, name='bn1')
     relu1 = relay.nn.relu(data=bn1)
     # Although kernel is not used here when global_pool=True, we should put one
-    pool1 = relay.nn.global_avg_pool2d(data=relu1, layout=data_layout)
+    pool1 = relay.nn.global_avg_pool3d(data=relu1, layout=data_layout)
     flat = relay.nn.batch_flatten(data=pool1)
     fc1 = layers.dense_add_bias(data=flat, units=num_classes, name='fc1')
     net = relay.nn.softmax(data=fc1)
@@ -206,17 +196,18 @@ def resnet(units,
 def get_net(batch_size,
             num_classes,
             num_layers=50,
-            image_shape=(3, 224, 224),
-            layout="NCHW",
+            image_shape=(3, 16, 112, 112),
+            layout="NCDHW",
             dtype="float32",
             **kwargs):
     """
     Adapted from https://github.com/tornadomeet/ResNet/blob/master/train_resnet.py
     Original author Wei Wu
     """
-    (_, height, _) = image_shape
-    if layout == "NHWC":
-        (height, _, _) = image_shape
+    if layout=="NCDHW":
+        (_, _, height, _) = image_shape
+    else:
+        (_, height, _, _) = image_shape
     data_shape = (batch_size,) + image_shape
     if height <= 28:
         num_stages = 3
@@ -269,8 +260,8 @@ def get_net(batch_size,
 def get_workload(batch_size=1,
                  num_classes=1000,
                  num_layers=18,
-                 image_shape=(3, 224, 224),
-                 layout="NCHW",
+                 image_shape=(3, 16, 112, 112),
+                 layout="NCDHW",
                  dtype="float32",
                  **kwargs):
     """Get benchmark workload for resnet
@@ -290,7 +281,7 @@ def get_workload(batch_size=1,
         The input image shape
 
     layout: str
-        The data layout for conv2d
+        The data layout for conv3d
 
     dtype : str, optional
         The data type

--- a/python/tvm/relay/testing/resnet_3d.py
+++ b/python/tvm/relay/testing/resnet_3d.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Network definition of 3D ResNet for Action Recognition (CVPR 2018) 
+Network definition of 3D ResNet for Action Recognition (CVPR 2018)
 
 Reference : https://github.com/kenshohara/3D-ResNets-PyTorch
 """
@@ -159,7 +159,7 @@ def resnet(units,
     assert num_unit == num_stages
     data = relay.var("data", shape=data_shape, dtype=dtype)
     data = layers.batch_norm_infer(data=data, epsilon=2e-5, scale=False, name='bn_data')
-    if layout=="NCDHW":
+    if layout == "NCDHW":
         (_, _, _, height, _) = data_shape
     else:
         (_, _, height, _, _) = data_shape
@@ -209,7 +209,7 @@ def get_net(batch_size,
     Adapted from https://github.com/tornadomeet/ResNet/blob/master/train_resnet.py
     Original author Wei Wu
     """
-    if layout=="NCDHW":
+    if layout == "NCDHW":
         (_, _, height, _) = image_shape
     else:
         (_, height, _, _) = image_shape

--- a/python/tvm/relay/testing/resnet_3d.py
+++ b/python/tvm/relay/testing/resnet_3d.py
@@ -14,6 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+Network definition of 3D ResNet for Action Recognition (CVPR 2018) 
+
+Reference : https://github.com/kenshohara/3D-ResNets-PyTorch
+"""
 
 # pylint: disable=unused-argument
 from tvm import relay

--- a/tests/python/relay/test_autotvm_task_extraction.py
+++ b/tests/python/relay/test_autotvm_task_extraction.py
@@ -25,6 +25,8 @@ def get_network(name, batch_size):
 
     if name == 'resnet-18':
         mod, params = relay.testing.resnet.get_workload(num_layers=18, batch_size=batch_size)
+    elif name == 'resnet3d-18':
+        mod, params = relay.testing.resnet_3d.get_workload(num_layers=18, batch_size=batch_size)
     elif name == 'mobilenet':
         mod, params = relay.testing.mobilenet.get_workload(batch_size=batch_size)
     elif name == 'dcgan':
@@ -40,6 +42,7 @@ def test_task_extraction():
     mod_list = []
     params_list = []
     conv2d = relay.op.get("nn.conv2d")
+    conv3d = relay.op.get("nn.conv3d")
     conv2d_transpose = relay.op.get("nn.conv2d_transpose")
     dense = relay.op.get("nn.dense")
 
@@ -77,6 +80,12 @@ def test_task_extraction():
     tasks = autotvm.task.extract_from_program(mod, target=target,
                                               params=params)
     assert len(tasks) == 13
+
+    mod, params, _ = get_network('resnet3d-18', batch_size=1)
+    tasks = autotvm.task.extract_from_program(mod, target=target,
+                                              params=params,
+                                              ops=(conv3d,))
+    assert len(tasks) == 12
 
     mod, params, _ = get_network('mobilenet', batch_size=1)
     mod_list.append(mod)


### PR DESCRIPTION
- Add ResNet-3d
- Update network definitions (resnet, mobilenet, dqn, dcgan) in relay testing for NHWC layout
   - Ansor works better with NHWC layout because this layout does not require data packing for vectorization over channel dimension.