### PR TITLE
[TF Frontend]raise right error in tensorflow split op

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1742,7 +1742,7 @@ def _split(has_size_vector):
                 indices_or_sections = attr['num_split']
             input_node = inputs[input_node_index]
             axis_input_value = _get_num_param(params, inputs[input_axis_index])
-        except (IndexError, KeyError):
+        except (IndexError, KeyError, AttributeError):
             raise TypeError(
                 "Unsupported argument for split: `axis` and `num_or_size_splits` "
                 "should be constants")


### PR DESCRIPTION
when there are dynamic args in `split` op, it will raise `AttributeError: <class ‘tvm.relay.expr.Call’> has no attribute name_hint`. catch it and raise the correct error for better readability.

@siju-samuel could you help review this pr?