### PR TITLE
Fixed point multiplication improvements for AArch64

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -298,6 +298,17 @@ struct ClipAttrs : public tvm::AttrsNode<ClipAttrs> {
   }
 };
 
+/*! \brief Attributes for FixedPointMultiply operator */
+struct FixedPointMultiplyAttrs : public tvm::AttrsNode<FixedPointMultiplyAttrs> {
+  int32_t multiplier;
+  int32_t shift;
+
+  TVM_DECLARE_ATTRS(FixedPointMultiplyAttrs, "relay.attrs.FixedPointMultiplyAttrs") {
+    TVM_ATTR_FIELD(multiplier).describe("Integer multiplier.");
+    TVM_ATTR_FIELD(shift).describe("Shift.");
+  }
+};
+
 /*! \brief Attributes for LayoutTransform operator */
 struct LayoutTransformAttrs : public tvm::AttrsNode<LayoutTransformAttrs> {
   std::string src_layout;

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -304,8 +304,10 @@ struct FixedPointMultiplyAttrs : public tvm::AttrsNode<FixedPointMultiplyAttrs> 
   int32_t shift;
 
   TVM_DECLARE_ATTRS(FixedPointMultiplyAttrs, "relay.attrs.FixedPointMultiplyAttrs") {
-    TVM_ATTR_FIELD(multiplier).describe("Integer multiplier.");
-    TVM_ATTR_FIELD(shift).describe("Shift.");
+    TVM_ATTR_FIELD(multiplier)
+        .describe("Multiplier of a fixed floating point number described as multiplier*2^(shift)");
+    TVM_ATTR_FIELD(shift).describe(
+        "Shift of a fixed floating point number described as multiplier*2^(shift)");
   }
 };
 

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -93,6 +93,17 @@ TVM_DLL const Op& shift_right();
 TVM_DLL const Op& large_uint_imm();
 
 /*!
+ * \brief Execute a fixed point multiplication y = round(x * m * 2^s).
+ * The default rounding rule is to the nearest value, rounding half up
+ * (i.e., round(x.1) = x and round (x.5) = x+1)
+ * \param x input value
+ * \param m integer multiplier
+ * \param s integer shift
+ * \return The constructed expression.
+ */
+TVM_DLL const Op& fixed_point_multiply();
+
+/*!
  * \brief See pesudo code
  *
  *  Handle address_of(Load *op) {

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -98,7 +98,7 @@ TVM_DLL const Op& large_uint_imm();
  * The default rounding rule is to the nearest value, rounding half up
  * (i.e., round(x.1) = x and round (x.5) = x+1)
  */
-TVM_DLL const Op& qmuls();
+TVM_DLL const Op& q_multiply_shift();
 
 /*!
  * \brief See pesudo code

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -96,10 +96,6 @@ TVM_DLL const Op& large_uint_imm();
  * \brief Execute a fixed point multiplication y = round(x * m * 2^s).
  * The default rounding rule is to the nearest value, rounding half up
  * (i.e., round(x.1) = x and round (x.5) = x+1)
- * \param x input value
- * \param m integer multiplier
- * \param s integer shift
- * \return The constructed expression.
  */
 TVM_DLL const Op& fixed_point_multiply();
 

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -93,11 +93,12 @@ TVM_DLL const Op& shift_right();
 TVM_DLL const Op& large_uint_imm();
 
 /*!
- * \brief Execute a fixed point multiplication y = round(x * m * 2^s).
+ * \brief Execute a multiplication between two Q-numbers x and y
+ * followed by a right shift s
  * The default rounding rule is to the nearest value, rounding half up
  * (i.e., round(x.1) = x and round (x.5) = x+1)
  */
-TVM_DLL const Op& fixed_point_multiply();
+TVM_DLL const Op& qmuls();
 
 /*!
  * \brief See pesudo code

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -558,13 +558,16 @@ TVM_DLL PrimExpr LargeUIntImm(DataType dtype, int64_t low, int64_t high);
  *
  *    out = round(x*y*2^-s)
  *
+ * Please note that the two Q-numbers x and y are supposed to have
+ * the same number of fractional bits q.
+ *
  * More about Q-numbers here: https://en.wikipedia.org/wiki/Q_(number_format)
  *
  * The rounding rule is to the nearest value, rounding half up
  * (i.e., round(x.1) = x and round (x.5) = x+1)
  * \param x first Q-number
  * \param y second Q-number
- * \param q Q-ness of x and y
+ * \param q number of fractional bits in x and y. Needs to be > 0
  * \param s integer right shift
  * \return The constructed expression.
  */

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -553,15 +553,22 @@ TVM_DLL PrimExpr trunc(PrimExpr x);
 TVM_DLL PrimExpr LargeUIntImm(DataType dtype, int64_t low, int64_t high);
 
 /*!
- * \brief Execute a fixed point multiplication y = round(x * m * 2^s).
- * The default rounding rule is to the nearest value, rounding half up
+ * \brief Execute a multiplication between two Q-numbers x and y
+ * followed by a right shift s. The mathematical expression is:
+ *
+ *    out = round(x*y*2^-s)
+ *
+ * More about Q-numbers here: https://en.wikipedia.org/wiki/Q_(number_format)
+ *
+ * The rounding rule is to the nearest value, rounding half up
  * (i.e., round(x.1) = x and round (x.5) = x+1)
- * \param x input value
- * \param m integer multiplier
- * \param s integer shift
+ * \param x first Q-number
+ * \param y second Q-number
+ * \param q Q-ness of x and y
+ * \param s integer right shift
  * \return The constructed expression.
  */
-TVM_DLL PrimExpr fixed_point_multiply(PrimExpr x, PrimExpr m, PrimExpr s);
+TVM_DLL PrimExpr qmuls(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s);
 
 // Intrinsic operators
 #define TVM_DECLARE_INTRIN_UNARY(OpName)           \

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -571,7 +571,7 @@ TVM_DLL PrimExpr LargeUIntImm(DataType dtype, int64_t low, int64_t high);
  * \param s integer right shift
  * \return The constructed expression.
  */
