### PR TITLE
[LLVM/CPU] Terminate basic block after "ret" instruction

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -781,6 +781,10 @@ llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
     return CreateStaticHandle();
   } else if (op->op.same_as(builtin::tvm_throw_last_error())) {
     builder_->CreateRet(ConstInt32(-1));
+    auto next_block = std::next(builder_->GetInsertBlock()->getIterator());
+    llvm::BasicBlock* new_bb =
+        llvm::BasicBlock::Create(*ctx_, "cont", function_, &*next_block);
+    builder_->SetInsertPoint(new_bb);
     return ConstInt32(-1);
   } else if (op->op.same_as(builtin::tvm_struct_get())) {
     CHECK_EQ(op->args.size(), 3U);

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -22,14 +22,14 @@
  */
 #ifdef TVM_LLVM_VERSION
 
+#include "codegen_cpu.h"
+
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/tir/analysis.h>
 
 #include <algorithm>
 #include <memory>
 #include <unordered_map>
-
-#include "codegen_cpu.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -22,14 +22,14 @@
  */
 #ifdef TVM_LLVM_VERSION
 
-#include "codegen_cpu.h"
-
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/tir/analysis.h>
 
 #include <algorithm>
 #include <memory>
 #include <unordered_map>
+
+#include "codegen_cpu.h"
 
 namespace tvm {
 namespace codegen {
@@ -782,8 +782,7 @@ llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
   } else if (op->op.same_as(builtin::tvm_throw_last_error())) {
     builder_->CreateRet(ConstInt32(-1));
     auto next_block = std::next(builder_->GetInsertBlock()->getIterator());
-    llvm::BasicBlock* new_bb =
-        llvm::BasicBlock::Create(*ctx_, "cont", function_, &*next_block);
+    llvm::BasicBlock* new_bb = llvm::BasicBlock::Create(*ctx_, "cont", function_, &*next_block);
     builder_->SetInsertPoint(new_bb);
     return ConstInt32(-1);
   } else if (op->op.same_as(builtin::tvm_struct_get())) {


### PR DESCRIPTION
`ret` is a terminator in LLVM IR and there should be no instructions in the basic block following it. When generating a `ret`, end the current block and start a new one.