### PR TITLE
MXNet pre-quantized BERT

### DIFF
--- a/include/tvm/relay/qnn/attrs.h
+++ b/include/tvm/relay/qnn/attrs.h
@@ -75,6 +75,19 @@ struct QuantizeAttrs : public tvm::AttrsNode<QuantizeAttrs> {
   }
 };
 
+/*! \brief Attribute for dequantize operator */
+struct DequantizeAttrs : public tvm::AttrsNode<DequantizeAttrs> {
+  int axis;
+
+  TVM_DECLARE_ATTRS(DequantizeAttrs, "relay.attrs.DequantizeAttrs") {
+    TVM_ATTR_FIELD(axis)
+        .describe(
+            "The channel axis for channel wise dequantization. Default value is -1,"
+            "which corresponds to the last axis.")
+        .set_default(-1);
+  }
+};
+
 }  // namespace qnn
 }  // namespace relay
 }  // namespace tvm

--- a/python/tvm/relay/frontend/nnvm_common.py
+++ b/python/tvm/relay/frontend/nnvm_common.py
@@ -17,10 +17,13 @@
 # pylint: disable=invalid-name, import-self, len-as-condition
 """Utility functions common to NNVM and MxNet conversion."""
 import warnings
+from ... import error
+from ...tir.op import min_value
 from .. import expr as _expr
 from .. import op as _op
 from .common import get_relay_op
 from .common import infer_type as _infer_type
+from .common import infer_shape as _infer_shape
 
 def _warn_not_used(attr, op='nnvm'):
     err = "{} is ignored in {}.".format(attr, op)
@@ -57,9 +60,53 @@ def _init_op(new_op):
 def _softmax_op(new_op):
     """softmax/log_softmax"""
     def _impl(inputs, attrs, _dtype='float32'):
-        # TODO(@icemelon9): currently ignore the 2nd input to softmax for mxnet 1.6
-        # assert len(inputs) == 1
         axis = attrs.get_int("axis", -1)
+        use_length = attrs.get_bool("use_length", False)
+        if use_length:
+            # The second arg is valid_length. We can use sequence mask to mask the input before
+            # computing softmax
+            assert len(inputs) == 2
+
+            data = inputs[0]
+            length = inputs[1]
+            data_shape = _infer_shape(data)
+            length_shape = _infer_shape(length)
+
+            if axis < 0:
+                axis = len(data_shape) + axis
+
+            data_ndims = len(data_shape)
+            length_ndims = len(length_shape)
+
+            # Sequence_mask supports axis = 0 and 1 and requires data to be in specific format.
+            if axis == data_ndims - 1 and data_ndims > 2 and length_ndims == 2:
+                new_batch_size = 1
+                for dim in range(length_ndims):
+                    assert data_shape[dim] == length_shape[dim]
+                    new_batch_size *= data_shape[dim]
+
+                # Reshape the data and length to satisfy sequence mask
+                data = _op.reshape(data, newshape=(new_batch_size, -1))
+                length = _op.reshape(length, newshape=(new_batch_size))
+
+                # Input data is now 2D, we can set the axis = 1
+                axis = 1
+            elif data_ndims > 2:
+                raise error.OpNotImplemented(\
+                        "Operator softmax with use_length=True is supported only for axis -1")
+
+            res = _op.sequence_mask(data=data,
+                                    valid_length=length,
+                                    mask_value=float(min_value("float").value),
+                                    axis=axis)
+
+            # Apply softmax
+            res = new_op(res, axis=axis)
+
+            # Reshape back to input data shape
+            if len(data_shape) > 2:
+                return _op.reshape(res, newshape=data_shape)
+            return res
         return new_op(inputs[0], axis=axis)
     return _impl
 

--- a/python/tvm/relay/frontend/nnvm_common.py
+++ b/python/tvm/relay/frontend/nnvm_common.py
@@ -70,6 +70,7 @@ def _softmax_op(new_op):
             data = inputs[0]
             length = inputs[1]
             data_shape = _infer_shape(data)
+            data_dtype = _infer_type(data).checked_type.dtype
             length_shape = _infer_shape(length)
 
             if axis < 0:
