### PR TITLE
Raise an exception when extern function does not return Stmt

### DIFF
--- a/python/tvm/te/operation.py
+++ b/python/tvm/te/operation.py
@@ -313,6 +313,8 @@ def extern(shape,
     body = fcompute(input_placeholders, output_placeholders)
     if isinstance(body, tvm.tir.PrimExpr):
         body = tvm.tir.Evaluate(body)
+    if not isinstance(body, tvm.tir.Stmt):
+        raise ValueError("Function '{}' should return PrimExpr or Stmt".format(fcompute.__name__))
 
     op = _ffi_api.ExternOp(name, tag, attrs,
                            inputs, input_placeholders,


### PR DESCRIPTION
The function for `tvm.te.extern` should return either `PrimExpr` or `Stmt`, however there is no check if it actually does so. If it does not, the result may be a segmentation fault later on. Catch this case early on, so an informative message can be shown.