### PR TITLE
[Target] Use TargetNode::attrs for Target serialization

### DIFF
--- a/apps/android_camera/models/prepare_model.py
+++ b/apps/android_camera/models/prepare_model.py
@@ -28,7 +28,7 @@ import tvm.relay as relay
 from tvm.contrib import util, ndk, graph_runtime as runtime
 from tvm.contrib.download import download_testdata, download
 
-target = 'llvm -target=arm64-linux-android'
+target = 'llvm -mtriple=arm64-linux-android'
 target_host = None
 
 def del_dir(target: Union[Path, str], only_if_empty: bool = False):

--- a/apps/android_rpc/tests/android_rpc_test.py
+++ b/apps/android_rpc/tests/android_rpc_test.py
@@ -36,7 +36,7 @@ key = "android"
 # Change target configuration.
 # Run `adb shell cat /proc/cpuinfo` to find the arch.
 arch = "arm64"
-target = "llvm -target=%s-linux-android" % arch
+target = "llvm -mtriple=%s-linux-android" % arch
 
 # whether enable to execute test on OpenCL target
 test_opencl = False

--- a/apps/ios_rpc/tests/ios_rpc_mobilenet.py
+++ b/apps/ios_rpc/tests/ios_rpc_mobilenet.py
@@ -52,7 +52,7 @@ key = "iphone"
 #sdk = "iphonesimulator"
 arch = "arm64"
 sdk = "iphoneos"
-target_host = "llvm -target=%s-apple-darwin" % arch
+target_host = "llvm -mtriple=%s-apple-darwin" % arch
 
 # override metal compiler to compile to iphone
 @tvm.register_func("tvm_callback_metal_compile")

--- a/apps/ios_rpc/tests/ios_rpc_test.py
+++ b/apps/ios_rpc/tests/ios_rpc_test.py
@@ -46,7 +46,7 @@ key = "iphone"
 # Change target configuration, this is setting for iphone6s
 arch = "arm64"
 sdk = "iphoneos"
-target = "llvm -target=%s-apple-darwin" % arch
+target = "llvm -mtriple=%s-apple-darwin" % arch
 
 # override metal compiler to compile to iphone
 @tvm.register_func("tvm_callback_metal_compile")

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -58,9 +58,8 @@ class TargetNode : public Object {
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("id", &id);
     v->Visit("tag", &tag);
-    v->Visit("keys_", &keys);
+    v->Visit("keys", &keys);
     v->Visit("attrs", &attrs);
-    v->Visit("_str_repr_", &str_repr_);
   }
 
   template <typename TObjectRef>

--- a/include/tvm/target/target_id.h
+++ b/include/tvm/target/target_id.h
@@ -60,6 +60,21 @@ class TargetIdNode : public Object {
   int device_type;
   /*! \brief Default keys of the target */
   Array<String> default_keys;
+
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("name", &name);
+    v->Visit("device_type", &device_type);
+    v->Visit("default_keys", &default_keys);
+  }
+
+  Map<String, ObjectRef> ParseAttrsFromRaw(const std::vector<std::string>& options) const;
+
+  Optional<String> StringifyAttrsToRaw(const Map<String, ObjectRef>& attrs) const;
+
+  static constexpr const char* _type_key = "TargetId";
+  TVM_DECLARE_FINAL_OBJECT_INFO(TargetIdNode, Object);
+
+ private:
   /*! \brief Stores the required type_key and type_index of a specific attr of a target */
   struct ValueTypeInfo {
     String type_key;
@@ -68,22 +83,12 @@ class TargetIdNode : public Object {
     std::unique_ptr<ValueTypeInfo> val;
   };
 
-  void VisitAttrs(AttrVisitor* v) {
-    v->Visit("name", &name);
-    v->Visit("device_type", &device_type);
-    v->Visit("default_keys", &default_keys);
-  }
-
-  Map<String, ObjectRef> ParseAttrsFromRawString(const std::vector<std::string>& options);
-
-  static constexpr const char* _type_key = "TargetId";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TargetIdNode, Object);
-
- private:
   uint32_t AttrRegistryIndex() const { return index_; }
   String AttrRegistryName() const { return name; }
   /*! \brief Perform schema validation */
   void ValidateSchema(const Map<String, ObjectRef>& config) const;
+  /*! \brief Verify if the obj is consistent with the type info */
+  void VerifyTypeInfo(const ObjectRef& obj, const TargetIdNode::ValueTypeInfo& info) const;
   /*! \brief A hash table that stores the type information of each attr of the target key */
   std::unordered_map<String, ValueTypeInfo> key2vtype_;
   /*! \brief A hash table that stores the default value of each attr of the target key */

--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -147,6 +147,10 @@ def decode(row, protocol='json'):
             return None
 
         tgt, task_name, task_args, task_kwargs = row["input"]