@@ -97,7 +98,7 @@ def _softmax_op(new_op):
 
             res = _op.sequence_mask(data=data,
                                     valid_length=length,
-                                    mask_value=float(min_value("float").value),
+                                    mask_value=float(min_value(data_dtype).value),
                                     axis=axis)
 
             # Apply softmax

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -121,7 +121,8 @@ def quantize(data,
 
 def dequantize(data,
                input_scale,
-               input_zero_point):
+               input_zero_point,
+               axis=-1):
     r""" Dequantize op
     This operator takes quantized int8 and unit8 as input and produces
     dequantized float32 as output. The output shape is the same as input shape. The input
@@ -135,6 +136,8 @@ def dequantize(data,
         The input zero_point.
     input_scale : tvm.relay.Expr
         The input scale.
+    axis : int
+        The channel axis for quantization. Default value is -1 which corresponds to the last axis.
     Returns
     -------
     result : tvm.relay.Expr
@@ -143,7 +146,8 @@ def dequantize(data,
 
     return _make.dequantize(data,
                             input_scale,
-                            input_zero_point)
+                            input_zero_point,
+                            axis)
 
 
 def concatenate(data,

--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -34,6 +34,8 @@ namespace tvm {
 namespace relay {
 namespace qnn {
 
+TVM_REGISTER_NODE_TYPE(DequantizeAttrs);
+
 bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                    const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 4);
@@ -45,9 +47,16 @@ bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
       << "Input type should be one of the quantized types [unit8, int8, int32] but was "
       << input_dtype;
 
-  // Check the types of scale and zero points.
-  CHECK(IsScalarType(types[1], DataType::Float(32)));  // input_scale
-  CHECK(IsScalarType(types[2], DataType::Int(32)));    // input_zero_point
+  const auto* dequantize_attrs = attrs.as<DequantizeAttrs>();
+  int axis = dequantize_attrs->axis;
+  axis = (axis == -1) ? data->shape.size() - 1 : axis;
+  CHECK_LT(axis, static_cast<int>(data->shape.size()))
+      << "axis " << dequantize_attrs->axis << " is out of range";
+  CHECK_GE(axis, 0) << "axis " << dequantize_attrs->axis << " is out of range";
+
+  // Check and assign types for scale and zero points.
+  AssignType(types[1], DataType::Float(32), data->shape[axis], reporter);  // scale
+  AssignType(types[2], DataType::Int(32), data->shape[axis], reporter);    // zero point
 
   const Array<tvm::PrimExpr> oshape = data->shape;
   // assign output type, output will always be float 32.
@@ -55,16 +64,34 @@ bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   return true;
 }
 
-Expr MakeDequantize(Expr data, Expr input_scale, Expr input_zero_point) {
+Expr MakeDequantize(Expr data, Expr input_scale, Expr input_zero_point, int axis) {
   // real_value = scale * (quantized_value - zero_point)
   // A more detailed explanation can be found here -
   // https://github.com/google/gemmlowp/blob/master/doc/quantization.md
+  auto attrs = make_object<DequantizeAttrs>();
+  attrs->axis = axis;
   static const Op& op = Op::Get("qnn.dequantize");
-  return Call(op, {data, input_scale, input_zero_point}, Attrs(), {});
+  return Call(op, {data, input_scale, input_zero_point}, Attrs(attrs), {});
 }
 
 Expr DequantizeLower(const Expr& input_tensor, const Expr& input_scale,
-                     const Expr& input_zero_point) {
+                     const Expr& input_zero_point, const Array<IndexExpr>& input_shape,
+                     const DequantizeAttrs* attrs) {
+  const auto axis = attrs->axis;
+
+  size_t n_dim = input_shape.size();
+
+  // Expand scale and zero point if the input tensor is channel quantized
+  auto expanded_input_scale = input_scale;
+  if (!IsConstScalar(input_scale)) {
+    expanded_input_scale = ExpandBiasToMatchAxis(input_scale, n_dim, {axis});
+  }
+
+  auto expanded_input_zero_point = input_zero_point;
+  if (!IsConstScalar(input_zero_point)) {
+    expanded_input_zero_point = ExpandBiasToMatchAxis(input_zero_point, n_dim, {axis});
+  }
+
   auto shift = Subtract(Cast(input_tensor, DataType::Int(32)), input_zero_point);
   auto scaled_output = Multiply(Cast(shift, DataType::Float(32)), input_scale);
   return scaled_output;
@@ -77,7 +104,20 @@ Expr DequantizeQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   auto& input_scale = new_args[1];
   auto& input_zero_point = new_args[2];
   CHECK_EQ(types.size(), 4);
-  return DequantizeLower(data, input_scale, input_zero_point);
+
+  // Get attrs.
+  const auto* dequantize_attrs = attrs.as<DequantizeAttrs>();
+  CHECK(dequantize_attrs != nullptr);
+
+  // Find input shape.
+  CHECK_EQ(types.size(), 4);
+  auto in_type = types[0];
+  auto in_tensor_type = in_type.as<TensorTypeNode>();
+  CHECK(in_tensor_type != nullptr) << "Type information missing."
+                                   << " Please run infer_type pass.";
+  Array<IndexExpr> input_shape = in_tensor_type->shape;
+
+  return DequantizeLower(data, input_scale, input_zero_point, input_shape, dequantize_attrs);
 }
 
 RELAY_REGISTER_OP("qnn.dequantize")
@@ -85,6 +125,7 @@ RELAY_REGISTER_OP("qnn.dequantize")
 The input is always quantized (int8, uint8) and will be converted to float32 given input scale and zero_point.
 - **data**: Quantized tensor of any shape to dequantize. The input data can be of floating point
 )code" TVM_ADD_FILELINE)
+    .set_attrs_type<DequantizeAttrs>()
     .set_num_inputs(3)
     .add_argument("data", "Tensor", "The tensor to dequantize.")
     .add_argument("input_scale", "Tensor", "The quantization scale of the input tensor.")

--- a/tests/python/relay/test_op_qnn_dequantize.py
+++ b/tests/python/relay/test_op_qnn_dequantize.py
@@ -21,13 +21,14 @@ import numpy as np
 from tvm import relay
 from tvm.contrib import graph_runtime
 
-def quantize_test_driver(in_dtype, quant_args, in_data, verify_output_data):
+def dequantize_test_driver(in_dtype, quant_args, in_data, verify_output_data, axis):
     shape = in_data.shape
     input_data = relay.var("input_data", shape=shape, dtype=in_dtype)
     input_zero_point = relay.const(quant_args['in_zero_point'], 'int32')
     input_scale = relay.const(quant_args['in_scale'], 'float32')
     quantized_output = relay.qnn.op.dequantize(input_data, input_scale=input_scale,
-                                               input_zero_point=input_zero_point)
+                                               input_zero_point=input_zero_point,
+                                               axis=axis)
     mod = relay.Function(relay.analysis.free_vars(quantized_output), quantized_output)
     mod = tvm.IRModule.from_expr(mod)
     with tvm.transform.PassContext(opt_level=3):
@@ -48,8 +49,8 @@ def test_uint8_to_float32():
         .astype('float32') \
         .reshape((2, 5))
     quant_args = {"in_zero_point":127, "in_scale":0.5}
-    quantize_test_driver(in_dtype='uint8', quant_args=quant_args, in_data=data,
-                         verify_output_data=output)
+    dequantize_test_driver(in_dtype='uint8', quant_args=quant_args, in_data=data,
+                           verify_output_data=output, axis=-1)
 
 def test_int8_to_float32():
     data = np.array([-128, -127, -126, -125, -124, 123, 124, 125, 126, 127]) \
@@ -59,18 +60,31 @@ def test_int8_to_float32():
         .astype('float32') \
         .reshape((2, 5))
     quant_args = {"in_zero_point": -1, "in_scale": 0.5}
-    quantize_test_driver(in_dtype='int8', quant_args=quant_args, in_data=data,
-                         verify_output_data=output)
+    dequantize_test_driver(in_dtype='int8', quant_args=quant_args, in_data=data,
+                           verify_output_data=output, axis=-1)
 
 def test_int32_to_float32():
     data = np.array([113, 29, -1052]).astype('int32')
     output = np.array([0.6550452, 0.16810896, -6.098297]).astype('float32')
     quant_args = {"in_zero_point": 0, "in_scale": 0.0057968604}
-    quantize_test_driver(in_dtype='int32', quant_args=quant_args, in_data=data,
-                         verify_output_data=output)
+    dequantize_test_driver(in_dtype='int32', quant_args=quant_args, in_data=data,
+                           verify_output_data=output, axis=-1)
+
+
+def test_channelwise_axis_1():
+    data = np.transpose(np.array([0, 1, 2, 3, 4, 243, 247, 249, 250, 251]) \
+                        .astype('uint8').reshape((2,5)))
+    output = np.transpose(np.array([-63.5, -63, -62.5, -62, -61.5, 30, 31, 31.5, 31.75, 32]) \
+                         .astype('float32').reshape((2,5)))
+    quant_args = {"in_zero_point" : np.array([127, 123]).astype('int32'),
+                  "in_scale"      : np.array([0.5, 0.25]).astype('float32')}
+
+    dequantize_test_driver(in_dtype='uint8', quant_args=quant_args, in_data=data,
+                           verify_output_data=output, axis=1)
 
 
 if __name__ == "__main__":
     test_uint8_to_float32()
     test_int8_to_float32()
     test_int32_to_float32()
+    test_channelwise_axis_1()


### PR DESCRIPTION
MXnet pre-quantized BERT model - https://gluon-nlp.mxnet.io/examples/sentence_embedding/bert.html#Quantize-the-model

Features added in this PR

* Support for Tensor quantization for MXNet Dense operator
* Support for Channel quantization for MXNet Dense operator
* Adding channel wise support for dequantize op
* Support softmax use_length for axis=-1
