### PR TITLE
[RUNTIME] if a param not in input, we should still consume it's data

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -198,7 +198,11 @@ void GraphRuntime::LoadParams(dmlc::Stream* strm) {
   CHECK(size == names.size()) << "Invalid parameters file format";
   for (size_t i = 0; i < size; ++i) {
     int in_idx = GetInputIndex(names[i]);
-    if (in_idx < 0) continue;
+    if (in_idx < 0) {
+      NDArray temp;
+      temp.Load(strm);
+      continue;
+    }
     uint32_t eid = this->entry_id(input_nodes_[in_idx], 0);
     CHECK_LT(eid, data_entry_.size());
 


### PR DESCRIPTION
so the read pointer of stream can move forward, or else next read operation will read wrong data.

Signed-off-by: windclarion <windclarion@gmail.com>


