### PR TITLE
Improve docker/bash.sh to handle git worktrees

### DIFF
--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -189,7 +189,7 @@ def main():
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     (out, _) = proc.communicate()
-    assert proc.returncode == 0
+    assert proc.returncode == 0, f'{" ".join(cmd)} errored: {out}'
     res = out.decode("utf-8")
     flist = res.split()
     error_list = []


### PR DESCRIPTION
The lint tool doesn't mount the correct .git directory into the docker image when using git-worktree. Adding support for that.