### PR TITLE
[AUTOTVM] Use LocalRunner by default in the tutorial tune_relay_cuda.py

### DIFF
--- a/tutorials/autotvm/tune_relay_cuda.py
+++ b/tutorials/autotvm/tune_relay_cuda.py
@@ -128,11 +128,7 @@ tuning_option = {
 
     'measure_option': autotvm.measure_option(
         builder=autotvm.LocalBuilder(timeout=10),
-        #runner=autotvm.LocalRunner(number=20, repeat=3, timeout=4, min_repeat_ms=150),
-        runner=autotvm.RPCRunner(
-            '1080ti',  # change the device key to your key
-            '0.0.0.0', 9190,
-            number=20, repeat=3, timeout=4, min_repeat_ms=150)
+        runner=autotvm.LocalRunner(number=20, repeat=3, timeout=4, min_repeat_ms=150),
     ),
 }
 


### PR DESCRIPTION
The tutorial should use LocalRunner by default. Otherwise, the tutorial is not runnable out of the box.

This bug was introduced during the nnvm-to-relay migration in #2594