### PR TITLE
[VTA] Fix FSIM Compile Error.

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -103,13 +103,13 @@ elseif(PYTHON)
     # Target lib: vta
     add_library(vta SHARED ${FPGA_RUNTIME_SRCS})
     target_include_directories(vta PUBLIC vta/runtime)
+    target_include_directories(vta PUBLIC ${VTA_HW_PATH}/include)
     foreach(__def ${VTA_DEFINITIONS})
       string(SUBSTRING ${__def} 3 -1 __strip_def)
       target_compile_definitions(vta PUBLIC ${__strip_def})
     endforeach()
     if(${VTA_TARGET} STREQUAL "pynq" OR
        ${VTA_TARGET} STREQUAL "ultra96")
-      target_include_directories(vta PUBLIC ${VTA_HW_PATH}/include)
       target_link_libraries(vta ${__cma_lib})
     elseif(${VTA_TARGET} STREQUAL "de10nano")  # DE10-Nano rules
      #target_compile_definitions(vta PUBLIC VTA_MAX_XFER=2097152) # (1<<21)


### PR DESCRIPTION
Issue:
when set vta target into "sim", vta compile would get fail and
show error message "fatal error: vta/driver.h: No such file or directory".

Solution:
set VTA_HW include path correctly.

