### PR TITLE
[Relay][Frontend][Onnx] GRU Layer Support

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1499,8 +1499,6 @@ class RNN(OnnxOpConverter):
     """ Operator converter for RNNs such as LSTM and GRU.
     """
 
-    name = ""
-
     @classmethod
     def _activation_helper(cls, activation, alpha, beta):
         convert_map = _get_convert_map(1)
@@ -1532,16 +1530,13 @@ class RNN(OnnxOpConverter):
         ]
         return activation.decode("utf-8") in needs_beta
 
-    @classmethod
-    def _impl_v7(cls, inputs, attr, params):
-        if cls.name == 'LSTM':
-            return cls._lstm(inputs, attr, params)
-        if cls.name == 'GRU':
-            return cls._gru(inputs, attr, params)
-        raise NotImplementedError("%s RNNs are not yet supported." % cls.name)
+
+class LSTM(RNN):
+    """Operator converter for LSTM
+    """
 
     @classmethod
-    def _lstm(cls, inputs, attr, params):
+    def _impl_v7(cls, inputs, attr, params):
         # Unpack inputs, note that if optional and not provided then value will be None.
         X = inputs[0]
         W = inputs[1]
@@ -1652,8 +1647,13 @@ class RNN(OnnxOpConverter):
 
         return _expr.TupleWrapper(_expr.Tuple((output, H_t, C_t)), 3)
 
+
+class GRU(RNN):
+    """Operator convert for GRU
+    """
+
     @classmethod
-    def _gru(cls, inputs, attr, params):
+    def _impl_v7(cls, inputs, attr, params):
         # Unpack inputs, note that if optional and not provided then value will be None.
         X = inputs[0]
         W = inputs[1]
@@ -1757,18 +1757,6 @@ class RNN(OnnxOpConverter):
         H_t = _op.expand_dims(H_t, axis=0)
 
         return _expr.TupleWrapper(_expr.Tuple((output, H_t)), 2)
-
-
-class LSTM(RNN):
-    """Operator converter for LSTM
-    """
-    name = "LSTM"
-
-
-class GRU(RNN):
-    """Operator convert for GRU
-    """
-    name = "GRU"
 
 
 class Resize(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1533,15 +1533,13 @@ class RNN(OnnxOpConverter):
     @classmethod
     def _impl_v7(cls, inputs, attr, params):
         if cls.name == 'LSTM':
-            return cls.lstm(inputs, attr, params)
-        elif cls.name == 'GRU':
-            return cls.gru(inputs, attr, params)
-        else:
-            raise NotImplementedError("%s RNNs are not yet supported." %
-                                      cls.name)
+            return cls._lstm(inputs, attr, params)
+        if cls.name == 'GRU':
+            return cls._gru(inputs, attr, params)
+        raise NotImplementedError("%s RNNs are not yet supported." % cls.name)
 
     @classmethod
-    def lstm(cls, inputs, attr, params):
+    def _lstm(cls, inputs, attr, params):
         # Unpack inputs, note that if optional and not provided then value will be None.
         X = inputs[0]
         W = inputs[1]
@@ -1653,7 +1651,7 @@ class RNN(OnnxOpConverter):
         return _expr.TupleWrapper(_expr.Tuple((output, H_t, C_t)), 3)
 
     @classmethod
-    def gru(cls, inputs, attr, params):
+    def _gru(cls, inputs, attr, params):
         # Unpack inputs, note that if optional and not provided then value will be None.
         X = inputs[0]
         W = inputs[1]

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1166,14 +1166,6 @@ class HardSigmoid(OnnxOpConverter):
         attr = {'a_min': 0, 'a_max': 1}
         return AttrCvt('clip')([transformX], attr)
 
-class Softsign(OnnxOpConverter):
-    """ Operator converter for Softsign.
-    """
-    @classmethod
-    def _impl_v1(cls, inputs, attr, params):
-        x = inputs[0]
-        return x / (1 + _op.abs(x))
-
 class Reduce(OnnxOpConverter):
     """ Operator converter for reduce ops.
     """
@@ -1537,7 +1529,7 @@ class RNN(OnnxOpConverter):
             "HardSigmoid",
         ]
         return activation.decode("utf-8") in needs_beta
-    
+
     @classmethod
     def _impl_v7(cls, inputs, attr, params):
         if cls.name == 'LSTM':
@@ -1545,7 +1537,8 @@ class RNN(OnnxOpConverter):
         elif cls.name == 'GRU':
             return cls.gru(inputs, attr, params)
         else:
-            raise NotImplementedError("%s RNNs are not yet supported." % cls.name)
+            raise NotImplementedError("%s RNNs are not yet supported." %
+                                      cls.name)
 
     @classmethod
     def lstm(cls, inputs, attr, params):
@@ -1596,7 +1589,8 @@ class RNN(OnnxOpConverter):
         if 'activations' in attr:
             activations = attr['activations']
             if len(activations) != 3:
