### PR TITLE
[LLVM] Auto-convert shuffle with single index to "extract element"

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1119,6 +1119,10 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const ShuffleNode* op) {
   }
   llvm::Value* mask = llvm::ConstantDataVector::get(builder_->getContext(), idx);
   auto res = builder_->CreateShuffleVector(v0, llvm::UndefValue::get(v0->getType()), mask);
+  // If the output is a single-element vector, convert it back to a scalar.
+  if (idx.size() == 1) {
+    res = builder_->CreateExtractElement(res, ConstInt32(0));
+  }
   return res;
 }
 


### PR DESCRIPTION
Data types with a single lane are treated as scalars in TVM. On the other hand, in LLVM there is a difference between a scalar type and a vector type with a single lane. Because of that, a shuffle with a single index is equivalent to extracting an element in TIR, but not in the generated LLVM IR. This patch changes the LLVM codegen for shuffle to auto-convert single-lane vectors to scalars.