### PR TITLE
[Frontend][TFLite] Fix fully_connected converter when batch size is not 1

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1656,7 +1656,6 @@ class OperatorConverter(object):
         output_tensor_type = output_tensor.tensor.Type()
         output_tensor_type_str = self.get_tensor_type_str(output_tensor_type)
 
-        input_tensor_shape = input_tensor.tensor.ShapeAsNumpy()
         weight_tensor_shape = weight_tensor.tensor.ShapeAsNumpy()
 
         # Weight should have only 2 dimensions(TFLite convention)

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1669,14 +1669,7 @@ class OperatorConverter(object):
         # Dense expected Input shape: [batch_size, n_units]
         # Dense expected Weight shape: [out_dim, n_units]
         # Dense output shape: [batch_size, out_dim]
-        # So it is evident that input shape: [batch_size = input_size / n_units, n_units]
-        input_size = 1
-        for _, shape in enumerate(input_tensor_shape):
-            input_size *= shape
-
-        # First get the batch size
-        batch_size = int(input_size / weight_tensor_shape[1])
-        target_shape = tuple((batch_size, weight_tensor_shape[1]))
+        target_shape = tuple((-1, weight_tensor_shape[1]))
         in_expr = self.get_expr(input_tensor_idx)
         in_expr = _op.reshape(in_expr, target_shape)
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -210,10 +210,12 @@ def run_tflite_graph(tflite_model_buf, input_data):
     input_data = convert_to_list(input_data)
 
     interpreter = interpreter_wrapper.Interpreter(model_content=tflite_model_buf)
-    interpreter.allocate_tensors()
-
     input_details = interpreter.get_input_details()
     output_details = interpreter.get_output_details()
+
+    for i in range(len(input_details)):
+        interpreter.resize_tensor_input(input_details[i]['index'], input_data[i].shape)
+    interpreter.allocate_tensors()
 
     # set input
     assert len(input_data) == len(input_details)
@@ -2515,6 +2517,20 @@ def test_forward_inception_v4_net():
     tvm.testing.assert_allclose(np.squeeze(tvm_output[0]), np.squeeze(tflite_output[0]),
                                 rtol=1e-5, atol=1e-5)
 
+def test_forward_inception_v4_net_batched():
+    """Test the Inception V4 TF Lite model."""
+    # InceptionV4
+    tflite_model_file = tf_testing.get_workload_official(
+        "https://storage.googleapis.com/download.tensorflow.org/models/tflite/model_zoo/upload_20180427/inception_v4_2018_04_27.tgz",
+        "inception_v4.tflite")
+    with open(tflite_model_file, "rb") as f:
+        tflite_model_buf = f.read()
+    data = np.random.uniform(size=(4, 299, 299, 3)).astype('float32')
+    tflite_output = run_tflite_graph(tflite_model_buf, data)
+    tvm_output = run_tvm_graph(tflite_model_buf, data, 'input')
+    tvm.testing.assert_allclose(np.squeeze(tvm_output[0]), np.squeeze(tflite_output[0]),
+                                rtol=1e-5, atol=1e-5)
+
 def test_forward_qnn_inception_v1_net():
     """Test the Quantized TFLite Inception model."""
     # InceptionV1
@@ -2880,6 +2896,7 @@ if __name__ == '__main__':
     test_forward_mobilenet_v3()
     test_forward_inception_v3_net()
     test_forward_inception_v4_net()
+    test_forward_inception_v4_net_batched()
     test_forward_coco_ssd_mobilenet_v1()
     test_forward_mediapipe_hand_landmark()
 


### PR DESCRIPTION
The fully_connected converter used the shapes from the TFLite model to reshape the data tensor. However, the TFLite model shapes do not reflect those provided by the `data_shape` parameter in `from_tflite()`. The TFLite model shape `input_tensor.tensor.ShapeAsNumpy()` will give a batch size of `1` because the TFLite model obviously doesn't know about the `data_shape` dict the user provided to the relay importer.

For this particular op, the reshape can always be set to `(-1, n_units)` without needing to calculate a batch size.

For inceptionv4, without this PR we would incorrectly compute a batch size of 1 adding this reshape from %515: `(4, 1, 1, 1536)` to %516: `(1, 1536)`. This ultimately causes the model output to become `(1, 1001)` instead of `(4, 1001)`
```
  ..
  %515 = nn.avg_pool2d(%514, pool_size=[8, 8], padding=[0, 0, 0, 0], layout="NHWC") /* ty=Tensor[(4, 1, 1, 1536), float32] */;                                          
  %516 = reshape(%515, meta[relay.Constant][0] /* ty=Tensor[(2), int32] */ /* ty=Tensor[(2), int32] */, newshape=[1, 1536]) /* ty=Tensor[(1, 1536), float32] */;
  %517 = nn.dense(%516, %v_param_299, units=None) /* ty=Tensor[(1, 1001), float32] */;                                                                                  
  %518 = nn.bias_add(%517, %v_param_300) /* ty=Tensor[(1, 1001), float32] */;                        
  nn.softmax(%518, axis=1) /* ty=Tensor[(1, 1001), float32] */                                                                                                          
} 
```

Btw, should the reshape op have some validation to prevent reshapes where the numbers of elements don't match? `(4, 1, 1, 1536)` -> `(1, 1536)` shouldn't be valid.