-TVM_DLL PrimExpr qmuls(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s);
+TVM_DLL PrimExpr q_multiply_shift(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s);
 
 // Intrinsic operators
 #define TVM_DECLARE_INTRIN_UNARY(OpName)           \

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -552,6 +552,17 @@ TVM_DLL PrimExpr trunc(PrimExpr x);
  */
 TVM_DLL PrimExpr LargeUIntImm(DataType dtype, int64_t low, int64_t high);
 
+/*!
+ * \brief Execute a fixed point multiplication y = round(x * m * 2^s).
+ * The default rounding rule is to the nearest value, rounding half up
+ * (i.e., round(x.1) = x and round (x.5) = x+1)
+ * \param x input value
+ * \param m integer multiplier
+ * \param s integer shift
+ * \return The constructed expression.
+ */
+TVM_DLL PrimExpr fixed_point_multiply(PrimExpr x, PrimExpr m, PrimExpr s);
+
 // Intrinsic operators
 #define TVM_DECLARE_INTRIN_UNARY(OpName)           \
   inline PrimExpr OpName(PrimExpr x) {             \

--- a/python/tvm/relay/op/_tensor.py
+++ b/python/tvm/relay/op/_tensor.py
@@ -131,6 +131,14 @@ def clip_compute(attrs, inputs, output_type):
 
 register_injective_schedule("clip")
 
+# fixed point multiply
+@register_compute("fixed_point_multiply")
+def fixed_point_multiply_compute(attrs, inputs, output_type):
+    assert len(inputs) == 1
+    return [topi.fixed_point_multiply(inputs[0], attrs.multiplier, attrs.shift)]
+
+register_injective_schedule("fixed_point_multiply")
+
 # full
 @script
 def _full_shape_func(shape):

--- a/python/tvm/relay/op/tensor.py
+++ b/python/tvm/relay/op/tensor.py
@@ -1034,6 +1034,27 @@ def clip(a, a_min, a_max):
     """
     return _make.clip(a, a_min, a_max)
 
+def fixed_point_multiply(data, multiplier, shift):
+    """Fixed point multiplication between data and a fixed point
+    constant expressed as multiplier * 2^(-shift), where multiplier
+    is a Q-number with 31 fractional bits
+
+    Parameters
+    ----------
+    data : relay.Expr
+        The input tensor.
+    multiplier : int
+        The integer multiplier of the fixed point constant.
+    a_max : float
+        The integer shift of the fixed point constant.
+
+    Returns
+    -------
+    result : relay.Expr
+        The output of the fixed point multiplication
+    """
+    return _make.fixed_point_multiply(data, multiplier, shift)
+
 
 def concatenate(data, axis):
     """Concatenate the input tensors along the given axis.

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -45,7 +45,7 @@ from .op import trunc, abs, round, nextafter, nearbyint, power, popcount, fmod, 
 from .op import isnan, isfinite, isinf, copysign
 from .op import div, indexdiv, indexmod, truncdiv, truncmod, floordiv, floormod
 from .op import comm_reducer, min, max, sum
-from .op import qmuls
+from .op import q_multiply_shift
 
 from . import ir_builder
 from . import transform

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -45,6 +45,7 @@ from .op import trunc, abs, round, nextafter, nearbyint, power, popcount, fmod, 
 from .op import isnan, isfinite, isinf, copysign
 from .op import div, indexdiv, indexmod, truncdiv, truncmod, floordiv, floormod
 from .op import comm_reducer, min, max, sum
+from .op import fixed_point_multiply
 
 from . import ir_builder
 from . import transform

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -45,7 +45,7 @@ from .op import trunc, abs, round, nextafter, nearbyint, power, popcount, fmod, 
 from .op import isnan, isfinite, isinf, copysign
 from .op import div, indexdiv, indexmod, truncdiv, truncmod, floordiv, floormod
 from .op import comm_reducer, min, max, sum
-from .op import fixed_point_multiply
+from .op import qmuls
 
 from . import ir_builder
 from . import transform

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -982,7 +982,7 @@ def qmuls(x, y, q, s):
     y : PrimExpr
         Second Q-number
     q : PrimExpr
-        Q-ness of x and y
+        Number of fractional bits in x and y. Needs to be > 0
     s : PrimExpr
         Integer shift
 

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -965,17 +965,24 @@ def popcount(x):
     """
     return call_intrin(x.dtype, "tir.popcount", x)
 
-def fixed_point_multiply(x, m, s):
-    """Execute a fixed point multiplication y = round(x * m * 2^s).
-    The default rounding rule is to the nearest value, rounding half up
+def qmuls(x, y, q, s):
+    """Execute a multiplication between two Q-numbers x and y
+    followed by a right shift s. The mathematical expression is:
+
+       out = round(x*y*2^-s)
+
+    More about Q-numbers here: https://en.wikipedia.org/wiki/Q_(number_format)
+    The rounding rule is to the nearest value, rounding half up
     (i.e., round(x.1) = x and round (x.5) = x+1)
 
     Parameters
     ----------
     x : PrimExpr
-        Input argument.
-    m : PrimExpr
-        Integer multiplier
+        First Q-number
+    y : PrimExpr
+        Second Q-number
+    q : PrimExpr
+        Q-ness of x and y
     s : PrimExpr
         Integer shift
 
@@ -984,7 +991,7 @@ def fixed_point_multiply(x, m, s):
     y : PrimExpr
         The result.
     """
-    return call_intrin(x.dtype, "tir.fixed_point_multiply", x, m, s)
+    return call_intrin(x.dtype, "tir.qmuls", x, y, q, s)
 
 def fmod(x, y):
     """Return the remainder of x divided by y with the same sign as x.

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -965,7 +965,7 @@ def popcount(x):
     """
     return call_intrin(x.dtype, "tir.popcount", x)
 
-def qmuls(x, y, q, s):
+def q_multiply_shift(x, y, q, s):
     """Execute a multiplication between two Q-numbers x and y
     followed by a right shift s. The mathematical expression is:
 
@@ -991,7 +991,7 @@ def qmuls(x, y, q, s):
     y : PrimExpr
         The result.
     """
-    return call_intrin('int32', "tir.qmuls", x, y, q, s)
+    return call_intrin('int32', "tir.q_multiply_shift", x, y, q, s)
 
 def fmod(x, y):
     """Return the remainder of x divided by y with the same sign as x.

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -991,7 +991,7 @@ def qmuls(x, y, q, s):
     y : PrimExpr
         The result.
     """
-    return call_intrin(x.dtype, "tir.qmuls", x, y, q, s)
+    return call_intrin('int32', "tir.qmuls", x, y, q, s)
 
 def fmod(x, y):
     """Return the remainder of x divided by y with the same sign as x.

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -965,6 +965,27 @@ def popcount(x):
     """
     return call_intrin(x.dtype, "tir.popcount", x)
 
+def fixed_point_multiply(x, m, s):
+    """Execute a fixed point multiplication y = round(x * m * 2^s).
+    The default rounding rule is to the nearest value, rounding half up
+    (i.e., round(x.1) = x and round (x.5) = x+1)
+
+    Parameters
+    ----------
+    x : PrimExpr
+        Input argument.
+    m : PrimExpr
+        Integer multiplier
+    s : PrimExpr
+        Integer shift
+
+    Returns
+    -------
+    y : PrimExpr
+        The result.
+    """
+    return call_intrin(x.dtype, "tir.fixed_point_multiply", x, m, s)
+
 def fmod(x, y):
     """Return the remainder of x divided by y with the same sign as x.
 

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -277,20 +277,6 @@ Expr MakeClip(Expr a, double a_min, double a_max) {
 
 TVM_REGISTER_GLOBAL("relay.op._make.clip").set_body_typed(MakeClip);
 
-// relay.fixed_point_multiply
-TVM_REGISTER_NODE_TYPE(FixedPointMultiplyAttrs);
-
-RELAY_REGISTER_OP("fixed_point_multiply")
-    .describe(R"code( fixed point multiplication )code" TVM_ADD_FILELINE)
-    .set_num_inputs(1)
-    .add_argument("data", "Tensor", "The input tensor.")
-    .add_type_rel("Identity", IdentityRel)
-    .set_attr<TOpPattern>("TOpPattern", kElemWise)
-    .set_attr<TOpIsStateful>("TOpIsStateful", false)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
-    .set_attrs_type<FixedPointMultiplyAttrs>()
-    .set_support_level(3);
-
 RELAY_REGISTER_OP("clip")
     .describe(R"code(Clip tensor values.
 This function takes a tensor, a minimum value `a_min`, and a maximum value `a_max`, and returns a clipped tensor where all values below `a_min` are set to `a_min` and all values above `a_max` are set to `a_max`. `a_min` and `a_max` are cast to the tensor's dtype.
@@ -303,6 +289,29 @@ This function takes a tensor, a minimum value `a_min`, and a maximum value `a_ma
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
     .set_attrs_type<ClipAttrs>()
     .set_support_level(3);
+
+// relay.fixed_point_multiply
+TVM_REGISTER_NODE_TYPE(FixedPointMultiplyAttrs);
+
+TVM_REGISTER_GLOBAL("relay.op._make.fixed_point_multiply")
+    .set_body_typed([](Expr a, int32_t multiplier, int32_t shift) {
+      auto attrs = make_object<FixedPointMultiplyAttrs>();
+      attrs->multiplier = multiplier;
+      attrs->shift = shift;
+      static const Op& op = Op::Get("fixed_point_multiply");
+      return Call(op, {a}, Attrs(attrs), {});
+    });
+
+RELAY_REGISTER_OP("fixed_point_multiply")
+    .describe(R"code(fixed point multiplication)code" TVM_ADD_FILELINE)
+    .set_num_inputs(1)
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_type_rel("Identity", IdentityRel)
+    .set_attr<TOpPattern>("TOpPattern", kElemWise)
+    .set_attr<TOpIsStateful>("TOpIsStateful", false)
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
+    .set_attrs_type<FixedPointMultiplyAttrs>()
+    .set_support_level(10);
 
 RELAY_REGISTER_UNARY_OP("floor")
     .describe(R"code(Returns the floor of input array, computed element-wise.

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -277,6 +277,20 @@ Expr MakeClip(Expr a, double a_min, double a_max) {
 
 TVM_REGISTER_GLOBAL("relay.op._make.clip").set_body_typed(MakeClip);
 
+// relay.fixed_point_multiply
+TVM_REGISTER_NODE_TYPE(FixedPointMultiplyAttrs);
+
+RELAY_REGISTER_OP("fixed_point_multiply")
+    .describe(R"code( fixed point multiplication )code" TVM_ADD_FILELINE)
+    .set_num_inputs(1)
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_type_rel("Identity", IdentityRel)
+    .set_attr<TOpPattern>("TOpPattern", kElemWise)
+    .set_attr<TOpIsStateful>("TOpIsStateful", false)
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
+    .set_attrs_type<FixedPointMultiplyAttrs>()
+    .set_support_level(3);
+
 RELAY_REGISTER_OP("clip")
     .describe(R"code(Clip tensor values.
 This function takes a tensor, a minimum value `a_min`, and a maximum value `a_max`, and returns a clipped tensor where all values below `a_min` are set to `a_min` and all values above `a_max` are set to `a_max`. `a_min` and `a_max` are cast to the tensor's dtype.

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -159,11 +159,11 @@ Expr RequantizeLower(const Expr& input_tensor, const Expr& input_scale,
       const bool is_upward_rounding = (param->rounding == "UPWARD");
 
       // When using upward rounding (i.e., x.5 rounded to x+1), leverage
-      // the fixed_point_muliply intrinsic
-      scaled_int32_t = (is_upward_rounding ? relay::FixedPointMultiply(
-                                                 scaled_int32_t, fixed_point_multiplier, shift)
-                                           : FixedPointMultiply(scaled_int32_t, double_multiplier,
-                                                                input_shape, param->rounding));
+      // the FixedPointMultiply operator
+      scaled_int32_t =
+          (is_upward_rounding
+               ? FixedPointMultiply(scaled_int32_t, fixed_point_multiplier, shift)
+               : FixedPointMultiplyToNearest(scaled_int32_t, double_multiplier, input_shape));
     }
 
   } else {

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -153,9 +153,19 @@ Expr RequantizeLower(const Expr& input_tensor, const Expr& input_scale,
         static_cast<double>(input_scale_float) / static_cast<double>(output_scale_float);
     // Skip if input and output scales are same.
     if (!IsEqualScalar(input_scale, output_scale)) {
-      scaled_int32_t =
-          FixedPointMultiply(scaled_int32_t, double_multiplier, input_shape, param->rounding);
+      int32_t fixed_point_multiplier, shift;
+      std::tie(fixed_point_multiplier, shift) = GetFixedPointMultiplierShift(double_multiplier);
+
+      const bool is_upward_rounding = (param->rounding == "UPWARD");
+
+      // When using upward rounding (i.e., x.5 rounded to x+1), leverage
+      // the fixed_point_muliply intrinsic
+      scaled_int32_t = (is_upward_rounding ? relay::FixedPointMultiply(
+                                                 scaled_int32_t, fixed_point_multiplier, shift)
+                                           : FixedPointMultiply(scaled_int32_t, double_multiplier,
+                                                                input_shape, param->rounding));
     }
+
   } else {
     // This is per-channel (per=axis) quantization.
     std::vector<double> double_multipliers;

--- a/src/relay/qnn/util.cc
+++ b/src/relay/qnn/util.cc
@@ -56,8 +56,8 @@ std::pair<int32_t, int32_t> GetFixedPointMultiplierShift(double double_multiplie
   return std::make_pair(significand, exponent);
 }
 
-Expr FixedPointMultiply(Expr tensor, double multiplier, const Array<IndexExpr>& input_shape,
-                        const std::string& rounding) {
+Expr FixedPointMultiplyToNearest(Expr tensor, double multiplier,
+                                 const Array<IndexExpr>& input_shape) {
   // Choose high precision datatype to be int64. This is for avoiding overflow
   // in multiplication of two int32 values.
   DataType hp_dtype = DataType::Int(64);
@@ -90,19 +90,15 @@ Expr FixedPointMultiply(Expr tensor, double multiplier, const Array<IndexExpr>& 
   int64_t pos_rounding_value = (1ll << (total_right_shift - 1));
 
   Expr round_scalar;
-  if (rounding == "UPWARD") {
-    round_scalar = MakeConstantScalar(hp_dtype, pos_rounding_value);
-  } else if (rounding == "TONEAREST") {
-    auto pos_rounder = MakeConstantScalar(hp_dtype, pos_rounding_value);
-    auto neg_rounder = MakeConstantScalar(hp_dtype, pos_rounding_value - 1);
-    auto pos_rounder_t = Full(pos_rounder, input_shape, hp_dtype);
-    auto neg_rounder_t = Full(neg_rounder, input_shape, hp_dtype);
 
-    auto zero_t = Zeros(input_shape, hp_dtype);
-    round_scalar = Where(GreaterEqual(tensor, zero_t), pos_rounder_t, neg_rounder_t);
-  } else {
-    LOG(FATAL) << "Rounding mode " << rounding << " not supported.";
-  }
+  auto pos_rounder = MakeConstantScalar(hp_dtype, pos_rounding_value);
+  auto neg_rounder = MakeConstantScalar(hp_dtype, pos_rounding_value - 1);
+  auto pos_rounder_t = Full(pos_rounder, input_shape, hp_dtype);
+  auto neg_rounder_t = Full(neg_rounder, input_shape, hp_dtype);
+
+  auto zero_t = Zeros(input_shape, hp_dtype);
+  round_scalar = Where(GreaterEqual(tensor, zero_t), pos_rounder_t, neg_rounder_t);
+
   // Add the rounding scalar.
   tensor = Add(tensor, round_scalar);
 

--- a/src/relay/qnn/util.cc
+++ b/src/relay/qnn/util.cc
@@ -30,25 +30,6 @@ namespace tvm {
 namespace relay {
 namespace qnn {
 
-/*
- * \brief Convert FP32 representation into fixed point representation.
- * \param double_multplier The input FP32 number.
- * \return The pair of multiplier and shift for fixed point representation.
- * \note Converts a floating point number so that it can be represented by
- *       integers. The representation is
- *             float_number = (significand) * 2^(exponent)
- *
- *       The significand is a number between 0.5 and 1. This is represented by
- *       an integer number. For example, if it is int32, then the decimal point
- *       exists between bit 31 and 30 from LSB (or between first and second bit
- *       from the left).
- *
- *       Some examples are
- *           0.25 = (0.5) * 2^(-1)
- *           0.125 = (0.5) * 2^(-2)
- *
- *       Credit to TFLite reference implementation.
- */
 std::pair<int32_t, int32_t> GetFixedPointMultiplierShift(double double_multiplier) {
   int32_t significand, exponent;
   if (double_multiplier == 0.) {

--- a/src/relay/qnn/util.h
+++ b/src/relay/qnn/util.h
@@ -115,13 +115,12 @@ static inline int64_t get_const_int(const tvm::PrimExpr& x) {
 
 /*
  * \brief Fixed point multiplication between integer tensor with floating point
- scalar.
+ * scalar. This implementation rounds  to the nearest value when it is midway
+ * between two representable values.
  * \param tensor The quantized input tensor of dtype int64.
  * \param multiplier The scalar multiplier.
  * \param input_shape Shape of the input tensor.
- * \param rounding "UPWARD" or "TONEAREST". The rounding direction when the value
- is midway between" "two representable values.
- * \return The sequence of Relay ops for fixed point multiplication.
+ * \return The sequence of Relay ops for fixed point multiplication with TONEARES rounding.
 
  * \note Original compuation is scale_fp32 * quantized_tensor.  To convert into
  *       integer computation, the multiplication with fp32 scalar can be
@@ -135,8 +134,8 @@ static inline int64_t get_const_int(const tvm::PrimExpr& x) {
  *       2) Round the result.
  *       3) Right shift the result
  */
-Expr FixedPointMultiply(Expr tensor, double multiplier, const Array<IndexExpr>& input_shape,
-                        const std::string& rounding);
+Expr FixedPointMultiplyToNearest(Expr tensor, double multiplier,
+                                 const Array<IndexExpr>& input_shape);
 
 /*
  * \brief Fixed point multiplication between integer tensor with floating point

--- a/src/relay/qnn/util.h
+++ b/src/relay/qnn/util.h
@@ -70,6 +70,27 @@ static inline int32_t GetQmax(const DataType& dtype) {
   }
 }
 
+/*
+ * \brief Convert FP32 representation into fixed point representation.
+ * \param double_multplier The input FP32 number.
+ * \return The pair of multiplier and shift for fixed point representation.
+ * \note Converts a floating point number so that it can be represented by
+ *       integers. The representation is
+ *             float_number = (significand) * 2^(exponent)
+ *
+ *       The significand is a number between 0.5 and 1. This is represented by
+ *       an integer number. For example, if it is int32, then the decimal point
+ *       exists between bit 31 and 30 from LSB (or between first and second bit
+ *       from the left).
+ *
+ *       Some examples are
+ *           0.25 = (0.5) * 2^(-1)
+ *           0.125 = (0.5) * 2^(-2)
+ *
+ *       Credit to TFLite reference implementation.
+ */
+std::pair<int32_t, int32_t> GetFixedPointMultiplierShift(double double_multiplier);
+
 Expr RequantizeLower(const Expr& input_tensor, const Expr& input_scale,
                      const Expr& input_zero_point, const Expr& output_scale,
                      const Expr& output_zero_point, const RequantizeAttrs* param,

--- a/src/relay/transforms/pattern_util.h
+++ b/src/relay/transforms/pattern_util.h
@@ -495,6 +495,14 @@ inline Expr Round(Expr x) {
 
 inline Expr Clip(Expr x, double a_min, double a_max) { return MakeClip(x, a_min, a_max); }
 
+inline Expr FixedPointMultiply(Expr x, int32_t multiplier, int32_t shift) {
+  static const Op& op = Op::Get("fixed_point_multiply");
+  auto attrs = make_object<FixedPointMultiplyAttrs>();
+  attrs->multiplier = multiplier;
+  attrs->shift = shift;
+  return Call(op, {x}, Attrs(attrs), {});
+}
+
 inline Expr Add(Expr lhs, Expr rhs) {
   static const Op& op = Op::Get("add");
   return Call(op, {lhs, rhs}, Attrs(), {});

--- a/src/target/intrin_rule.cc
+++ b/src/target/intrin_rule.cc
@@ -138,14 +138,14 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.qmuls")
 
       // 1) Calculating the integer multiplier and integer shift
       PrimExpr zero = make_const(s.dtype(), 0);
-      PrimExpr left_shift = tir::Select((s > zero), s, zero);
+      PrimExpr left_shift = tir::Select(s > zero, s, zero);
       PrimExpr right_shift = tir::Select(s > zero, zero, -s);
 
       // 2) Multiply the integer multiplier
       x = tir::Select(left_shift != zero, x << cast(hp_dtype, left_shift), cast(hp_dtype, x));
 
       // 3) Perform the multiplication in higher precision.
-      x = x * y;
+      x = x * cast(hp_dtype, y);
 
       // 4) Find the rounding scalar
       PrimExpr total_right_shift = right_shift + q;

--- a/src/target/intrin_rule.cc
+++ b/src/target/intrin_rule.cc
@@ -115,7 +115,7 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.isinf")
       *rv = isinf(call->args[0]);
     });
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.qmuls")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.q_multiply_shift")
     .set_body([](const TVMArgs& args, TVMRetValue* rv) {
       using tir::make_const;
 

--- a/src/target/intrin_rule.cc
+++ b/src/target/intrin_rule.cc
@@ -115,6 +115,52 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.isinf")
       *rv = isinf(call->args[0]);
     });
 
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.fixed_point_multiply")
+    .set_body([](const TVMArgs& args, TVMRetValue* rv) {
+      using tir::make_const;
+
+      PrimExpr e = args[0];
+      const tir::CallNode* call = e.as<tir::CallNode>();
+      CHECK(call != nullptr);
+
+      PrimExpr tensor = call->args[0];
+      PrimExpr fixed_point_multiplier = call->args[1];
+      PrimExpr shift = call->args[2];
+
+      // Only int32 types are supported (any number of lanes is allowed)
+      CHECK(tensor.dtype().code() == DLDataTypeCode::kDLInt && tensor.dtype().bits() == 32);
+      CHECK(fixed_point_multiplier.dtype().code() == DLDataTypeCode::kDLInt &&
+            fixed_point_multiplier.dtype().bits() == 32);
+      CHECK(shift.dtype().code() == DLDataTypeCode::kDLInt && shift.dtype().bits() == 32);
+
+      DataType hp_dtype = DataType::Int(64, tensor.dtype().lanes());
+      DataType lp_dtype = DataType::Int(32, tensor.dtype().lanes());
+
+      // 1) Calculating the integer multiplier and integer shift
+      PrimExpr zero = make_const(shift.dtype(), 0);
+      PrimExpr left_shift = tir::Select((shift > zero), shift, zero);
+      PrimExpr right_shift = tir::Select(shift > zero, zero, -shift);
+
+      // 2) Multiply the integer multiplier
+      tensor = tir::Select(left_shift != zero, tensor << cast(hp_dtype, left_shift),
+                           cast(hp_dtype, tensor));
+
+      // 3) Perform the multiplication in higher precision.
+      tensor = tensor * fixed_point_multiplier;
+
+      // 4) Find the rounding scalar
+      PrimExpr total_right_shift = right_shift + 31;
+      PrimExpr pos_rounding_value = (make_const(hp_dtype, 1) << (total_right_shift - 1));
+
+      tensor = tensor + pos_rounding_value;
+
+      // 5) Simply right shift the result to get the final output.
+      tensor = tensor >> total_right_shift;
+
+      // 6) The fixed point multiplication keeps the value in int32 range. Casting back to int32.
+      *rv = cast(lp_dtype, tensor);
+    });
+
 }  // namespace intrin
 }  // namespace codegen
 }  // namespace tvm

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -89,6 +89,11 @@ TIR_DEFINE_BUILTIN_FUNC(if_then_else)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
 
+TIR_DEFINE_BUILTIN_FUNC(fixed_point_multiply)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TVectorizable>("TVectorizable", true);
+
 TIR_DEFINE_BUILTIN_FUNC(isnullptr).set_num_inputs(1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -89,7 +89,7 @@ TIR_DEFINE_BUILTIN_FUNC(if_then_else)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_BUILTIN_FUNC(fixed_point_multiply)
+TIR_DEFINE_BUILTIN_FUNC(qmuls)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -89,7 +89,7 @@ TIR_DEFINE_BUILTIN_FUNC(if_then_else)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_BUILTIN_FUNC(qmuls)
+TIR_DEFINE_BUILTIN_FUNC(q_multiply_shift)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -90,9 +90,9 @@ PrimExpr LargeUIntImm(DataType t, int64_t low, int64_t high) {
                    {make_const(DataType::UInt(32), low), make_const(DataType::UInt(32), high)});
 }
 
-// fixed_point_multiply
-PrimExpr fixed_point_multiply(PrimExpr x, PrimExpr m, PrimExpr s) {
-  return tir::Call(x.dtype(), tir::builtin::fixed_point_multiply(), {x, m, s});
+// Q-multiplication
+PrimExpr qmuls(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s) {
+  return tir::Call(x.dtype(), tir::builtin::qmuls(), {x, y, q, s});
 }
 
 // The public function with a quick checking path.

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -90,6 +90,11 @@ PrimExpr LargeUIntImm(DataType t, int64_t low, int64_t high) {
                    {make_const(DataType::UInt(32), low), make_const(DataType::UInt(32), high)});
 }
 
+// fixed_point_multiply
+PrimExpr fixed_point_multiply(PrimExpr x, PrimExpr m, PrimExpr s) {
+  return tir::Call(x.dtype(), tir::builtin::fixed_point_multiply(), {x, m, s});
+}
+
 // The public function with a quick checking path.
 void BinaryOpMatchTypes(PrimExpr& lhs, PrimExpr& rhs) {  // NOLINT(*)
   if (lhs.dtype() == rhs.dtype()) return;

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -91,8 +91,9 @@ PrimExpr LargeUIntImm(DataType t, int64_t low, int64_t high) {
 }
 
 // Q-multiplication
-PrimExpr qmuls(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s) {
-  return tir::Call(DataType::Int(32, x.dtype().lanes()), tir::builtin::qmuls(), {x, y, q, s});
+PrimExpr q_multiply_shift(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s) {
+  return tir::Call(DataType::Int(32, x.dtype().lanes()), tir::builtin::q_multiply_shift(),
+                   {x, y, q, s});
 }
 
 // The public function with a quick checking path.

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -92,7 +92,7 @@ PrimExpr LargeUIntImm(DataType t, int64_t low, int64_t high) {
 
 // Q-multiplication
 PrimExpr qmuls(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s) {
-  return tir::Call(x.dtype(), tir::builtin::qmuls(), {x, y, q, s});
+  return tir::Call(DataType::Int(32, x.dtype().lanes()), tir::builtin::qmuls(), {x, y, q, s});
 }
 
 // The public function with a quick checking path.

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -84,6 +84,22 @@ def test_clip():
     ref_res = np.clip(data, 1., 4.)
     np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=0.01)
 
+def test_fixed_point_multiply():
+    # Test 23 * 1/16
+    # [m,s] = [0.5, -3] = frexp(1/16)
+    # M = 0.5*2^31 = 1073741824
+    # so M = 1073741824 and s = -3
+
+    a = relay.var("a", relay.TensorType((10, 4), "int32"))
+    y = relay.fixed_point_multiply(a, 1073741824, -3)
+    yy = run_infer_type(y)
+    assert yy.checked_type == relay.TensorType((10, 4), "int32")
+
+    data = 23*np.ones((10, 4)).astype('int32')
+    intrp = create_executor()
+    op_res = intrp.evaluate(y, { a: relay.const(data) })
+    ref_res = np.ones((10, 4)).astype('int32')
+    np.testing.assert_allclose(op_res.asnumpy(), ref_res, atol=1)
 
 def test_reinterpret():
     a = relay.var("a", relay.TensorType((1000, 4), "float32"))
@@ -1034,3 +1050,4 @@ if __name__ == "__main__":
     test_isinf()
     test_unravel_index()
     test_sparse_to_dense()
+    test_fixed_point_multiply()

--- a/topi/python/topi/arm_cpu/conv2d_gemm.py
+++ b/topi/python/topi/arm_cpu/conv2d_gemm.py
@@ -175,7 +175,7 @@ def schedule_conv2d_gemm(cfg, s, out, final_out):
     if out != final_out:
         n, h, w, c = out.op.axis
         _, inner = s[out].split(c, 4)
-        s[C].compute_at(s[out],inner)
+        s[C].compute_at(s[out], inner)
         s[out].vectorize(inner)
 
 

--- a/topi/python/topi/arm_cpu/conv2d_gemm.py
+++ b/topi/python/topi/arm_cpu/conv2d_gemm.py
@@ -119,7 +119,7 @@ def compute_conv2d_gemm_without_weight_transform(cfg,
     C = te.compute((batches, M, N),
                    lambda b, x, y:
                    C_interleaved[b, x // 4, y // 4, idxm(x, 4), idxm(y, 4)],
-                   name="C", tag='injective')
+                   name="C")
 
     # --- Produce the conv output
     out_shape = (batches, OH, OW, OC)
@@ -129,7 +129,7 @@ def compute_conv2d_gemm_without_weight_transform(cfg,
     return out
 
 # Schedules
-def schedule_conv2d_gemm(cfg, s, out):
+def schedule_conv2d_gemm(cfg, s, out, final_out):
     """Create schedule for tensors"""
     C = out.op.input_tensors[0]
     C_interleaved = C.op.input_tensors[0]
@@ -172,8 +172,11 @@ def schedule_conv2d_gemm(cfg, s, out):
         s[C_interleaved].tensorize(yi, gem_v_dotprod)
 
     # Output transform
-    N, OH, OW, OC = out.shape
-    s[C].split(C.op.axis[1], OW)
-    s[C].compute_at(s[out], out.op.axis[3])
+    if out != final_out:
+        n, h, w, c = out.op.axis
+        _, inner = s[out].split(c, 4)
+        s[C].compute_at(s[out],inner)
+        s[out].vectorize(inner)
+
 
     return s

--- a/topi/python/topi/arm_cpu/conv2d_int8.py
+++ b/topi/python/topi/arm_cpu/conv2d_int8.py
@@ -137,11 +137,23 @@ def compute_conv2d_NHWC_quantized_without_transform(cfg, data, B, strides, paddi
 def schedule_conv2d_NHWC_quantized(cfg, outs):
     """Create schedule for tensors"""
     s = te.create_schedule([x.op for x in outs])
+    # Vectorize the output and then inline all the rest
+    out = outs[0]
+    n,h,w,c = out.op.axis
+    outer, inner = s[out].split(c, 4)
+    s[out].vectorize(inner)
 
     def _callback(op):
         """Traverse operators from computation graph"""
         if op.name == "conv2d_gemm_output":
-            schedule_conv2d_gemm(cfg, s, op.output(0))
+            conv_out = op.output(0)
+            schedule_conv2d_gemm(cfg, s, conv_out, out)
+            if out != conv_out:
+                s[conv_out].compute_at(s[out], inner)
+            else:
+                C = conv_out.op.input_tensors[0]
+                s[C].compute_at(s[out], inner)
+
 
     traverse_inline(s, outs[0].op, _callback)
     return s

--- a/topi/python/topi/arm_cpu/conv2d_int8.py
+++ b/topi/python/topi/arm_cpu/conv2d_int8.py
@@ -139,7 +139,7 @@ def schedule_conv2d_NHWC_quantized(cfg, outs):
     s = te.create_schedule([x.op for x in outs])
     # Vectorize the output and then inline all the rest
     out = outs[0]
-    n,h,w,c = out.op.axis
+    n, h, w, c = out.op.axis
     outer, inner = s[out].split(c, 4)
     s[out].vectorize(inner)
 

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -61,13 +61,11 @@ def schedule_injective(outs):
     """
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
-    x = outs[0]
-    dtype = x.op.input_tensors[0].dtype
-    print(dtype)
-    if dtype == 'int32':
-        max_vlen = 4
-    else:
-        max_vlen = 8
+    out = outs[0]
+    ins = out.op.input_tensors
+    dtype = ins[0].dtype if len(ins) else out.dtype
+    max_vlen = 4 if dtype == 'int32' else 8
+
     if list(s[x].op.axis):
         # do not vectorize for broadcast
         (io, ii) = s[x].split(list(s[x].op.axis)[-1], max_vlen)

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -62,13 +62,10 @@ def schedule_injective(outs):
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
     x = outs[0]
-    ins = x.op.input_tensors
-    dtype = ins[0].dtype if len(ins) > 0 else x.dtype
-    max_vlen = 4 if dtype == 'int32' else 8
 
     if list(s[x].op.axis):
         # do not vectorize for broadcast
-        (io, ii) = s[x].split(list(s[x].op.axis)[-1], max_vlen)
+        (io, ii) = s[x].split(list(s[x].op.axis)[-1], 4)
         s[x].vectorize(ii)
     tvm.te.schedule.AutoInlineInjective(s)
 

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -62,9 +62,15 @@ def schedule_injective(outs):
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
     x = outs[0]
+    dtype = x.op.input_tensors[0].dtype
+    print(dtype)
+    if dtype == 'int32':
+        max_vlen = 4
+    else:
+        max_vlen = 8
     if list(s[x].op.axis):
         # do not vectorize for broadcast
-        (io, ii) = s[x].split(list(s[x].op.axis)[-1], 8)
+        (io, ii) = s[x].split(list(s[x].op.axis)[-1], max_vlen)
         s[x].vectorize(ii)
     tvm.te.schedule.AutoInlineInjective(s)
 

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -61,9 +61,9 @@ def schedule_injective(outs):
     """
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
-    out = outs[0]
-    ins = out.op.input_tensors
-    dtype = ins[0].dtype if len(ins) > 0 else out.dtype
+    x = outs[0]
+    ins = x.op.input_tensors
+    dtype = ins[0].dtype if len(ins) > 0 else x.dtype
     max_vlen = 4 if dtype == 'int32' else 8
 
     if list(s[x].op.axis):

--- a/topi/python/topi/arm_cpu/injective.py
+++ b/topi/python/topi/arm_cpu/injective.py
@@ -63,7 +63,7 @@ def schedule_injective(outs):
     s = te.create_schedule([x.op for x in outs])
     out = outs[0]
     ins = out.op.input_tensors
-    dtype = ins[0].dtype if len(ins) else out.dtype
+    dtype = ins[0].dtype if len(ins) > 0 else out.dtype
     max_vlen = 4 if dtype == 'int32' else 8
 
     if list(s[x].op.axis):

--- a/topi/python/topi/arm_cpu/tensor_intrin.py
+++ b/topi/python/topi/arm_cpu/tensor_intrin.py
@@ -455,10 +455,10 @@ def dot_int8_int8_int32(int32_lanes, dtype='uint'):
 def _qmuls_arm(op):
     """
     Implementation of qmuls through arm intrinsics sqrdmulh and srshl
-    when q == 31. 
+    when q == 31.
 
-    Please note that this is introducing a small round-up error for 
-    some corner cases. This is because we are rounding twice instead 
+    Please note that this is introducing a small round-up error for
+    some corner cases. This is because we are rounding twice instead
     than only once. I.e.:
 
         * original qmuls: round(x*y*2^-s)

--- a/topi/python/topi/arm_cpu/tensor_intrin.py
+++ b/topi/python/topi/arm_cpu/tensor_intrin.py
@@ -471,7 +471,7 @@ def _qmuls_arm(op):
 
     # Don't use this intrinsic if we don't have a int32x4 vector
     # and if we are not multiplying q31 numbers
-    if x.dtype != "int32x4" and q == 31:
+    if x.dtype != "int32x4" or q.val != 31:
         return op
 
     # Case 1, shift is negative

--- a/topi/python/topi/math.py
+++ b/topi/python/topi/math.py
@@ -633,11 +633,9 @@ def fixed_point_multiply(x, multiplier, shift):
     def _compute(*indices):
         value = x(*indices)
         return tvm.tir.qmuls(value,
-                             tvm.tir.const(multiplier, x.dtype),
-                             tvm.tir.const(31, x.dtype),
-                             tvm.tir.const(shift, x.dtype))
-
-    assert x.dtype == "int32", "input tensor type needs to be int32"
+                             tvm.tir.const(multiplier, 'int32'),
+                             tvm.tir.const(31, 'int32'),
+                             tvm.tir.const(shift, 'int32'))
     return te.compute(x.shape, _compute)
 
 def cast(x, dtype):

