### PR TITLE
[TIR][BugFix] Avoid simplifying substituted tir.Any expressions for layout transformations

### DIFF
--- a/src/tir/ir/data_layout.cc
+++ b/src/tir/ir/data_layout.cc
@@ -323,7 +323,12 @@ inline Array<PrimExpr> TransformShape(const Array<PrimExpr>& src_shape,
       if (symbolic_var_set.count(i)) {
         result.push_back(tir::Any());
       } else {
-        result.push_back(ana.Simplify(tir::Substitute(rule, bind_map)));
+        auto sub = tir::Substitute(rule, bind_map);
+        if (sub.as<tir::AnyNode>()) {
+          result.push_back(tir::Any());
+        } else {
+          result.push_back(ana.Simplify(sub));
+        }
       }
     }
   }

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -324,7 +324,17 @@ def verify_any_layout_transform(data_shape, src_layout, dst_layout, static_data_
 
 def test_any_layout_transform():
     verify_any_layout_transform(any_dims(4), "NCHW", "NHWC", (3, 4, 5, 6), (3, 5, 6, 4))
+    verify_any_layout_transform((3, relay.Any(), relay.Any(), 6), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
+    verify_any_layout_transform((relay.Any(), 4, 5, relay.Any()), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
+    verify_any_layout_transform((3, 4, 5, relay.Any()), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
+    verify_any_layout_transform((relay.Any(), 4, 5, 6), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
+    verify_any_layout_transform((3, 4, 5, 6), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
+    verify_any_layout_transform((3, relay.Any(), 5, 6), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
+    verify_any_layout_transform((3, 4, relay.Any(), 6), "NHWC", "NCHW", (3, 4, 5, 6), (3, 6, 4, 5))
     verify_any_layout_transform(any_dims(5), "NCHW16c", "NCHW2c", (1, 2, 8, 8, 16), (1, 16, 8, 8, 2))
+    verify_any_layout_transform((1, relay.Any(), 8, 8, relay.Any()), "NCHW16c", "NCHW2c", (1, 2, 8, 8, 16), (1, 16, 8, 8, 2))
+    verify_any_layout_transform((1, relay.Any(), relay.Any(), 8, 16), "NCHW16c", "NCHW2c", (1, 2, 8, 8, 16), (1, 16, 8, 8, 2))
+    verify_any_layout_transform((1, 2, 8, relay.Any(), 16), "NCHW16c", "NCHW2c", (1, 2, 8, 8, 16), (1, 16, 8, 8, 2))
     verify_any_layout_transform(any_dims(5), "NCHW6n", "NHWC", (3, 4, 5, 6, 6), (18, 5, 6, 4))
     verify_any_layout_transform(any_dims(4), "NCHW", "NCHW4c", (3, 4, 5, 6), (3, 1, 5, 6, 4))
     verify_any_layout_transform((16, 1), "CH", "C4cH", (16, 1), (4, 4, 1))


### PR DESCRIPTION
Avoid simplifying substituted tir.Any expressions when applying shape transformation during layout conversion. Add tests to reproduce the exposed bug observed during ingestion of [ssd_mobilenet_v3_small_coco_2020_01_14](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v3_small_coco_2020_01_14.tar.gz) without specifying an explicit input shape via the TF frontend.

