### PR TITLE
[AutoTVM] Load configs even it has no entity

### DIFF
--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -209,13 +209,7 @@ def load_from_file(filename):
             ret = decode(row)
             if ret is None:
                 continue
-            inp, res = ret
-            # Avoid loading the record with an empty config. The TOPI schedule with no entities
-            # will result in an empty entity map (e.g., depthwise_conv2d_nchw on x86).
-            # Using an empty config will cause problems when applying alter op like NCHW to NCHWc.
-            if not inp.config._entity_map:
-                continue
-            yield (inp, res)
+            yield ret
 
 
 def split_workload(in_file, clean=True):


### PR DESCRIPTION
In #4520, I added a logic to skip the records with empty entities to avoid KeyError when altering depthwise ops. Due to the Relay op strategy, we won't let NCHWc use NCHW config anymore, so this logic is no longer required. In addition, the reason of removing this logic in this PR is to allow the records of vendor libraries to be loaded and selected by op strategy.

cc @icemelon9 @tqchen 
