### PR TITLE
fix tvm relay testing tf.py typo error

### DIFF
--- a/python/tvm/relay/testing/tf.py
+++ b/python/tvm/relay/testing/tf.py
@@ -50,7 +50,7 @@ def ProcessGraphDefParam(graph_def):
     Returns
     -------
     graph_def : Obj
-        tensorflow graph devinition
+        tensorflow graph definition
 
     """
 


### PR DESCRIPTION
Find a typo error when go through the tf module, please take a look @tqchen