+        tgt = str(tgt)
+        if "-target" in tgt:
+            logger.warning("\"-target\" is deprecated, use \"-mtriple\" instead.")
+            tgt = tgt.replace("-target", "-mtriple")
         tgt = _target.create(str(tgt))
 
         def clean_json_to_python(x):

--- a/python/tvm/exec/measure_peak.py
+++ b/python/tvm/exec/measure_peak.py
@@ -18,7 +18,7 @@
 
 e.g.
 python3 -m tvm.exec.measure_peak --target cuda --rpc-host 0.0.0.0 --rpc-port 9090
-python3 -m tvm.exec.measure_peak --target opencl --target-host "llvm -target=aarch64-linux-gnu" \
+python3 -m tvm.exec.measure_peak --target opencl --target-host "llvm -mtriple=aarch64-linux-gnu" \
         --rpc-host $TVM_OPENCL_DEVICE_HOST --rpc-port 9090
 """
 

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -234,7 +234,7 @@ def is_fast_int8_on_intel():
 def is_fast_int8_on_arm():
     """ Checks whether the hardware has support for fast Int8 arithmetic operations. """
     target = tvm.target.Target.current(allow_none=False)
-    return '+v8.2a,+dotprod' in target.mattr
+    return "+v8.2a" in target.mattr and "+dotprod" in target.mattr
 
 def is_aarch64_arm():
     """ Checks whether we are compiling for an AArch64 target. """

--- a/python/tvm/target/__init__.py
+++ b/python/tvm/target/__init__.py
@@ -26,7 +26,7 @@ The list of options include:
 
    The device name.
 
-- **-mtriple=<target triple>** or **-target**
+- **-mtriple=<target triple>**
 
    Specify the target triple, which is useful for cross
    compilation.

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -43,19 +43,6 @@ class Target(Object):
     - :py:func:`tvm.target.mali` create Mali target
     - :py:func:`tvm.target.intel_graphics` create Intel Graphics target
     """
-    def __new__(cls):
-        # Always override new to enable class
-        obj = Object.__new__(cls)
-        obj._keys = None
-        obj._libs = None
-        return obj
-
-    @property
-    def keys(self):
-        if not self._keys:
-            self._keys = [str(k) for k in self.keys_]
-        return self._keys
-
     def __enter__(self):
         _ffi_api.EnterTargetScope(self)
         return self
@@ -103,14 +90,11 @@ class Target(Object):
     @property
     def mattr(self):
         """Returns the mattr from the target if it exists."""
-        return self.attrs.get("mattr", "")
+        return list(self.attrs.get("mattr", []))
 
     @property
     def libs(self):
-        if not self._libs:
-            self._libs = list(self.attrs.get("libs", ""))
-        return self._libs
-
+        return list(self.attrs.get("libs", []))
 
 
 def _merge_opts(opts, new_opts):

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -178,16 +178,16 @@ def arm_cpu(model='unknown', options=None):
         Additional options
     """
     trans_table = {
-        "pixel2":    ["-model=snapdragon835", "-target=arm64-linux-android -mattr=+neon"],
-        "mate10":    ["-model=kirin970", "-target=arm64-linux-android -mattr=+neon"],
-        "mate10pro": ["-model=kirin970", "-target=arm64-linux-android -mattr=+neon"],
-        "p20":       ["-model=kirin970", "-target=arm64-linux-android -mattr=+neon"],
-        "p20pro":    ["-model=kirin970", "-target=arm64-linux-android -mattr=+neon"],
-        "rasp3b":    ["-model=bcm2837", "-target=armv7l-linux-gnueabihf -mattr=+neon"],
-        "rasp4b":    ["-model=bcm2711", "-target=arm-linux-gnueabihf -mattr=+neon"],
-        "rk3399":    ["-model=rk3399", "-target=aarch64-linux-gnu -mattr=+neon"],
-        "pynq":      ["-model=pynq", "-target=armv7a-linux-eabi -mattr=+neon"],
-        "ultra96":   ["-model=ultra96", "-target=aarch64-linux-gnu -mattr=+neon"],
+        "pixel2":    ["-model=snapdragon835", "-mtriple=arm64-linux-android -mattr=+neon"],
+        "mate10":    ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
+        "mate10pro": ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
+        "p20":       ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
+        "p20pro":    ["-model=kirin970", "-mtriple=arm64-linux-android -mattr=+neon"],
+        "rasp3b":    ["-model=bcm2837", "-mtriple=armv7l-linux-gnueabihf -mattr=+neon"],
+        "rasp4b":    ["-model=bcm2711", "-mtriple=arm-linux-gnueabihf -mattr=+neon"],
+        "rk3399":    ["-model=rk3399", "-mtriple=aarch64-linux-gnu -mattr=+neon"],
+        "pynq":      ["-model=pynq", "-mtriple=armv7a-linux-eabi -mattr=+neon"],
+        "ultra96":   ["-model=ultra96", "-mtriple=aarch64-linux-gnu -mattr=+neon"],
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 
@@ -246,7 +246,7 @@ def hexagon(cpu_ver='v66', sim_args=None, hvx=128):
         Size of hvx register. Value of 0 indicates disabled hvx.
     """
     # Example compiler arguments
