### PR TITLE
Delete declaration of unused op_node

### DIFF
--- a/src/te/operation/compute_op.cc
+++ b/src/te/operation/compute_op.cc
@@ -88,7 +88,6 @@ Array<PrimExpr> BaseComputeOpNode::output_shape(size_t idx) const {
 
 Tensor compute(Array<PrimExpr> shape, FCompute fcompute, std::string name, std::string tag,
                Map<String, ObjectRef> attrs) {
-  auto op_node = make_object<ComputeOpNode>();
   // compute dimension.
   size_t ndim = shape.size();
   std::vector<IterVar> axis;
@@ -105,7 +104,6 @@ Tensor compute(Array<PrimExpr> shape, FCompute fcompute, std::string name, std::
 
 Array<Tensor> compute(Array<PrimExpr> shape, FBatchCompute fcompute, std::string name,
                       std::string tag, Map<String, ObjectRef> attrs) {
-  auto op_node = make_object<ComputeOpNode>();
   // compute dimension.
   size_t ndim = shape.size();
   std::vector<IterVar> axis;


### PR DESCRIPTION
Based on this [issue](https://github.com/apache/incubator-tvm/pull/77/files#diff-03a3a12f09e6fce448be590460b24fa3L67),  it seems that the use of op_node is deleted, but its declaration is left, this code is useless. @tqchen @jroesch 