### PR TITLE
[TARGET] each option of target str should only contain one '='

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -180,16 +180,16 @@ def arm_cpu(model='unknown', options=None):
         Additional options
     """
     trans_table = {
-        "pixel2":    ["-model=snapdragon835", "-mtriple=arm64-linux-android -mattr=+neon"],
-        "mate10":    ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
-        "mate10pro": ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
-        "p20":       ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
-        "p20pro":    ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
-        "rasp3b":    ["-model=bcm2837", "-mtriple=armv7l-linux-gnueabihf -mattr=+neon"],
-        "rasp4b":    ["-model=bcm2711", "-mtriple=arm-linux-gnueabihf -mattr=+neon"],
-        "rk3399":    ["-model=rk3399", "-mtriple=aarch64-linux-gnu -mattr=+neon"],
-        "pynq":      ["-model=pynq", "-mtriple=armv7a-linux-eabi -mattr=+neon"],
-        "ultra96":   ["-model=ultra96", "-mtriple=aarch64-linux-gnu -mattr=+neon"],
+        "pixel2":    ["-model=snapdragon835", "-mtriple=arm64-linux-android", "-mattr=+neon"],
+        "mate10":    ["-model=kirin970", "-mtriple=arm64-linux-android", "-mattr=+neon"],
+        "mate10pro": ["-model=kirin970", "-mtriple=arm64-linux-android", "-mattr=+neon"],
+        "p20":       ["-model=kirin970", "-mtriple=arm64-linux-android", "-mattr=+neon"],
+        "p20pro":    ["-model=kirin970", "-mtriple=arm64-linux-android", "-mattr=+neon"],
+        "rasp3b":    ["-model=bcm2837", "-mtriple=armv7l-linux-gnueabihf", "-mattr=+neon"],
+        "rasp4b":    ["-model=bcm2711", "-mtriple=arm-linux-gnueabihf", "-mattr=+neon"],
+        "rk3399":    ["-model=rk3399", "-mtriple=aarch64-linux-gnu", "-mattr=+neon"],
+        "pynq":      ["-model=pynq", "-mtriple=armv7a-linux-eabi", "-mattr=+neon"],
+        "ultra96":   ["-model=ultra96", "-mtriple=aarch64-linux-gnu", "-mattr=+neon"],
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -16,6 +16,7 @@
 # under the License.
 import tvm
 from tvm import te
+from tvm.target import cuda, rocm, mali, intel_graphics, arm_cpu, vta, bifrost, hexagon
 
 @tvm.target.generic_func
 def mygeneric(data):
@@ -67,6 +68,14 @@ def test_target_string_parse():
     assert tvm.target.mali().device_name == "mali"
     assert tvm.target.arm_cpu().device_name == "arm_cpu"
 
+
+def test_target_create():
+    targets = [cuda(), rocm(), mali(), intel_graphics(), arm_cpu('rk3399'), vta(), bifrost()]
+    for tgt in targets:
+        assert tgt is not None
+
+
 if __name__ == "__main__":
     test_target_dispatch()
     test_target_string_parse()
+    test_target_create()


### PR DESCRIPTION
src/target/target_id.cc ParseAttrsFromRawString L222:
if ((pos = FindUniqueSubstr(s, "=")) != -1)
require option contains only one '='

The CHECK code in FindUniqueSubstr will cause build fail.

Signed-off-by: windclarion <windclarion@gmail.com>


