### PR TITLE
[autotune bugfix]filter out error features

### DIFF
--- a/python/tvm/autotvm/tuner/xgboost_cost_model.py
+++ b/python/tvm/autotvm/tuner/xgboost_cost_model.py
@@ -236,6 +236,8 @@ class XGBoostCostModel(CostModel):
         else:
             raise RuntimeError("Invalid feature type: " + self.fea_type)
         res = pool.map(feature_extract_func, data)
+        # filter out None output, which is caused by extract exception
+        res = [r for r in res if r is not None]
 
         # filter out feature with different shapes
         fea_len = len(self._get_feature([0])[0])


### PR DESCRIPTION
Filter out None output, which is caused by extract exception. Or it will raise exception at following lines: https://github.com/Meteorix/incubator-tvm/blob/cb1aa974a4ef4ea3c15c9a56ce3231e56c02396f/python/tvm/autotvm/tuner/xgboost_cost_model.py#L246

@tqchen could you help review this pr?