### PR TITLE
[CI] Bump tvmai/ci-cpu to 0.63 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 
 ci_lint = "tvmai/ci-lint:v0.61"
 ci_gpu = "tvmai/ci-gpu:v0.64"
-ci_cpu = "tvmai/ci-cpu:v0.62"
+ci_cpu = "tvmai/ci-cpu:v0.63"
 ci_wasm = "tvmai/ci-wasm:v0.60"
 ci_i386 = "tvmai/ci-i386:v0.52"
 


### PR DESCRIPTION
After #5936, the latest docker image with DNNL is `tvmai/ci-cpu:0.63`.

cc @tqchen @zhiics 