-                raise NotImplementedError("LSTM assumes 3 activation functions are provided")
+                raise NotImplementedError(
+                    "LSTM assumes 3 activation functions are provided")
             alpha_loc = 0
             alphas = attr.get('activation_alpha', [])
             if isinstance(alphas, float):
@@ -1610,10 +1604,12 @@ class RNN(OnnxOpConverter):
                 alpha = None
                 beta = None
                 activation = activations[i]
-                if cls._activation_needs_alpha(activation) and len(alphas) > alpha_loc:
+                if cls._activation_needs_alpha(
+                        activation) and len(alphas) > alpha_loc:
                     alpha = alphas[alpha_loc]
                     alpha_loc += 1
-                if cls._activation_needs_beta(activation) and len(betas) > beta_loc:
+                if cls._activation_needs_beta(
+                        activation) and len(betas) > beta_loc:
                     beta = betas[beta_loc]
                     beta_loc += 1
                 acts.append(cls._activation_helper(activation, alpha, beta))
@@ -1696,7 +1692,8 @@ class RNN(OnnxOpConverter):
         if 'activations' in attr:
             activations = attr['activations']
             if len(activations) != 2:
-                raise NotImplementedError("GRU assumes 2 activation functions are provided")
+                raise NotImplementedError(
+                    "GRU assumes 2 activation functions are provided")
             alpha_loc = 0
             alphas = attr.get('activation_alpha', [])
             if isinstance(alphas, float):
@@ -1710,10 +1707,12 @@ class RNN(OnnxOpConverter):
                 alpha = None
                 beta = None
                 activation = activations[i]
-                if cls._activation_needs_alpha(activation) and len(alphas) > alpha_loc:
+                if cls._activation_needs_alpha(
+                        activation) and len(alphas) > alpha_loc:
                     alpha = alphas[alpha_loc]
                     alpha_loc += 1
-                if cls._activation_needs_beta(activation) and len(betas) > beta_loc:
+                if cls._activation_needs_beta(
+                        activation) and len(betas) > beta_loc:
                     beta = betas[beta_loc]
                     beta_loc += 1
                 acts.append(cls._activation_helper(activation, alpha, beta))
@@ -1960,7 +1959,6 @@ def _get_convert_map(opset):
         'PRelu': Prelu.get_converter(opset),
         'Sigmoid': Renamer('sigmoid'),
         'HardSigmoid': HardSigmoid.get_converter(opset),
-        'Softsign': Softsign.get_converter(opset),
         'Max': Maximum.get_converter(opset),
         'Min': Minimum.get_converter(opset),
         'Sum': Sum.get_converter(opset),

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -60,6 +60,8 @@ class onnx_input():
 
     def __getitem__(self, item):
         if isinstance(item, int):
+            if item > (len(self.input_keys) - 1):
+                return None
             return self.input_dict[self.input_keys[item]]
         if isinstance(item, str):
             if item not in self.input_keys:
@@ -1544,12 +1546,12 @@ class RNN(OnnxOpConverter):
         X = inputs[0]
         W = inputs[1]
         R = inputs[2]
-        B = inputs['B']
+        B = inputs[3]
         # Sequence length currently unused as it can be inferred from shapes.
         #sequence_lens = inputs['sequence_lens']
-        h_0 = inputs['initial_h']
-        c_0 = inputs['initial_c']
-        P = inputs['P']
+        h_0 = inputs[5]
+        c_0 = inputs[6]
+        P = inputs[7]
 
         num_directions = infer_shape(W)[0]
         W_dtype = infer_type(W).type_annotation.dtype
@@ -1656,10 +1658,10 @@ class RNN(OnnxOpConverter):
         X = inputs[0]
         W = inputs[1]
         R = inputs[2]
-        B = inputs['B']
+        B = inputs[3]
         # Sequence length currently unused as it can be inferred from shapes.
         #sequence_lens = inputs['sequence_lens']
-        h_0 = inputs['initial_h']
+        h_0 = inputs[5]
         linear_before_reset = attr.get('linear_before_reset', 0)
 
         num_directions = infer_shape(W)[0]

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2574,25 +2574,28 @@ def test_lppool():
 
 
 def verify_rnn(seq_length,
-                batch_size,
-                input_size,
-                hidden_size,
-                rnn_type='LSTM',
-                use_bias=False,
-                activations=None,
-                alphas=None,
-                betas=None,
-                use_initial_state=False,
-                use_peep=False):
+               batch_size,
+               input_size,
+               hidden_size,
+               rnn_type='LSTM',
+               use_bias=False,
+               activations=None,
+               alphas=None,
+               betas=None,
+               use_initial_state=False,
+               use_peep=False):
     if rnn_type == 'LSTM':
         multiplier = 4
     elif rnn_type == 'GRU':
         multiplier = 3
     else:
         raise NotImplementedError("%s RNNs not yet supported." % rnn_type)
