### PR TITLE
[LLVM] Create TBAA information based on the unrelying buffer type

### DIFF
--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -273,7 +273,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   void CreateSerialFor(llvm::Value* begin, llvm::Value* end, llvm::Value* stride,
                        const Var& loop_var, const Stmt& body);
   // add alias information.
-  void AddAliasInfo(llvm::Instruction* load, const VarNode* buffer, PrimExpr index, DataType type);
+  void AddAliasInfo(llvm::Instruction* load, const VarNode* buffer, PrimExpr index);
   // The IRBuilder.
   using IRBuilder = llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter>;
   // The current function


### PR DESCRIPTION
Currently, the TBAA information is based on the access type, i.e. the data type from the load or store instruction. When the same
memory area is accessed with different types, the corresponding load/store instruction may end up not being aliased to each other. This could lead to incorrect code being generated.

An example of when such a situation can occur is when two different `buffer_decl`s are created for the same buffer:
```
  ba = buffer_decl(... dtype = 'int16' ...)
  bb = buffer_decl(data = ba.data, dtype = 'int32x32' ...)
```
Then instructions
```
  ba[x] = 0
  ... = bb[x]
```
may be reordered in the final code due to the alias info indicating that they are not aliased.