### PR TITLE
Fix some typo errors in license header

### DIFF
--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -1,4 +1,4 @@
-# License .to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -73,6 +73,7 @@ def compile(mod, target=None, target_host=None, params=None):
 
 class VMCompiler(object):
     """Compiler that compiles Relay module to VM executable."""
+
     def __init__(self):
         self.mod = _vm._VMCompiler()
         self._lower = self.mod["lower"]
@@ -239,6 +240,7 @@ class VMExecutor(Executor):
     target : :py:class:`Target`
         The target option to build the function.
     """
+
     def __init__(self, mod, ctx, target):
         if mod is None:
             raise RuntimeError("Must provide module to get VM executor.")

--- a/python/tvm/runtime/profiler_vm.py
+++ b/python/tvm/runtime/profiler_vm.py
@@ -1,4 +1,4 @@
-# License .to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -23,12 +23,15 @@ Provides extra APIs for profiling vm execution.
 from tvm.runtime import _ffi_api
 from . import vm
 
+
 def enabled():
     """Whether vm profiler is enabled."""
     return hasattr(_ffi_api, "_VirtualMachineDebug")
 
+
 class VirtualMachineProfiler(vm.VirtualMachine):
     """Relay profile VM runtime."""
+
     def __init__(self, mod):
         super(VirtualMachineProfiler, self).__init__(mod)
         m = mod.module if isinstance(mod, vm.Executable) else mod

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -1,4 +1,4 @@
-# License .to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -27,6 +27,7 @@ from tvm._ffi.runtime_ctypes import TVMByteArray
 from tvm._ffi import base as _base
 from .object import Object
 from . import _ffi_api, container
+
 
 def _convert(arg, cargs):
     if isinstance(arg, Object):
@@ -59,6 +60,7 @@ def convert(args):
 
 class Executable(object):
     """Relay VM executable"""
+
     def __init__(self, mod):
         self.mod = mod
         self._function_params = {}
@@ -272,6 +274,7 @@ class Executable(object):
 
 class VirtualMachine(object):
     """Relay VM runtime."""
+
     def __init__(self, mod):
         if not isinstance(mod, (Executable, tvm.runtime.Module)):
             raise TypeError("mod is expected to be the type of Executable or " +


### PR DESCRIPTION
This PR is proposed to fix typo errors in some python files, so as to make the license header in the same style. Besides, the change of blank lines seems to be caused from auto-formating in VSCode.