-    x_np = np.random.uniform(size=(seq_length, batch_size, input_size)).astype('float32')
-    w_np = np.random.uniform(size=(1, multiplier * hidden_size, input_size)).astype('float32')
-    r_np = np.random.uniform(size=(1, multiplier * hidden_size, hidden_size)).astype('float32')
+    x_np = np.random.uniform(size=(seq_length, batch_size,
+                                   input_size)).astype('float32')
+    w_np = np.random.uniform(size=(1, multiplier * hidden_size,
+                                   input_size)).astype('float32')
+    r_np = np.random.uniform(size=(1, multiplier * hidden_size,
+                                   hidden_size)).astype('float32')
     input_names = ["X", "W", "R"]
     input_tensors = [
         helper.make_tensor_value_info("X", TensorProto.FLOAT, list(x_np.shape)),
@@ -2602,20 +2605,25 @@ def verify_rnn(seq_length,
     input_values = [x_np, w_np, r_np]
 
     if use_bias:
-        b_np = np.random.uniform(size=(1, multiplier * 2 * hidden_size)).astype('float32')
+        b_np = np.random.uniform(size=(1, multiplier * 2 *
+                                       hidden_size)).astype('float32')
         input_names.append("B")
         input_tensors.append(
-            helper.make_tensor_value_info("B", TensorProto.FLOAT, [1, multiplier * 2 * hidden_size]))
+            helper.make_tensor_value_info("B", TensorProto.FLOAT,
+                                          [1, multiplier * 2 * hidden_size]))
         input_values.append(b_np)
 
     if use_initial_state:
         assert use_bias == True, "Initial states must have bias specified."
         sequence_np = np.repeat(seq_length, batch_size).astype('int32')
         input_names.append("sequence_lens")
-        input_tensors.append(helper.make_tensor_value_info("sequence_lens", TensorProto.INT32, [batch_size]))
+        input_tensors.append(
+            helper.make_tensor_value_info("sequence_lens", TensorProto.INT32,
+                                          [batch_size]))
         input_values.append(sequence_np)
 
-        initial_h_np = np.random.uniform(size=(1, batch_size, hidden_size)).astype('float32')
+        initial_h_np = np.random.uniform(size=(1, batch_size,
+                                               hidden_size)).astype('float32')
         input_names.append("initial_h")
         input_tensors.append(
             helper.make_tensor_value_info("initial_h", TensorProto.FLOAT,
@@ -2623,11 +2631,12 @@ def verify_rnn(seq_length,
         input_values.append(initial_h_np)
 
         if rnn_type == 'LSTM':
-            initial_c_np = np.random.uniform(size=(1, batch_size, hidden_size)).astype('float32')
+            initial_c_np = np.random.uniform(
+                size=(1, batch_size, hidden_size)).astype('float32')
             input_names.append("initial_c")
             input_tensors.append(
                 helper.make_tensor_value_info("initial_c", TensorProto.FLOAT,
-                                            [1, batch_size, hidden_size]))
+                                              [1, batch_size, hidden_size]))
             input_values.append(initial_c_np)
 
     if use_peep and rnn_type == 'LSTM':
@@ -2635,20 +2644,25 @@ def verify_rnn(seq_length,
         p_np = np.random.uniform(size=(1, 3 * hidden_size)).astype('float32')
         input_names.append("P")
         input_tensors.append(
-            helper.make_tensor_value_info("P", TensorProto.FLOAT, [1, 3 * hidden_size]))
+            helper.make_tensor_value_info("P", TensorProto.FLOAT,
+                                          [1, 3 * hidden_size]))
         input_values.append(p_np)
 
     Y_shape = [seq_length, 1, batch_size, hidden_size]
     Y_h_shape = [1, batch_size, hidden_size]
     outputs = ["Y", "Y_h"]
-    graph_outputs = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, list(Y_shape)),
-                     helper.make_tensor_value_info("Y_h", TensorProto.FLOAT, list(Y_h_shape))]
+    graph_outputs = [
+        helper.make_tensor_value_info("Y", TensorProto.FLOAT, list(Y_shape)),
+        helper.make_tensor_value_info("Y_h", TensorProto.FLOAT, list(Y_h_shape))
+    ]
     output_shapes = [Y_shape, Y_h_shape]
-    
+
     if rnn_type == 'LSTM':
         Y_c_shape = [1, batch_size, hidden_size]
         outputs.append("Y_c")
-        graph_outputs.append(helper.make_tensor_value_info("Y_c", TensorProto.FLOAT, list(Y_c_shape)))
+        graph_outputs.append(
+            helper.make_tensor_value_info("Y_c", TensorProto.FLOAT,
+                                          list(Y_c_shape)))
         output_shapes.append(Y_c_shape)
 
     rnn_node = helper.make_node(
@@ -2666,7 +2680,7 @@ def verify_rnn(seq_length,
     graph = helper.make_graph([rnn_node],
                               "rnn_test",
                               inputs=input_tensors,
-                              outputs= graph_outputs)
+                              outputs=graph_outputs)
 
     model = helper.make_model(graph, producer_name='rnn_test')
 
@@ -2676,7 +2690,8 @@ def verify_rnn(seq_length,
             model,
             input_values,
             target,
-            ctx, output_shapes,
+            ctx,
+            output_shapes,
             output_dtype=['float32'] * len(output_shapes))
         for o_out, t_out in zip(onnx_out, tvm_out):
             tvm.testing.assert_allclose(o_out, t_out, rtol=5e-3, atol=5e-3)
@@ -2684,17 +2699,53 @@ def verify_rnn(seq_length,
 
 def test_lstm():
     # No bias.
-    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=32, use_bias=False, rnn_type='LSTM')
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=False,
+        rnn_type='LSTM')
     # large batch.