--- a/topi/python/topi/math.py
+++ b/topi/python/topi/math.py
@@ -632,7 +632,8 @@ def fixed_point_multiply(x, multiplier, shift):
         value = x(*indices)
         m = tvm.tir.const(multiplier, x.dtype)
         s = tvm.tir.const(shift, x.dtype)
-        return tvm.tir.fixed_point_multiply(value, m, s)
+        q = tvm.tir.const(31, x.dtype)
+        return tvm.tir.qmuls(value, m, q, s)
 
     assert x.dtype == "int32", "input tensor type needs to be int32"
     return te.compute(x.shape, _compute)

--- a/topi/python/topi/math.py
+++ b/topi/python/topi/math.py
@@ -612,6 +612,30 @@ def clip(x, a_min, a_max):
         return tvm.te.max(tvm.te.min(value, const_max), const_min)
     return te.compute(x.shape, _compute)
 
+@tvm.te.tag_scope(tag=tag.ELEMWISE)
+def fixed_point_multiply(x, multiplier, shift):
+    """
+
+    Parameters
+    ----------
+    x :          tvm.te.Tensor or Expr
+                 Input argument.
+    multiplier:  Integer multiplier
+    shift:       Integer shift
+
+    Returns
+    -------
+    y : tvm.te.Tensor
+        The result.
+    """
+    def _compute(*indices):
+        value = x(*indices)
+        m = tvm.tir.const(multiplier, x.dtype)
+        s = tvm.tir.const(shift, x.dtype)
+        return tvm.tir.fixed_point_multiply(value, m, s)
+
+    assert x.dtype == "int32", "input tensor type needs to be int32"
+    return te.compute(x.shape, _compute)
 
 def cast(x, dtype):
     """Cast input to specified data type.

--- a/topi/python/topi/math.py
+++ b/topi/python/topi/math.py
@@ -630,10 +630,10 @@ def fixed_point_multiply(x, multiplier, shift):
     """
     def _compute(*indices):
         value = x(*indices)
