### PR TITLE
Add support for tflite arg_min and arg_max

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1637,7 +1637,7 @@ class OperatorConverter(object):
         return self._convert_reduce(_op.reduce.any, op)
 
     def _convert_arg_min_max(self, relay_op, op):
-        """Generic method to convert TFLite arg_min_max"""
+        """Generic method converting TFLite arg_min_max"""
         try:
             from tflite.BuiltinOptions import BuiltinOptions
             from tflite.ArgMinOptions import ArgMinOptions

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1658,8 +1658,8 @@ class OperatorConverter(object):
         axis_tensor = input_tensors[1]
         # In Tensorflow, `axis` argument is a Tensor, not attribute. We
         # support the case where it inputs from a scalar constant.
-        axis_value = self.get_tensor_value( axis_tensor )
-        assert( 1 == axis_value.size )
+        axis_value = self.get_tensor_value(axis_tensor)
+        assert axis_value.size == 1
         axis_value = axis_value.item()
 
         if op.BuiltinOptionsType() == BuiltinOptions.ArgMinOptions:

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -1755,6 +1755,30 @@ def test_all_reduce():
     if package_version.parse(tf.VERSION) >= package_version.parse('1.15.0'):
         _test_forward_reduce(_test_reduce_any, dtype="bool")
 
+#######################################################################
+# Arg_min_max
+# -----------
+
+def _test_arg_min_max(math_op, data, axis, output_dtype):
+    """ One iteration of arg_min_max"""
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        out = math_op(input=in_data, axis=axis, output_type=output_dtype)
+        compare_tflite_with_tvm(data, 'Placeholder:0', [in_data], [out])
+
+def _test_arg_min(data, axis, output_dtype):
+    """ One iteration of arg_min """
+    return _test_arg_min_max(math_ops.argmin, data, axis, output_dtype)
+
+def _test_arg_max(data, axis, output_dtype):
+    """ One iteration of arg_max """
+    return _test_arg_min_max(math_ops.argmax, data, axis, output_dtype)
+
+def test_forward_arg_min_max():
+    data = np.array(np.random.uniform(0, 100, (3, 4)), dtype=np.float32)
+    for axis in [None, 0, 1, -1]:
+        _test_arg_min(data=data, axis=axis, output_dtype=np.int32)
+        _test_arg_max(data=data, axis=axis, output_dtype=np.int32)
 
 #######################################################################
 # Select, Where
@@ -2834,6 +2858,7 @@ if __name__ == '__main__':
     test_forward_sparse_to_dense()
     test_forward_select()
     test_forward_quantize_dequantize()
+    test_forward_arg_min_max()
 
     # NN
     test_forward_convolution()

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -1777,16 +1777,16 @@ def _test_arg_min_max(math_op, data, axis, quantized=False):
             compare_tflite_with_tvm([data], [in_data.name], [in_data], [out])
 
 def test_forward_arg_min_max():
-    data = np.array(np.random.uniform(0, 100, (3, 4)), dtype=np.uint8)
     # test quantized
-    # There is no quantized version of ArgMin
-    for axis in [None, 0, 1, -1]:
-        _test_arg_min_max(math_ops.argmax, data, axis, True)
+    for data in [np.array(np.random.uniform(-100, 100, (3, 4)), dtype=np.uint8)]:
+        # There is no quantized version of ArgMin
+        for axis in [None, 0, 1, -1]:
+            _test_arg_min_max(math_ops.argmax, data, axis, True)
 
-    data = np.array(np.random.uniform(0, 100, (3, 4)), dtype=np.float32)
-    for axis in [None, 0, 1, -1]:
-        _test_arg_min_max(math_ops.argmax, data, axis)
-        _test_arg_min_max(math_ops.argmin, data, axis)
+    for data in [np.array(np.random.uniform(-100, 100, (3, 4)), dtype=np.float32)]:
+        for axis in [None, 0, 1, -1]:
+            _test_arg_min_max(math_ops.argmax, data, axis)
+            _test_arg_min_max(math_ops.argmin, data, axis)
 
 
 #######################################################################


### PR DESCRIPTION
### "Add support for tflite arg_min and arg_max"

This is an updated version of abandoned PR [[Relay][Frontend][TFLite] Add parser support for arg_min_max #4704](https://github.com/apache/incubator-tvm/pull/4704) rebased on top of current master with small updates related to tflite 2.1.0.

Please note unit tests for arg_max and arg_min emit following warning:
/workspace/src/te/schedule/bound.cc:119: not in feed graph consumer = compute(T_multiply_red_temp, 0x53f5050)