-    verify_rnn(seq_length=4, batch_size=8, input_size=16, hidden_size=32, use_bias=True, rnn_type='LSTM')
+    verify_rnn(
+        seq_length=4,
+        batch_size=8,
+        input_size=16,
+        hidden_size=32,
+        use_bias=True,
+        rnn_type='LSTM')
     # Non power of two.
-    verify_rnn(seq_length=3, batch_size=3, input_size=16, hidden_size=40, use_bias=True, rnn_type='LSTM')
+    verify_rnn(
+        seq_length=3,
+        batch_size=3,
+        input_size=16,
+        hidden_size=40,
+        use_bias=True,
+        rnn_type='LSTM')
     # Long sequence.
-    verify_rnn(seq_length=8, batch_size=1, input_size=16, hidden_size=32, use_bias=True, rnn_type='LSTM')
+    verify_rnn(
+        seq_length=8,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=True,
+        rnn_type='LSTM')
     # Large hidden.
-    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=128, use_bias=True, rnn_type='LSTM')
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=128,
+        use_bias=True,
+        rnn_type='LSTM')
     # Large input.
-    verify_rnn(seq_length=2, batch_size=1, input_size=64, hidden_size=32, use_bias=True, rnn_type='LSTM')
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=64,
+        hidden_size=32,
+        use_bias=True,
+        rnn_type='LSTM')
 
     # Different activation testing.
     # Default value hardsigmoid.
@@ -2752,17 +2803,53 @@ def test_lstm():
 
 def test_gru():
     # No bias.
-    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=32, use_bias=False, rnn_type='GRU')
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=False,
+        rnn_type='GRU')
     # large batch.
-    verify_rnn(seq_length=4, batch_size=8, input_size=16, hidden_size=32, use_bias=True, rnn_type='GRU')
+    verify_rnn(
+        seq_length=4,
+        batch_size=8,
+        input_size=16,
+        hidden_size=32,
+        use_bias=True,
+        rnn_type='GRU')
     # Non power of two.
-    verify_rnn(seq_length=3, batch_size=3, input_size=16, hidden_size=40, use_bias=True, rnn_type='GRU')
+    verify_rnn(
+        seq_length=3,
+        batch_size=3,
+        input_size=16,
+        hidden_size=40,
+        use_bias=True,
+        rnn_type='GRU')
     # Long sequence.
-    verify_rnn(seq_length=8, batch_size=1, input_size=16, hidden_size=32, use_bias=True, rnn_type='GRU')
+    verify_rnn(
+        seq_length=8,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=True,
+        rnn_type='GRU')
     # Large hidden.
-    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=128, use_bias=True, rnn_type='GRU')
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=128,
+        use_bias=True,
+        rnn_type='GRU')
     # Large input.
-    verify_rnn(seq_length=2, batch_size=1, input_size=64, hidden_size=32, use_bias=True, rnn_type='GRU')
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=64,
+        hidden_size=32,
+        use_bias=True,
+        rnn_type='GRU')
 
     # Different activation testing.
     # Default value hardsigmoid.
@@ -2772,7 +2859,7 @@ def test_gru():
         input_size=16,
         hidden_size=32,
         use_bias=False,
