### PR TITLE
[Build] Option to specify alternate directory to output build to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 # under the License.
 
 ROOTDIR = $(CURDIR)
+# Specify an alternate output directory relative to ROOTDIR. Default build
+OUTPUTDIR = $(if $(OUTDIR), $(OUTDIR), build)
 
 .PHONY: clean all test doc pylint cpplint scalalint lint\
 	 cython cython2 cython3 web runtime vta
@@ -38,16 +40,16 @@ PKG_LDFLAGS =
 
 
 all:
-	@mkdir -p build && cd build && cmake .. && $(MAKE)
+	@mkdir -p $(OUTPUTDIR) && cd $(OUTPUTDIR) && cmake .. && $(MAKE)
 
 runtime:
-	@mkdir -p build && cd build && cmake .. && $(MAKE) runtime
+	@mkdir -p $(OUTPUTDIR) && cd $(OUTPUTDIR) && cmake .. && $(MAKE) runtime
 
 vta:
-	@mkdir -p build && cd build && cmake .. && $(MAKE) vta
+	@mkdir -p $(OUTPUTDIR) && cd $(OUTPUTDIR) && cmake .. && $(MAKE) vta
 
 cpptest:
-	@mkdir -p build && cd build && cmake .. && $(MAKE) cpptest
+	@mkdir -p $(OUTPUTDIR) && cd $(OUTPUTDIR) && cmake .. && $(MAKE) cpptest
 
 # EMCC; Web related scripts
 EMCC_FLAGS= -std=c++11 -DDMLC_LOG_STACK_TRACE=0\
@@ -57,17 +59,17 @@ EMCC_FLAGS= -std=c++11 -DDMLC_LOG_STACK_TRACE=0\
 	-s USE_GLFW=3 -s USE_WEBGL2=1 -lglfw\
 	$(INCLUDE_FLAGS)
 
-web: build/libtvm_web_runtime.js build/libtvm_web_runtime.bc
+web: $(OUTPUTDIR)/libtvm_web_runtime.js $(OUTPUTDIR)/libtvm_web_runtime.bc
 
-build/libtvm_web_runtime.bc: web/web_runtime.cc
-	@mkdir -p build/web
+$(OUTPUTDIR)/libtvm_web_runtime.bc: web/web_runtime.cc
+	@mkdir -p $(OUTPUTDIR)/web
 	@mkdir -p $(@D)
-	emcc $(EMCC_FLAGS) -MM -MT build/libtvm_web_runtime.bc $< >build/web/web_runtime.d
+	emcc $(EMCC_FLAGS) -MM -MT $(OUTPUTDIR)/libtvm_web_runtime.bc $< >$(OUTPUTDIR)/web/web_runtime.d
 	emcc $(EMCC_FLAGS) -o $@ web/web_runtime.cc
 
-build/libtvm_web_runtime.js: build/libtvm_web_runtime.bc
+$(OUTPUTDIR)/libtvm_web_runtime.js: $(OUTPUTDIR)/libtvm_web_runtime.bc
 	@mkdir -p $(@D)
-	emcc $(EMCC_FLAGS) -o $@ build/libtvm_web_runtime.bc
+	emcc $(EMCC_FLAGS) -o $@ $(OUTPUTDIR)/libtvm_web_runtime.bc
 
 # Lint scripts
 cpplint:
@@ -128,13 +130,13 @@ jvmpkg:
 	(cd $(ROOTDIR)/jvm; \
 		mvn clean package -P$(JVM_PKG_PROFILE) -Dcxx="$(CXX)" \
 			-Dcflags="$(PKG_CFLAGS)" -Dldflags="$(PKG_LDFLAGS)" \
-			-Dcurrent_libdir="$(ROOTDIR)/build" $(JVM_TEST_ARGS))
+			-Dcurrent_libdir="$(ROOTDIR)/$(OUTPUTDIR)" $(JVM_TEST_ARGS))
 jvminstall:
 	(cd $(ROOTDIR)/jvm; \
 		mvn install -P$(JVM_PKG_PROFILE) -Dcxx="$(CXX)" \
 			-Dcflags="$(PKG_CFLAGS)" -Dldflags="$(PKG_LDFLAGS)" \
-			-Dcurrent_libdir="$(ROOTDIR)/build" $(JVM_TEST_ARGS))
+			-Dcurrent_libdir="$(ROOTDIR)/$(OUTPUTDIR)" $(JVM_TEST_ARGS))
 
 # clean rule
 clean:
-	@mkdir -p build && cd build && cmake .. && $(MAKE) clean
+	@mkdir -p $(OUTPUTDIR) && cd $(OUTPUTDIR) && cmake .. && $(MAKE) clean


### PR DESCRIPTION
Specify a different directory to build to other than "build". This is useful when you would like to manage 2 separate builds in the same tvm tree. You can specify a build directory when using make by adding OUTDIR=alternate-build-dir.

Change-Id: I3efed1135343f3903007115ce5dd683ef7bd9e8c