### PR TITLE
Enable CUDA Target For Virutal Machine Run with Dynamic Input

### DIFF
--- a/include/tvm/runtime/vm.h
+++ b/include/tvm/runtime/vm.h
@@ -700,6 +700,8 @@ class VirtualMachine : public runtime::ModuleNode {
  protected:
   /*! \brief The virtual machine's packed function table. */
   std::vector<PackedFunc> packed_funcs_;
+  /*! \brief The virtual machine's shape function recorder. */
+  std::unordered_map<Index, bool> shape_funcs_recorder_;
   /*! \brief The current stack of call frames. */
   std::vector<VMFrame> frames_;
   /*! \brief The fuction table index of the current function. */

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -3737,7 +3737,7 @@ def test_forward_dynamic_input_shape():
             graph_def = tf_testing.AddShapesToGraphDef(sess, out_name)
             tf_output = run_tf_graph(sess, np_data, 'data:0', ['{}:0'.format(out_name)])
             # TODO(kevinthesun): enable gpu test when VM heterogeneous execution is ready.
-            for device in ["llvm"]:
+            for device in ["llvm", "cuda"]:
                 ctx = tvm.context(device, 0)
                 if not ctx.exist:
                     print("Skip because %s is not enabled" % device)


### PR DESCRIPTION
Currently, when we want to compile and execute a network with dynamic input, only using `llvm` target can work as expected. 

If the target is as `CUDA`, the compilation part works fine, but the run part fails. The reason why this happens is that the shape functions dealing with dynamic inputs are normally built on target host like `llvm`, while the output tensors of shape functions need to locate on gpu target. Therefore, in the PR, I try to fix this bug by creating temporary output tensors on cpu for results of shape functions and coping them to the output tensors created by the vm located on gpu.