-        activations=['HardSigmoid', 'Tanh'],
+        activations=['HardSigmoid', 'Softsign'],
         rnn_type='GRU')
     # Multiple parameterized activations.
     verify_rnn(
@@ -2994,75 +3081,75 @@ def test_roi_align():
 
 
 if __name__ == '__main__':
-    #test_flatten()
-    #test_reshape()
-    #test_shape()
-    #test_expand()
-    #test_power()
-    #test_squeeze()
-    #test_unsqueeze()
-    #test_slice()
-    #test_floor()
-    #test_ceil()
-    #test_round()
-    #test_isinf()
-    #test_isnan()
-    #test_clip()
-    #test_onehot()
-    #test_matmul()
-    #test_batch_matmul()
-    #test_gather()
-    #test_gather_nd()
-    #test_scatter()
-    #test_lrn()
-    #test_instance_norm()
-    #test_upsample()
-    #test_forward_min()
-    #test_forward_max()
-    #test_forward_mean()
-    #test_forward_hardsigmoid()
-    #test_forward_arg_min_max()
-    #test_softmax()
-    #test_constantofshape()
-    #test_all_reduce_funcs()
-    #test_pad()
-    #test_split()
-    #test_binary_ops()
-    #test_single_ops()
-    #test_leaky_relu()
-    #test_elu()
-    #test_selu()
-    #test_prelu()
-    #test_ThresholdedRelu()
-    #test_ScaledTanh()
-    #test_ParametricSoftplus()
-    #test_Scale()
-    #test_LogSoftmax()
-    #test_resnet()
-    #test_inception()
-    #test_densenet()
-    #test_sign()
-    #test_not()
-    #test_and()
-    #test_tile()
-    #test_erf()
-    #test_where()
-    #test_or()
-    #test_depth_to_space()
-    #test_space_to_depth()
-    #test_batch_norm()
-    #test_batch_norm_dynamic_subgraph()
-    #test_conv()
-    #test_convtranspose()
-    #test_unsqueeze_constant()
-    #test_pooling()
-    #test_lppool()
-    #test_lstm()
+    test_flatten()
+    test_reshape()
+    test_shape()
+    test_expand()
+    test_power()
+    test_squeeze()
+    test_unsqueeze()
+    test_slice()
+    test_floor()
+    test_ceil()
+    test_round()
+    test_isinf()
+    test_isnan()
+    test_clip()
+    test_onehot()
+    test_matmul()
+    test_batch_matmul()
+    test_gather()
+    test_gather_nd()
+    test_scatter()
+    test_lrn()
+    test_instance_norm()
+    test_upsample()
+    test_forward_min()
+    test_forward_max()
+    test_forward_mean()
+    test_forward_hardsigmoid()
+    test_forward_arg_min_max()
+    test_softmax()
+    test_constantofshape()
+    test_all_reduce_funcs()
+    test_pad()
+    test_split()
+    test_binary_ops()
+    test_single_ops()
+    test_leaky_relu()
+    test_elu()
+    test_selu()
+    test_prelu()
+    test_ThresholdedRelu()
+    test_ScaledTanh()
+    test_ParametricSoftplus()
+    test_Scale()
+    test_LogSoftmax()
+    test_resnet()
+    test_inception()
+    test_densenet()
+    test_sign()
+    test_not()
+    test_and()
+    test_tile()
+    test_erf()
+    test_where()
+    test_or()
+    test_depth_to_space()
+    test_space_to_depth()
+    test_batch_norm()
+    test_batch_norm_dynamic_subgraph()
+    test_conv()
+    test_convtranspose()
+    test_unsqueeze_constant()
+    test_pooling()
+    test_lppool()
+    test_lstm()
     test_gru()
-    #test_resize()
-    #test_nonzero()
-    #test_topk()
-    #test_mod()
-    #test_xor()
-    #test_max_roi_pool()
-    #test_roi_align()
+    test_resize()
+    test_nonzero()
+    test_topk()
+    test_mod()
+    test_xor()
+    test_max_roi_pool()
+    test_roi_align()

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2583,7 +2583,8 @@ def verify_rnn(seq_length,
                alphas=None,
                betas=None,
                use_initial_state=False,
-               use_peep=False):
+               use_peep=False,
+               linear_before_reset=False):
     if rnn_type == 'LSTM':
         multiplier = 4
     elif rnn_type == 'GRU':
@@ -2676,6 +2677,9 @@ def verify_rnn(seq_length,
     if betas is not None:
         betas_attr = helper.make_attribute('activation_beta', betas)
         rnn_node.attribute.append(betas_attr)
+    if linear_before_reset and rnn_type == 'GRU':
+        lbr_attr = helper.make_attribute('linear_before_reset', 1)
+        rnn_node.attribute.append(lbr_attr)
 
     graph = helper.make_graph([rnn_node],
                               "rnn_test",
@@ -2817,7 +2821,8 @@ def test_gru():
         input_size=16,
         hidden_size=32,
         use_bias=True,
-        rnn_type='GRU')
+        rnn_type='GRU',
+        linear_before_reset=True)
     # Non power of two.
     verify_rnn(
         seq_length=3,

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2573,19 +2573,26 @@ def test_lppool():
                   pads=None, out_shape=[1, 1, 16, 16, 16], auto_pad='SAME_UPPER')
 
 
