### PR TITLE
[RELAY][GRAD] handle Tuple/TupleGetItem in first order gradient

### DIFF
--- a/src/relay/transforms/pattern_util.h
+++ b/src/relay/transforms/pattern_util.h
@@ -524,6 +524,12 @@ inline Expr OnesLike(Expr e) {
   return Call(op, {e});
 }
 
+Expr MakeOnes(Expr shape, DataType dtype);
+
+inline Expr Ones(Array<IndexExpr> shape, DataType dtype) {
+  return MakeOnes(CheckConstantShape(shape), dtype);
+}
+
 inline Expr CollapseSumLike(Expr e) {
   static const Op& op = Op::Get("collapse_sum_like");
   return Call(op, {e});


### PR DESCRIPTION
This adds tuple support for first order gradients.

We may have tuples passed to or returned from functions and at this stage, they aren't inlined (because we want to compute gradients based on that granularity), limiting the possibility to eliminate Tuple/GetTupleItem.
Examples of ops with tupels include dropout and concatenate.