-    # llvm -target=hexagon -mcpu=hexagonv66 -mattr=+hvxv66,+hvx-length128b
+    # llvm -mtriple=hexagon -mcpu=hexagonv66 -mattr=+hvxv66,+hvx-length128b
 
     # Check for valid codegen cpu
     valid_hex = ['v60', 'v62', 'v65', 'v66', 'v67', 'v67t']
@@ -261,7 +261,7 @@ def hexagon(cpu_ver='v66', sim_args=None, hvx=128):
 
     # Target string
     def create_target(cpu_ver):
-        target = ' -target=hexagon'
+        target = ' -mtriple=hexagon'
         mcpu = ' -mcpu=hexagon' + cpu_ver
         mattr = ''
         # HVX enable

--- a/rust/runtime/tests/test_wasm32/src/build_test_lib.py
+++ b/rust/runtime/tests/test_wasm32/src/build_test_lib.py
@@ -32,7 +32,7 @@ def main():
     s = tvm.te.create_schedule(C.op)
     s[C].parallel(s[C].op.axis[0])
     print(tvm.lower(s, [A, B, C], simple_mode=True))
-    tvm.build(s, [A, B, C], 'llvm -target=wasm32-unknown-unknown --system-lib').save(osp.join(sys.argv[1], 'test.o'))
+    tvm.build(s, [A, B, C], 'llvm -mtriple=wasm32-unknown-unknown --system-lib').save(osp.join(sys.argv[1], 'test.o'))
 
 if __name__ == '__main__':
     main()

--- a/rust/tvm-graph-rt/tests/test_wasm32/src/build_test_lib.py
+++ b/rust/tvm-graph-rt/tests/test_wasm32/src/build_test_lib.py
@@ -32,7 +32,7 @@ def main():
     s = tvm.te.create_schedule(C.op)
     s[C].parallel(s[C].op.axis[0])
     print(tvm.lower(s, [A, B, C], simple_mode=True))
-    tvm.build(s, [A, B, C], 'llvm -target=wasm32-unknown-unknown --system-lib').save(osp.join(sys.argv[1], 'test.o'))
+    tvm.build(s, [A, B, C], 'llvm -mtriple=wasm32-unknown-unknown --system-lib').save(osp.join(sys.argv[1], 'test.o'))
 
 if __name__ == '__main__':
     main()

