### PR TITLE
[Relay][TF] Make StridedSlice support dynamic input and constant attrs

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1458,6 +1458,15 @@ def _stridedSlice():
 
                 return ret
 
+        def _dyn():
+            for d in data_shape:
+                if not isinstance(d, int):
+                    return True
+            return False
+
+        if _dyn():
+            return _op.strided_slice(inputs[0], begin, end, stride)
+
         def _transform_mask(stride_dim, ellipsis_mask):
             """Handle mask inputs to create new begin, end, stride and output shape"""
             m_begin = [0] * data_dim

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2146,7 +2146,18 @@ Array<te::Tensor> StridedSliceCompute(const Attrs& attrs, const Array<te::Tensor
                                       const Type& out_type) {
   const StridedSliceAttrs* param = attrs.as<StridedSliceAttrs>();
   CHECK(param != nullptr);
-  if (param->begin && param->end && param->strides) {
+
+  bool dyn = false;
+  for (auto& v : out_type.as<TensorTypeNode>()->shape) {
+    if (const tir::VarNode* var_node = v.as<tir::VarNode>()) {
+      if (var_node->name_hint == "any_dim") {
+        dyn = true;
+        break;
+      }
+    }
+  }
+
+  if (param->begin && param->end && param->strides && !dyn) {
     Array<Integer> begin, end, strides;
     begin = param->begin.value();
     end = param->end.value();

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -657,7 +657,6 @@ def verify_any_strided_slice(data_shape, begin_shape, end_shape, strides_shape,
     mod = tvm.IRModule()
     data = relay.var('data', shape=data_shape, dtype='float32')
     if const_attrs:
-        data = relay.var('data', shape=data_np_shape, dtype='float32')
         begin = relay.const(np_begin)
         end = relay.const(np_end)
         strides = relay.const(np_strides)


### PR DESCRIPTION
@kevinthesun @mbrookhart @icemelon9  Could you please review this, thanks

The input of strided_slice is Expr and attrs are Const, but it is still possible this strided_slice is dynamic.

This PR adds / changes some test to demostrate this issue. If we make strided_slice static and add _dyn.strided_slice, the static version can't support this case, so we have to always use _dyn.strided_slice unless we are sure shape of input is static. I think other _dyn.* ops may have similiar issue