-def verify_lstm(seq_length,
+def verify_rnn(seq_length,
                 batch_size,
                 input_size,
                 hidden_size,
+                rnn_type='LSTM',
                 use_bias=False,
                 activations=None,
                 alphas=None,
                 betas=None,
                 use_initial_state=False,
                 use_peep=False):
+    if rnn_type == 'LSTM':
+        multiplier = 4
+    elif rnn_type == 'GRU':
+        multiplier = 3
+    else:
+        raise NotImplementedError("%s RNNs not yet supported." % rnn_type)
     x_np = np.random.uniform(size=(seq_length, batch_size, input_size)).astype('float32')
-    w_np = np.random.uniform(size=(1, 4 * hidden_size, input_size)).astype('float32')
-    r_np = np.random.uniform(size=(1, 4 * hidden_size, hidden_size)).astype('float32')
+    w_np = np.random.uniform(size=(1, multiplier * hidden_size, input_size)).astype('float32')
+    r_np = np.random.uniform(size=(1, multiplier * hidden_size, hidden_size)).astype('float32')
     input_names = ["X", "W", "R"]
     input_tensors = [
         helper.make_tensor_value_info("X", TensorProto.FLOAT, list(x_np.shape)),
@@ -2595,10 +2602,10 @@ def verify_lstm(seq_length,
     input_values = [x_np, w_np, r_np]
 
     if use_bias:
-        b_np = np.random.uniform(size=(1, 8 * hidden_size)).astype('float32')
+        b_np = np.random.uniform(size=(1, multiplier * 2 * hidden_size)).astype('float32')
         input_names.append("B")
         input_tensors.append(
-            helper.make_tensor_value_info("B", TensorProto.FLOAT, [1, 8 * hidden_size]))
+            helper.make_tensor_value_info("B", TensorProto.FLOAT, [1, multiplier * 2 * hidden_size]))
         input_values.append(b_np)
 
     if use_initial_state:
@@ -2615,14 +2622,15 @@ def verify_lstm(seq_length,
                                           [1, batch_size, hidden_size]))
         input_values.append(initial_h_np)
 
-        initial_c_np = np.random.uniform(size=(1, batch_size, hidden_size)).astype('float32')
-        input_names.append("initial_c")
-        input_tensors.append(
-            helper.make_tensor_value_info("initial_c", TensorProto.FLOAT,
-                                          [1, batch_size, hidden_size]))
-        input_values.append(initial_c_np)
+        if rnn_type == 'LSTM':
+            initial_c_np = np.random.uniform(size=(1, batch_size, hidden_size)).astype('float32')
+            input_names.append("initial_c")
+            input_tensors.append(
+                helper.make_tensor_value_info("initial_c", TensorProto.FLOAT,
+                                            [1, batch_size, hidden_size]))
+            input_values.append(initial_c_np)
 
-    if use_peep:
+    if use_peep and rnn_type == 'LSTM':
         assert use_initial_state == True, "Peepholes require initial state to be specified."
         p_np = np.random.uniform(size=(1, 3 * hidden_size)).astype('float32')
         input_names.append("P")
@@ -2632,41 +2640,35 @@ def verify_lstm(seq_length,
 
     Y_shape = [seq_length, 1, batch_size, hidden_size]
     Y_h_shape = [1, batch_size, hidden_size]
-    Y_c_shape = [1, batch_size, hidden_size]
+    outputs = ["Y", "Y_h"]
+    graph_outputs = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, list(Y_shape)),
+                     helper.make_tensor_value_info("Y_h", TensorProto.FLOAT, list(Y_h_shape))]
+    output_shapes = [Y_shape, Y_h_shape]
+    
+    if rnn_type == 'LSTM':
+        Y_c_shape = [1, batch_size, hidden_size]
+        outputs.append("Y_c")
+        graph_outputs.append(helper.make_tensor_value_info("Y_c", TensorProto.FLOAT, list(Y_c_shape)))
+        output_shapes.append(Y_c_shape)
 
-    if activations is None:
-        lstm_node = helper.make_node(
-            'LSTM', inputs=input_names, outputs=["Y", "Y_h", "Y_c"], hidden_size=hidden_size)
-    elif alphas is None:
-        lstm_node = helper.make_node(
-            'LSTM',
-            inputs=input_names,
-            outputs=["Y", "Y_h", "Y_c"],
-            hidden_size=hidden_size,
-            activations=activations)
-    else:
-        lstm_node = helper.make_node(
-            'LSTM',
-            inputs=input_names,
-            outputs=["Y", "Y_h", "Y_c"],
-            hidden_size=hidden_size,
-            activations=activations,
-            activation_alpha=alphas,
-            activation_beta=betas)
+    rnn_node = helper.make_node(
+        rnn_type, inputs=input_names, outputs=outputs, hidden_size=hidden_size)
+    if activations is not None:
+        activations_attr = helper.make_attribute('activations', activations)
+        rnn_node.attribute.append(activations_attr)
+    if alphas is not None:
+        alphas_attr = helper.make_attribute('activation_alpha', alphas)
+        rnn_node.attribute.append(alphas_attr)
+    if betas is not None:
+        betas_attr = helper.make_attribute('activation_beta', betas)
+        rnn_node.attribute.append(betas_attr)
 
-    graph = helper.make_graph([lstm_node],
-                              "lstm_test",
+    graph = helper.make_graph([rnn_node],
+                              "rnn_test",
                               inputs=input_tensors,
-                              outputs=[
-                                  helper.make_tensor_value_info("Y", TensorProto.FLOAT,
-                                                                list(Y_shape)),
-                                  helper.make_tensor_value_info("Y_h", TensorProto.FLOAT,
-                                                                list(Y_h_shape)),
-                                  helper.make_tensor_value_info("Y_c", TensorProto.FLOAT,
-                                                                list(Y_c_shape))
-                              ])
+                              outputs= graph_outputs)
 
-    model = helper.make_model(graph, producer_name='lstm_test')
+    model = helper.make_model(graph, producer_name='rnn_test')
 
     for target, ctx in ctx_list():
         onnx_out = get_onnxruntime_output(model, input_values, 'float32')
