### PR TITLE
Add support for checking big ONNX models

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2242,6 +2242,8 @@ class GraphProto(ExprFunctor):
 def from_onnx(model,
               shape=None,
               dtype="float32",
+              big_model=False,
+              model_path=None,
               opset=None):
     """Convert a ONNX model into an equivalent Relay Function.
 
@@ -2263,6 +2265,14 @@ def from_onnx(model,
     dtype : str or dict of str to str
         The input types to the graph
 
+    big_model : bool
+        Whether the size of the input model is larger than 2GB
+
+    model_path : str, optional
+        The path of input model, and the external data
+        files need under the same directory
+        Must be set if 'big_model' is True
+
     opset : int, optional
         Override to autodetected opset.
         This can be helpful for some testing.
@@ -2280,7 +2290,11 @@ def from_onnx(model,
         if hasattr(onnx.checker, 'check_model'):
             # try use onnx's own model checker before converting any model
             try:
-                onnx.checker.check_model(model)
+                if not big_model:
+                    onnx.checker.check_model(model)
+                if big_model:
+                    onnx.checker.check_model(model_path)
+                    # onnx.checker.check_model(model) will fail if model's size > 2GB
             except onnx.onnx_cpp2py_export.checker.ValidationError as e:
                 import warnings
                 # the checker is a bit violent about errors, so simply print warnings here

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2296,6 +2296,7 @@ def from_onnx(model_path=None,
                 onnx.checker.check_model(model)
             except onnx.onnx_cpp2py_export.checker.ValidationError as e:
                 import warnings
+                warnings.warn(str(e))
     except ImportError:
         pass
     global g


### PR DESCRIPTION
Some users adopt ONNX to convert and save their trained models. But some of the models are big, which have sizes larger than 2GB. In these cases, ONNX cannot save these big models successfully. Recently, developers of ONNX have made some updates on ONNX so that ONNX can save, load, check big models.
I note that TVM cannot yet support compiling big ONNX models because TVM fails to check big ONNX models. I have made minor modifications to the source codes so that TVM can support checking and compiling big ONNX models.

@adityaatluri  @liangfu  @zhiics  
Could you please have a look on this PR?
