### PR TITLE
Build crttest and cpptest separately.

### DIFF
--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -30,8 +30,8 @@ export OMP_NUM_THREADS=1
 # Remove existing testcases
 rm -f build/*_test
 
-make cpptest -j3
-make crttest -j3
+make cpptest -j8
+make crttest -j8
 for test in build/*_test; do
     ./$test
 done

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -30,7 +30,8 @@ export OMP_NUM_THREADS=1
 # Remove existing testcases
 rm -f build/*_test
 
-make crttest cpptest -j3
+make cpptest -j3
+make crttest -j3
 for test in build/*_test; do
     ./$test
 done


### PR DESCRIPTION
 * Try to fix random CI crashing, likely caused by concurrent cmake execution.

I think this is causing random errors in the CI, because cmake is running concurrently for crttest and cpptest.

@kparzysz-quic @tqchen 