-        m = tvm.tir.const(multiplier, x.dtype)
-        s = tvm.tir.const(shift, x.dtype)
-        q = tvm.tir.const(31, x.dtype)
-        return tvm.tir.qmuls(value, m, q, s)
+        return tvm.tir.qmuls(value,
+                             tvm.tir.const(multiplier, x.dtype),
+                             tvm.tir.const(31, x.dtype),
+                             tvm.tir.const(shift, x.dtype))
 
     assert x.dtype == "int32", "input tensor type needs to be int32"
     return te.compute(x.shape, _compute)

--- a/topi/python/topi/math.py
+++ b/topi/python/topi/math.py
@@ -614,16 +614,18 @@ def clip(x, a_min, a_max):
 
 @tvm.te.tag_scope(tag=tag.ELEMWISE)
 def fixed_point_multiply(x, multiplier, shift):
-    """
+    """Fixed point multiplication between data and a fixed point
+    constant expressed as multiplier * 2^(-shift), where multiplier
+    is a Q-number with 31 fractional bits
 
     Parameters
     ----------
-    x :          tvm.te.Tensor or Expr
-                 Input argument.
-    multiplier:  int
-                 Multiplier of a fixed floating point number described as multiplier*2^(shift)
-    shift:       int
-                 Shift of a fixed floating point number described as multiplier*2^(shift)
+    x : tvm.te.Tensor or Expr
+        Input argument.
+    multiplier : int
+        Multiplier of a fixed floating point number described as multiplier*2^(-shift).
+    shift : int
+        Shift of a fixed floating point number described as multiplier*2^(-shift).
 
     Returns
     -------