@@ -2674,37 +2676,38 @@ def verify_lstm(seq_length,
             model,
             input_values,
             target,
-            ctx, [Y_shape, Y_h_shape, Y_c_shape],
-            output_dtype=['float32', 'float32', 'float32'])
+            ctx, output_shapes,
+            output_dtype=['float32'] * len(output_shapes))
         for o_out, t_out in zip(onnx_out, tvm_out):
             tvm.testing.assert_allclose(o_out, t_out, rtol=5e-3, atol=5e-3)
 
 
 def test_lstm():
     # No bias.
-    verify_lstm(seq_length=2, batch_size=1, input_size=16, hidden_size=32, use_bias=False)
+    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=32, use_bias=False, rnn_type='LSTM')
     # large batch.
-    verify_lstm(seq_length=4, batch_size=8, input_size=16, hidden_size=32, use_bias=True)
+    verify_rnn(seq_length=4, batch_size=8, input_size=16, hidden_size=32, use_bias=True, rnn_type='LSTM')
     # Non power of two.
-    verify_lstm(seq_length=3, batch_size=3, input_size=16, hidden_size=40, use_bias=True)
+    verify_rnn(seq_length=3, batch_size=3, input_size=16, hidden_size=40, use_bias=True, rnn_type='LSTM')
     # Long sequence.
-    verify_lstm(seq_length=8, batch_size=1, input_size=16, hidden_size=32, use_bias=True)
+    verify_rnn(seq_length=8, batch_size=1, input_size=16, hidden_size=32, use_bias=True, rnn_type='LSTM')
     # Large hidden.
-    verify_lstm(seq_length=2, batch_size=1, input_size=16, hidden_size=128, use_bias=True)
+    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=128, use_bias=True, rnn_type='LSTM')
     # Large input.
-    verify_lstm(seq_length=2, batch_size=1, input_size=64, hidden_size=32, use_bias=True)
+    verify_rnn(seq_length=2, batch_size=1, input_size=64, hidden_size=32, use_bias=True, rnn_type='LSTM')
 
     # Different activation testing.
     # Default value hardsigmoid.
-    verify_lstm(
+    verify_rnn(
         seq_length=2,
         batch_size=1,
         input_size=16,
         hidden_size=32,
         use_bias=False,
-        activations=['HardSigmoid', 'Tanh', 'Tanh'])
+        activations=['HardSigmoid', 'Tanh', 'Tanh'],
+        rnn_type='LSTM')
     # Multiple parameterized activations.
-    verify_lstm(
+    verify_rnn(
         seq_length=2,
         batch_size=1,
         input_size=16,
@@ -2712,9 +2715,10 @@ def test_lstm():
         use_bias=False,
         activations=['HardSigmoid', 'LeakyRelu', 'Tanh'],
         alphas=[2.0, 0.5],
-        betas=[.3])
+        betas=[.3],
+        rnn_type='LSTM')
     # All parameterized with new Affine activation.
-    verify_lstm(
+    verify_rnn(
         seq_length=2,
         batch_size=1,
         input_size=16,
@@ -2722,24 +2726,86 @@ def test_lstm():
         use_bias=False,
         activations=['HardSigmoid', 'LeakyRelu', 'Affine'],
         alphas=[2.0, 0.5, 0.8],
-        betas=[.3, 0.1])
+        betas=[.3, 0.1],
+        rnn_type='LSTM')
 
     # Testing with initial state and peepholes
-    verify_lstm(
-        seq_length=2,
-        batch_size=1,
-        input_size=16,
-        hidden_size=32,
-        use_bias=True,
-        use_initial_state=True)
-    verify_lstm(
+    verify_rnn(
         seq_length=2,
         batch_size=1,
         input_size=16,
         hidden_size=32,
         use_bias=True,
         use_initial_state=True,
-        use_peep=True)
+        rnn_type='LSTM')
+
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=True,
+        use_initial_state=True,
+        use_peep=True,
+        rnn_type='LSTM')
+
+
+def test_gru():
+    # No bias.
+    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=32, use_bias=False, rnn_type='GRU')
+    # large batch.
+    verify_rnn(seq_length=4, batch_size=8, input_size=16, hidden_size=32, use_bias=True, rnn_type='GRU')
+    # Non power of two.
+    verify_rnn(seq_length=3, batch_size=3, input_size=16, hidden_size=40, use_bias=True, rnn_type='GRU')
+    # Long sequence.
+    verify_rnn(seq_length=8, batch_size=1, input_size=16, hidden_size=32, use_bias=True, rnn_type='GRU')
+    # Large hidden.
+    verify_rnn(seq_length=2, batch_size=1, input_size=16, hidden_size=128, use_bias=True, rnn_type='GRU')
+    # Large input.
+    verify_rnn(seq_length=2, batch_size=1, input_size=64, hidden_size=32, use_bias=True, rnn_type='GRU')
+
+    # Different activation testing.
+    # Default value hardsigmoid.
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=False,
+        activations=['HardSigmoid', 'Tanh'],
+        rnn_type='GRU')
+    # Multiple parameterized activations.
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=False,
+        activations=['HardSigmoid', 'LeakyRelu'],
+        alphas=[2.0, 0.5],
+        betas=[.3],
+        rnn_type='GRU')
+    # All parameterized with new Affine activation.
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=False,
+        activations=['HardSigmoid', 'Affine'],
+        alphas=[2.0, 0.8],
+        betas=[.3, 0.1],
+        rnn_type='GRU')
+
+    # Testing with initial state
+    verify_rnn(
+        seq_length=2,
+        batch_size=1,
+        input_size=16,
+        hidden_size=32,
+        use_bias=True,
+        use_initial_state=True,
+        rnn_type='GRU')
 
 
 def test_resize():
