### PR TITLE
[TOPI] Improve schedule for injective on x86

### DIFF
--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -24,6 +24,8 @@
 #ifndef TVM_RUNTIME_THREADING_BACKEND_H_
 #define TVM_RUNTIME_THREADING_BACKEND_H_
 
+#include <tvm/runtime/c_runtime_api.h>
+
 #include <functional>
 #include <memory>
 #include <vector>
@@ -92,7 +94,7 @@ void Yield();
 /*!
  * \return the maximum number of effective workers for this system.
  */
-int MaxConcurrency();
+TVM_DLL int MaxConcurrency();
 
 }  // namespace threading
 }  // namespace runtime

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -22,6 +22,7 @@
  * \brief Native threading backend
  */
 #include <dmlc/logging.h>
+#include <tvm/runtime/registry.h>
 #include <tvm/runtime/threading_backend.h>
 
 #include <algorithm>
@@ -264,6 +265,10 @@ int MaxConcurrency() {
   }
   return std::max(max_concurrency, 1);
 }
+
+TVM_REGISTER_GLOBAL("runtime.max_concurrency").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = MaxConcurrency();
+});
 
 }  // namespace threading
 }  // namespace runtime

--- a/topi/python/topi/x86/injective.py
+++ b/topi/python/topi/x86/injective.py
@@ -16,8 +16,8 @@
 # under the License.
 # pylint: disable=invalid-name
 """x86 declaration and schedules."""
-from tvm import te, tir, target, runtime
-from ..util import is_empty_shape, get_const_int
+from tvm import te, tir, runtime
+from ..util import is_empty_shape
 
 def schedule_injective_from_existing(sch, out):
     """Schedule for injective op from existing schedule.


### PR DESCRIPTION
The existing schedule does not handle parallel correctly for all shapes.
For example, it does not do parallel for shape (1, 4096, 1024) at all.
This pr makes the parallel strategy more general.
