### PR TITLE
[BUGFIX] Fix a number of memory leaks

### DIFF
--- a/src/ir/op.cc
+++ b/src/ir/op.cc
@@ -115,7 +115,7 @@ TVM_REGISTER_GLOBAL("ir.RegisterOpAttr")
           PackedFunc f = value;
           // If we get a function from frontend, avoid deleting it.
           std::unique_ptr<PackedFunc> fcopy(new PackedFunc(f));
-          reg.set_attr(attr_key, fcopy.get(), plevel);
+          reg.set_attr(attr_key, *fcopy, plevel);
         } else {
           reg.set_attr(attr_key, value, plevel);
         }

--- a/src/ir/op.cc
+++ b/src/ir/op.cc
@@ -114,8 +114,8 @@ TVM_REGISTER_GLOBAL("ir.RegisterOpAttr")
           // do an eager copy of the PackedFunc
           PackedFunc f = value;
           // If we get a function from frontend, avoid deleting it.
-          auto* fcopy = new PackedFunc(f);
-          reg.set_attr(attr_key, *fcopy, plevel);
+          std::unique_ptr<PackedFunc> fcopy(new PackedFunc(f));
+          reg.set_attr(attr_key, fcopy.get(), plevel);
         } else {
           reg.set_attr(attr_key, value, plevel);
         }

--- a/src/target/generic_func.cc
+++ b/src/target/generic_func.cc
@@ -131,7 +131,7 @@ TVM_REGISTER_GLOBAL("target.GenericFuncGetGlobal").set_body([](TVMArgs args, TVM
 TVM_REGISTER_GLOBAL("target.GenericFuncSetDefault").set_body([](TVMArgs args, TVMRetValue* ret) {
   GenericFunc generic_func = args[0];
   // Intentionally copy and not de-allocate it, to avoid free pyobject during shutdown
-  PackedFunc* func = new PackedFunc(args[1].operator PackedFunc());
+  std::unique_ptr<PackedFunc> func(new PackedFunc(args[1].operator PackedFunc()));
   bool allow_override = args[2];
 
   generic_func.set_default(*func, allow_override);
@@ -140,7 +140,7 @@ TVM_REGISTER_GLOBAL("target.GenericFuncSetDefault").set_body([](TVMArgs args, TV
 TVM_REGISTER_GLOBAL("target.GenericFuncRegisterFunc").set_body([](TVMArgs args, TVMRetValue* ret) {
   GenericFunc generic_func = args[0];
   // Intentionally copy and not de-allocate it, to avoid free pyobject during shutdown
-  PackedFunc* func = new PackedFunc(args[1].operator PackedFunc());
+  std::unique_ptr<PackedFunc> func(new PackedFunc(args[1].operator PackedFunc()));
   Array<runtime::String> tags = args[2];
   bool allow_override = args[3];
 


### PR DESCRIPTION
This PR fixed a number of memory leaks in C++, where memory allocations should have been handled with unique_ptr.