--- a/src/target/llvm/codegen_blob.cc
+++ b/src/target/llvm/codegen_blob.cc
@@ -33,7 +33,7 @@ namespace codegen {
 std::pair<std::unique_ptr<llvm::Module>, std::shared_ptr<llvm::LLVMContext>> CodeGenBlob(
     const std::string& data, bool system_lib, const std::string& target_triple) {
   InitializeLLVM();
-  auto tm = GetLLVMTargetMachine(std::string("-target ") + target_triple);
+  auto tm = GetLLVMTargetMachine(std::string("-mtriple ") + target_triple);
   auto triple = tm->getTargetTriple();
   auto ctx = std::make_shared<llvm::LLVMContext>();
   std::string module_name = "devc";

--- a/src/target/llvm/llvm_common.cc
+++ b/src/target/llvm/llvm_common.cc
@@ -73,9 +73,8 @@ void ParseLLVMTargetOptions(const std::string& target_str, std::string* triple, 
   bool soft_float_abi = false;
   std::string key, value;
   std::istringstream is(target_str.substr(start, target_str.length() - start));
-
   while (is >> key) {
-    if (key == "--system-lib" || key == "-system-lib") {
+    if (key == "-system-lib" || key == "-system-lib=0" || key == "-system-lib=1") {
       continue;
     }
     size_t pos = key.find('=');
@@ -103,7 +102,7 @@ void ParseLLVMTargetOptions(const std::string& target_str, std::string* triple, 
       } else {
         LOG(FATAL) << "invalid -mfloat-abi option " << value;
       }
-    } else if (key == "-device" || key == "-libs" || key == "-model") {
+    } else if (key == "-device" || key == "-libs" || key == "-model" || key == "-keys") {
       // pass
     } else {
       LOG(FATAL) << "unknown option " << key;

--- a/src/target/llvm/llvm_common.cc
+++ b/src/target/llvm/llvm_common.cc
@@ -85,7 +85,7 @@ void ParseLLVMTargetOptions(const std::string& target_str, std::string* triple, 
     } else {
       CHECK(is >> value) << "Unspecified value for option " << key;
     }
-    if (key == "-target" || key == "-mtriple") {
+    if (key == "-mtriple") {
       *triple = value;
     } else if (key == "-mcpu") {
       *mcpu = value;

--- a/src/target/llvm/llvm_common.cc
+++ b/src/target/llvm/llvm_common.cc
@@ -102,10 +102,6 @@ void ParseLLVMTargetOptions(const std::string& target_str, std::string* triple, 
       } else {
         LOG(FATAL) << "invalid -mfloat-abi option " << value;
       }
-    } else if (key == "-device" || key == "-libs" || key == "-model" || key == "-keys") {
-      // pass
-    } else {
-      LOG(FATAL) << "unknown option " << key;
     }
   }
 

--- a/src/target/llvm/llvm_common.h
+++ b/src/target/llvm/llvm_common.h
@@ -89,7 +89,7 @@ void InitializeLLVM();
 
 /*!
  * \brief Parse target options
- * \param target_str Target string, in format "llvm -target=xxx -mcpu=xxx"
+ * \param target_str Target string, in format "llvm -mtriple=xxx -mcpu=xxx"
  * \param triple Target triple
  * \param mcpu cpu info
  * \param options the options
@@ -100,7 +100,7 @@ void ParseLLVMTargetOptions(const std::string& target_str, std::string* triple, 
 
 /*!
  * \brief Get target machine from target_str string.
- * \param target_str Target string, in format "llvm -target=xxx -mcpu=xxx"
+ * \param target_str Target string, in format "llvm -mtriple=xxx -mcpu=xxx"
  * \param allow_null Whether allow null to be returned.
  * \return target machine
  */

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -251,7 +251,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
       target_ = pstr->getString().str();
     } else {
       std::ostringstream os;
-      os << "llvm -target " << module_->getTargetTriple();
+      os << "llvm -mtriple " << module_->getTargetTriple();
       target_ = os.str();
     }
     mptr_ = module_.get();

--- a/src/target/target_id.cc
+++ b/src/target/target_id.cc
@@ -23,6 +23,8 @@
  */
 #include <tvm/target/target_id.h>
 
+#include <algorithm>
+
 #include "../node/attr_registry.h"
 #include "../runtime/object_internal.h"
 
@@ -57,7 +59,8 @@ const TargetId& TargetId::Get(const String& target_id_name) {
   return reg->id_;
 }
 
-void VerifyTypeInfo(const ObjectRef& obj, const TargetIdNode::ValueTypeInfo& info) {
+void TargetIdNode::VerifyTypeInfo(const ObjectRef& obj,
+                                  const TargetIdNode::ValueTypeInfo& info) const {
   CHECK(obj.defined()) << "Object is None";
   if (!runtime::ObjectInternal::DerivedFrom(obj.get(), info.type_index)) {
     LOG(FATAL) << "AttributeError: expect type \"" << info.type_key << "\" but get "
@@ -205,8 +208,30 @@ static inline ObjectRef ParseScalar(uint32_t type_index, const std::string& str)
   return ObjectRef(nullptr);
 }
 
-Map<String, ObjectRef> TargetIdNode::ParseAttrsFromRawString(
-    const std::vector<std::string>& options) {
+static inline Optional<String> StringifyScalar(const ObjectRef& obj) {
+  if (const auto* p = obj.as<IntImmNode>()) {
+    return String(std::to_string(p->value));
+  }
+  if (const auto* p = obj.as<StringObj>()) {
+    return GetRef<String>(p);
+  }
+  return NullOpt;
+}
+
+static inline Optional<String> Join(const std::vector<String>& array, char separator) {
+  if (array.empty()) {
+    return NullOpt;
+  }
+  std::ostringstream os;
+  os << array[0];
+  for (size_t i = 1; i < array.size(); ++i) {
+    os << separator << array[i];
+  }
+  return String(os.str());
+}
+
+Map<String, ObjectRef> TargetIdNode::ParseAttrsFromRaw(
+    const std::vector<std::string>& options) const {
   std::unordered_map<String, ObjectRef> attrs;
   for (size_t iter = 0, end = options.size(); iter < end;) {
     std::string s = options[iter++];
@@ -245,6 +270,9 @@ Map<String, ObjectRef> TargetIdNode::ParseAttrsFromRawString(
       }
       LOG(FATAL) << os.str();
     }
+    // check if `name` has been set once
+    CHECK(!attrs.count(name)) << "AttributeError: key \"" << name
+                              << "\" appears more than once in the target string";
     // then `name` is valid, let's parse them
     // only several types are supported when parsing raw string
     const auto& info = it->second;
@@ -285,6 +313,39 @@ Map<String, ObjectRef> TargetIdNode::ParseAttrsFromRawString(
   return attrs;
 }
 
+Optional<String> TargetIdNode::StringifyAttrsToRaw(const Map<String, ObjectRef>& attrs) const {
+  std::ostringstream os;
+  std::vector<String> keys;
+  for (const auto& kv : attrs) {
+    keys.push_back(kv.first);
+  }
+  std::sort(keys.begin(), keys.end());
+  std::vector<String> result;
+  for (const auto& key : keys) {
+    const ObjectRef& obj = attrs[key];
+    Optional<String> value = NullOpt;
+    if (const auto* array = obj.as<ArrayNode>()) {
+      std::vector<String> items;
+      for (const ObjectRef& item : *array) {
+        Optional<String> str = StringifyScalar(item);
+        if (str.defined()) {
+          items.push_back(str.value());
+        } else {
+          items.clear();
+          break;
+        }
+      }
+      value = Join(items, ',');
+    } else {
+      value = StringifyScalar(obj);
+    }
+    if (value.defined()) {
+      result.push_back("-" + key + "=" + value.value());
+    }
+  }
+  return Join(result, ' ');
+}
+
 // TODO(@junrushao1994): remove some redundant attributes
 
 TVM_REGISTER_TARGET_ID("llvm")
@@ -294,7 +355,7 @@ TVM_REGISTER_TARGET_ID("llvm")
     .add_attr_option<String>("model")
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<String>("mcpu")
-    .add_attr_option<String>("mattr")
+    .add_attr_option<Array<String>>("mattr")
     .add_attr_option<String>("mtriple")
     .add_attr_option<String>("target")  // FIXME: rename to mtriple
     .set_default_keys({"cpu"})

--- a/src/target/target_id.cc
+++ b/src/target/target_id.cc
@@ -357,7 +357,6 @@ TVM_REGISTER_TARGET_ID("llvm")
     .add_attr_option<String>("mcpu")
     .add_attr_option<Array<String>>("mattr")
     .add_attr_option<String>("mtriple")
-    .add_attr_option<String>("target")  // FIXME: rename to mtriple
     .set_default_keys({"cpu"})
     .set_device_type(kDLCPU);
 

--- a/tests/cpp/build_module_test.cc
+++ b/tests/cpp/build_module_test.cc
@@ -56,7 +56,9 @@ TEST(BuildModule, Basic) {
   auto module = build(lowered, target, Target());
 
   auto mali_target = Target::Create("opencl -model=Mali-T860MP4@800Mhz -device=mali");
-  CHECK_EQ(mali_target->str(), "opencl -model=Mali-T860MP4@800Mhz -device=mali");
+  CHECK_EQ(
+      mali_target->str(),
+      "opencl -keys=mali,opencl,gpu -device=mali -max_num_threads=256 -model=Mali-T860MP4@800Mhz");
 }
 
 TEST(BuildModule, Heterogeneous) {

--- a/tests/python/relay/test_pass_qnn_legalize.py
+++ b/tests/python/relay/test_pass_qnn_legalize.py
@@ -133,7 +133,7 @@ def test_qnn_legalize_qnn_conv2d():
             assert 'cast' in legalized_mod.astext() and "qnn.conv2d" in legalized_mod.astext()
 
         # Since same dtype, there should not be any transformation
-        with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
+        with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
             legalized_mod = relay.qnn.transform.Legalize()(mod)
             assert tvm.ir.structural_equal(mod, legalized_mod)
 
@@ -146,7 +146,7 @@ def test_qnn_legalize_qnn_conv2d():
             assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
         # Older ARM vesions.
-        with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu'):
+        with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu'):
             legalized_mod = relay.qnn.transform.Legalize()(mod)
             assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
@@ -161,7 +161,7 @@ def test_qnn_legalize_qnn_conv2d():
         assert tvm.ir.structural_equal(mod, legalized_mod)
 
     # ARM - so check that transformation has happened.
-    with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
+    with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
         legalized_mod = relay.qnn.transform.Legalize()(mod)
         assert 'cast' in legalized_mod.astext() and "qnn.conv2d" in legalized_mod.astext()
 
@@ -174,7 +174,7 @@ def test_qnn_legalize_qnn_conv2d():
         assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
     # Older ARM vesions.
-    with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu'):
+    with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu'):
         legalized_mod = relay.qnn.transform.Legalize()(mod)
         assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
@@ -220,7 +220,7 @@ def test_qnn_legalize_qnn_dense():
             assert 'cast' in legalized_mod.astext() and "qnn.dense" in legalized_mod.astext()
 
         # Since same dtype, there should not be any transformation
-        with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
+        with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
             legalized_mod = relay.qnn.transform.Legalize()(mod)
             assert tvm.ir.structural_equal(mod, legalized_mod)
 
@@ -233,7 +233,7 @@ def test_qnn_legalize_qnn_dense():
             assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
         # Older ARM vesions.
-        with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu'):
+        with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu'):
             legalized_mod = relay.qnn.transform.Legalize()(mod)
             assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
@@ -248,7 +248,7 @@ def test_qnn_legalize_qnn_dense():
         assert tvm.ir.structural_equal(mod, legalized_mod)
 
     # ARM - so check that transformation has happened.
-    with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
+    with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'):
         legalized_mod = relay.qnn.transform.Legalize()(mod)
         assert 'cast' in legalized_mod.astext() and "qnn.dense" in legalized_mod.astext()
 
@@ -261,7 +261,7 @@ def test_qnn_legalize_qnn_dense():
         assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 
     # Older ARM vesions.
-    with tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu'):
+    with tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu'):
         legalized_mod = relay.qnn.transform.Legalize()(mod)
         assert 'cast' in legalized_mod.astext() and "qnn" not in legalized_mod.astext()
 

--- a/tests/python/unittest/test_target_codegen_arm.py
+++ b/tests/python/unittest/test_target_codegen_arm.py
@@ -21,7 +21,7 @@ import os
 import ctypes
 
 def test_popcount():
-    target = 'llvm -target=armv7l-none-linux-gnueabihf -mcpu=cortex-a53 -mattr=+neon'
+    target = 'llvm -mtriple=armv7l-none-linux-gnueabihf -mcpu=cortex-a53 -mattr=+neon'
 
     def check_correct_assembly(type, elements, counts):
         n = tvm.runtime.convert(elements)
@@ -45,7 +45,7 @@ def test_popcount():
 
 
 def test_vmlal_s16():
-    target = 'llvm -target=armv7l-none-linux-gnueabihf -mcpu=cortex-a53 -mattr=+neon'
+    target = 'llvm -mtriple=armv7l-none-linux-gnueabihf -mcpu=cortex-a53 -mattr=+neon'
 
     def check_correct_assembly(N):
         K = te.size_var("K")

--- a/tests/python/unittest/test_target_codegen_cross_llvm.py
+++ b/tests/python/unittest/test_target_codegen_cross_llvm.py
@@ -47,14 +47,14 @@ def test_llvm_add_pipeline():
             print("Skip because llvm is not enabled..")
             return
         temp = util.tempdir()
-        target = "llvm -target=i386-pc-linux-gnu"
+        target = "llvm -mtriple=i386-pc-linux-gnu"
         f = tvm.build(s, [A, B, C], target)
         path = temp.relpath("myadd.o")
         f.save(path)
         verify_elf(path, 0x03)
 
     def build_arm():
-        target = "llvm -target=armv7-none-linux-gnueabihf"
+        target = "llvm -mtriple=armv7-none-linux-gnueabihf"
         if not tvm.runtime.enabled(target):
             print("Skip because %s is not enabled.." % target)
             return

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -685,7 +685,7 @@ def test_dwarf_debug_information():
         # build two functions
         f2 = tvm.lower(s, [A, B, C], name="fadd1")
         f1 = tvm.lower(s, [A, B, C], name="fadd2")
-        m = tvm.build([f1, f2], target="llvm -target=aarch64-linux-gnu")
+        m = tvm.build([f1, f2], target="llvm -mtriple=aarch64-linux-gnu")
         ll = m.get_source("ll")
 
         # On non-Darwin OS, don't explicitly specify DWARF version.
@@ -695,7 +695,7 @@ def test_dwarf_debug_information():
 
         # Try Darwin, require DWARF-2
         m = tvm.build([f1, f2],
-                      target="llvm -target=x86_64-apple-darwin-macho")
+                      target="llvm -mtriple=x86_64-apple-darwin-macho")
         ll = m.get_source("ll")
         assert re.search(r"""i32 4, !"Dwarf Version", i32 2""", ll)
         assert re.search(r"""llvm.dbg.value""", ll)

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -59,8 +59,8 @@ def test_target_string_parse():
 
     assert target.id.name == "cuda"
     assert target.model == "unknown"
-    assert target.keys == ['cuda', 'gpu']
-    assert target.libs == ['cublas', 'cudnn']
+    assert set(target.keys) == set(['cuda', 'gpu'])
+    assert set(target.libs) == set(['cublas', 'cudnn'])
     assert str(target) == str(tvm.target.cuda(options="-libs=cublas,cudnn"))
 
     assert tvm.target.intel_graphics().device_name == "intel_graphics"

--- a/topi/python/topi/arm_cpu/tensor_intrin.py
+++ b/topi/python/topi/arm_cpu/tensor_intrin.py
@@ -267,7 +267,7 @@ def gemv_quantized_impl(M, N, data_type='uint8'):
     ll_path = temp.relpath("temp.ll")
     # Create LLVM ir from c source code
     ll_code = clang.create_llvm(cc_code,
-                                options=["--target=aarch64-linux-gnu -mattr=+neon"],
+                                options=["-mtriple=aarch64-linux-gnu -mattr=+neon"],
                                 output=ll_path)
     return ll_code
 

--- a/topi/recipe/conv/test_conv_int8_arm.py
+++ b/topi/recipe/conv/test_conv_int8_arm.py
@@ -58,7 +58,7 @@ WORKLOADS = [(56, 56, 64, 64, 3, 3, 1, 1, 1, 1),
             ]
 
 
-TARGET_NAME = 'llvm -device=arm_cpu -target=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'
+TARGET_NAME = 'llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+dotprod'
 NUM_VEC_LANES = 16
 CTX = tvm.context(TARGET_NAME, 0)
 

--- a/topi/recipe/gemm/android_gemm_square.py
+++ b/topi/recipe/gemm/android_gemm_square.py
@@ -30,7 +30,7 @@ key = "android"
 # Change target configuration.
 # Run `adb shell cat /proc/cpuinfo` to find the arch.
 arch = "arm64"
-target = "llvm -target=%s-linux-android" % arch
+target = "llvm -mtriple=%s-linux-android" % arch
 
 def ngflops(N):
     return 2.0 * float(N * N * N) / (10**9)

--- a/topi/tests/python/test_topi_bitserial_conv2d_rasp.py
+++ b/topi/tests/python/test_topi_bitserial_conv2d_rasp.py
@@ -36,7 +36,7 @@ def verify_bitserial_conv2d_nhwc(batch, in_size, in_channel, num_filter, kernel,
     input_type = 'uint32'
     out_dtype = 'int16'
 
-    device = 'llvm -device=arm_cpu -model=bcm2837 -target=armv7l-linux-gnueabihf -mattr=+neon'
+    device = 'llvm -device=arm_cpu -model=bcm2837 -mtriple=armv7l-linux-gnueabihf -mattr=+neon'
     with tvm.target.create(device):
         A = te.placeholder((batch, in_height, in_width, in_channel), dtype=input_type, name='A')
         W = te.placeholder((kernel, kernel, in_channel, num_filter), dtype=input_type, name='W')

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -190,7 +190,7 @@ def get_network(name, batch_size):
 
 # Replace "aarch64-linux-gnu" with the correct target of your board.
 # This target is used for cross compilation. You can query it by :code:`gcc -v` on your device.
-target = tvm.target.create('llvm -device=arm_cpu -target=aarch64-linux-gnu')
+target = tvm.target.create('llvm -device=arm_cpu -mtriple=aarch64-linux-gnu')
 
 # Also replace this with the device key in your tracker
 device_key = 'rk3399'

--- a/tutorials/autotvm/tune_relay_mobile_gpu.py
+++ b/tutorials/autotvm/tune_relay_mobile_gpu.py
@@ -191,7 +191,7 @@ target = tvm.target.create('opencl -device=mali')
 
 # Replace "aarch64-linux-gnu" with the correct target of your board.
 # This target host is used for cross compilation. You can query it by :code:`gcc -v` on your device.
-target_host = 'llvm -target=aarch64-linux-gnu'
+target_host = 'llvm -mtriple=aarch64-linux-gnu'
 
 # Also replace this with the device key in your tracker
 device_key = 'rk3399'

--- a/tutorials/cross_compilation_and_rpc.py
+++ b/tutorials/cross_compilation_and_rpc.py
@@ -107,7 +107,7 @@ s = te.create_schedule(B.op)
 
 ######################################################################
 # Then we cross compile the kernel.
-# The target should be 'llvm -target=armv7l-linux-gnueabihf' for
+# The target should be 'llvm -mtriple=armv7l-linux-gnueabihf' for
 # Raspberry Pi 3B, but we use 'llvm' here to make this tutorial runnable
 # on our webpage building server. See the detailed note in the following block.
 
@@ -116,7 +116,7 @@ local_demo = True
 if local_demo:
     target = 'llvm'
 else:
-    target = 'llvm -target=armv7l-linux-gnueabihf'
+    target = 'llvm -mtriple=armv7l-linux-gnueabihf'
 
 func = tvm.build(s, [A, B], target=target, name='add_one')
 # save the lib at a local temp folder
@@ -131,14 +131,14 @@ func.export_library(path)
 #   to False and replace :code:`target` in :code:`build` with the appropriate
 #   target triple for your device. The target triple which might be
 #   different for different devices. For example, it is
-#   :code:`'llvm -target=armv7l-linux-gnueabihf'` for Raspberry Pi 3B and
-#   :code:`'llvm -target=aarch64-linux-gnu'` for RK3399.
+#   :code:`'llvm -mtriple=armv7l-linux-gnueabihf'` for Raspberry Pi 3B and
+#   :code:`'llvm -mtriple=aarch64-linux-gnu'` for RK3399.
 #
 #   Usually, you can query the target by running :code:`gcc -v` on your
 #   device, and looking for the line starting with :code:`Target:`
 #   (Though it may still be a loose configuration.)
 #
-#   Besides :code:`-target`, you can also set other compilation options
+#   Besides :code:`-mtriple`, you can also set other compilation options
 #   like:
 #
 #   * -mcpu=<cpuname>
@@ -224,7 +224,7 @@ print('%g secs/op' % cost)
 def run_opencl():
     # NOTE: This is the setting for my rk3399 board. You need to modify
     # them according to your environment.
-    target_host = "llvm -target=aarch64-linux-gnu"
+    target_host = "llvm -mtriple=aarch64-linux-gnu"
     opencl_device_host = '10.77.1.145'
     opencl_device_port = 9090
 

--- a/tutorials/frontend/deploy_model_on_android.py
+++ b/tutorials/frontend/deploy_model_on_android.py
@@ -246,7 +246,7 @@ test_target = 'cpu'
 # Change target configuration.
 # Run `adb shell cat /proc/cpuinfo` to find the arch.
 arch = 'arm64'
-target = 'llvm -target=%s-linux-android' % arch
+target = 'llvm -mtriple=%s-linux-android' % arch
 target_host = None
 
 if local_demo:

--- a/tutorials/frontend/deploy_model_on_rasp.py
+++ b/tutorials/frontend/deploy_model_on_rasp.py
@@ -177,7 +177,7 @@ if local_demo:
 else:
     target = tvm.target.arm_cpu('rasp3b')
     # The above line is a simple form of
-    # target = tvm.target.create('llvm -device=arm_cpu -model=bcm2837 -target=armv7l-linux-gnueabihf -mattr=+neon')
+    # target = tvm.target.create('llvm -device=arm_cpu -model=bcm2837 -mtriple=armv7l-linux-gnueabihf -mattr=+neon')
 
 with tvm.transform.PassContext(opt_level=3):
     graph, lib, params = relay.build(func, target, params=params)

--- a/vta/python/vta/environment.py
+++ b/vta/python/vta/environment.py
@@ -237,9 +237,9 @@ class Environment(object):
     def target_host(self):
         """The target host"""
         if self.TARGET in ["pynq", "de10nano"]:
-            return "llvm -target=armv7-none-linux-gnueabihf"
+            return "llvm -mtriple=armv7-none-linux-gnueabihf"
         if self.TARGET == "ultra96":
-            return "llvm -target=aarch64-linux-gnu"
+            return "llvm -mtriple=aarch64-linux-gnu"
         if self.TARGET in ["sim", "tsim"]:
             return "llvm"
         raise ValueError("Unknown target %s" % self.TARGET)

--- a/web/tests/python/prepare_test_libs.py
+++ b/web/tests/python/prepare_test_libs.py
@@ -23,7 +23,7 @@ import os
 
 
 def prepare_test_libs(base_path):
-    target = "llvm -target=wasm32-unknown-unknown-wasm -system-lib"
+    target = "llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
     if not tvm.runtime.enabled(target):
         raise RuntimeError("Target %s is not enbaled" % target)
     n = te.var("n")

--- a/web/tests/python/webgpu_rpc_test.py
+++ b/web/tests/python/webgpu_rpc_test.py
@@ -35,7 +35,7 @@ def test_rpc():
         return
     # generate the wasm library
     target_device = "webgpu"
-    target_host = "llvm -target=wasm32-unknown-unknown-wasm -system-lib"
+    target_host = "llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
     if not tvm.runtime.enabled(target_host):
         raise RuntimeError("Target %s is not enbaled" % target_host)
 

--- a/web/tests/python/websock_rpc_test.py
+++ b/web/tests/python/websock_rpc_test.py
@@ -33,7 +33,7 @@ def test_rpc():
     if not tvm.runtime.enabled("rpc"):
         return
     # generate the wasm library
-    target = "llvm -target=wasm32-unknown-unknown-wasm -system-lib"
+    target = "llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
     if not tvm.runtime.enabled(target):
         raise RuntimeError("Target %s is not enbaled" % target)
     n = te.var("n")


### PR DESCRIPTION
This PR contains several minor but breaking changes as mentioned in #5960.

1. Use `TargetNode::attrs` for serialization, which means that the raw string exported from target object may largely differ from the raw string input to create target object.
2. Change type of `-mattr` to `Array<String>` from `String`.
3. Remove `keys` from `attrs` after parsing, in order to avoid potential duplication and confusion. De-duplicate `keys` after parsing.
4. `-target` is migrated to `-mtriple` to avoid potential confusion.

Future work:
1. `-device` should be deprecated.
2. `-model` is used in autotvm, should migrate to `tag` as per [TVM Target Specification](https://discuss.tvm.ai/t/rfc-tvm-target-specification/6844?u=junrushao1994).