@@ -2928,74 +2994,75 @@ def test_roi_align():
 
 
 if __name__ == '__main__':
-    test_flatten()
-    test_reshape()
-    test_shape()
-    test_expand()
-    test_power()
-    test_squeeze()
-    test_unsqueeze()
-    test_slice()
-    test_floor()
-    test_ceil()
-    test_round()
-    test_isinf()
-    test_isnan()
-    test_clip()
-    test_onehot()
-    test_matmul()
-    test_batch_matmul()
-    test_gather()
-    test_gather_nd()
-    test_scatter()
-    test_lrn()
-    test_instance_norm()
-    test_upsample()
-    test_forward_min()
-    test_forward_max()
-    test_forward_mean()
-    test_forward_hardsigmoid()
-    test_forward_arg_min_max()
-    test_softmax()
-    test_constantofshape()
-    test_all_reduce_funcs()
-    test_pad()
-    test_split()
-    test_binary_ops()
-    test_single_ops()
-    test_leaky_relu()
-    test_elu()
-    test_selu()
-    test_prelu()
-    test_ThresholdedRelu()
-    test_ScaledTanh()
-    test_ParametricSoftplus()
-    test_Scale()
-    test_LogSoftmax()
-    test_resnet()
-    test_inception()
-    test_densenet()
-    test_sign()
-    test_not()
-    test_and()
-    test_tile()
-    test_erf()
-    test_where()
-    test_or()
-    test_depth_to_space()
-    test_space_to_depth()
-    test_batch_norm()
-    test_batch_norm_dynamic_subgraph()
-    test_conv()
-    test_convtranspose()
-    test_unsqueeze_constant()
-    test_pooling()
-    test_lppool()
-    test_lstm()
-    test_resize()
-    test_nonzero()
-    test_topk()
-    test_mod()
-    test_xor()
-    test_max_roi_pool()
-    test_roi_align()
+    #test_flatten()
+    #test_reshape()
+    #test_shape()
+    #test_expand()
+    #test_power()
+    #test_squeeze()
+    #test_unsqueeze()
+    #test_slice()
+    #test_floor()
+    #test_ceil()
+    #test_round()
+    #test_isinf()
+    #test_isnan()
+    #test_clip()
+    #test_onehot()
+    #test_matmul()
+    #test_batch_matmul()
+    #test_gather()
+    #test_gather_nd()
+    #test_scatter()
+    #test_lrn()
+    #test_instance_norm()
+    #test_upsample()
+    #test_forward_min()
+    #test_forward_max()
+    #test_forward_mean()
+    #test_forward_hardsigmoid()
+    #test_forward_arg_min_max()
+    #test_softmax()
+    #test_constantofshape()
+    #test_all_reduce_funcs()
+    #test_pad()
+    #test_split()
+    #test_binary_ops()
+    #test_single_ops()
+    #test_leaky_relu()
+    #test_elu()
+    #test_selu()
+    #test_prelu()
+    #test_ThresholdedRelu()
+    #test_ScaledTanh()
+    #test_ParametricSoftplus()
+    #test_Scale()
+    #test_LogSoftmax()
+    #test_resnet()
+    #test_inception()
+    #test_densenet()
+    #test_sign()
+    #test_not()
+    #test_and()
+    #test_tile()
+    #test_erf()
+    #test_where()
+    #test_or()
+    #test_depth_to_space()
+    #test_space_to_depth()
+    #test_batch_norm()
+    #test_batch_norm_dynamic_subgraph()
+    #test_conv()
+    #test_convtranspose()
+    #test_unsqueeze_constant()
+    #test_pooling()
+    #test_lppool()
+    #test_lstm()
+    test_gru()
+    #test_resize()
+    #test_nonzero()
+    #test_topk()
+    #test_mod()
+    #test_xor()
+    #test_max_roi_pool()
+    #test_roi_align()


### PR DESCRIPTION
This PR adds GRU parsing to the onnx frontend. Currently this is done by unrolling the recurrence in a similar way to how we handle LSTMs. Since there's quite a bit of shared code, I've generalized the LSTM converter to an RNN converter and made LSTM and GRU subclasses. For testing, I again replaced the LSTM test function with a more general test_rnn function that supports both LSTM and GRU and should be easily expandable to other RNN functions should we ever want to add any.