@@ -632,10 +634,10 @@ def fixed_point_multiply(x, multiplier, shift):
     """
     def _compute(*indices):
         value = x(*indices)
-        return tvm.tir.qmuls(value,
-                             tvm.tir.const(multiplier, 'int32'),
-                             tvm.tir.const(31, 'int32'),
-                             tvm.tir.const(shift, 'int32'))
+        return tvm.tir.q_multiply_shift(value,
+                                        tvm.tir.const(multiplier, 'int32'),
+                                        tvm.tir.const(31, 'int32'),
+                                        tvm.tir.const(shift, 'int32'))
     return te.compute(x.shape, _compute)
 
 def cast(x, dtype):

--- a/topi/python/topi/math.py
+++ b/topi/python/topi/math.py
@@ -620,8 +620,10 @@ def fixed_point_multiply(x, multiplier, shift):
     ----------
     x :          tvm.te.Tensor or Expr
                  Input argument.
-    multiplier:  Integer multiplier
-    shift:       Integer shift
+    multiplier:  int
+                 Multiplier of a fixed floating point number described as multiplier*2^(shift)
+    shift:       int
+                 Shift of a fixed floating point number described as multiplier*2^(shift)
 
     Returns
     -------


### PR DESCRIPTION
### RFC
This PR is based on the following RFC: https://discuss.tvm.ai/t/rfc-using-arm-intrinsics-to-implement-fixed-point-multiplication-in-tvm

### High level description of the submission
The idea is to create a TIR intrinsic `fixed_point_multiply` that can be overloaded (by the means of `tvm.target.intrin.register_intrin_rule`) and use AArch64 intrinsics (other vendors can provide their own implementation)

The TIR default intrinsic is registered in: `tvm/src/target/intrin_rule.cc`
The overload for AArch64 lives in `tvm/topi/python/topi/arm_cpu/tensor_intrin.py`
 
