### PR TITLE
[Ansor][AutoTVM v2.0] Phase 1: Access Analyzer

### DIFF
--- a/include/tvm/auto_scheduler/auto_schedule.h
+++ b/include/tvm/auto_scheduler/auto_schedule.h
@@ -18,19 +18,17 @@
  */
 
 /*!
- * \file auto_scheduler/auto_schedule.h
- * \brief The user interface of the TVM Auto-scheduler. This is the entry structure to get
- * schedule search requirements from upper level (Python API), and returns a high performance
- * schedule after search process.
+ * \file tvm/auto_scheduler/auto_schedule.h
+ * \brief The user interface of the auto scheduler.
  */
 
 #ifndef TVM_AUTO_SCHEDULER_AUTO_SCHEDULE_H_
 #define TVM_AUTO_SCHEDULER_AUTO_SCHEDULE_H_
 
-#include <utility>
+#include <tvm/auto_scheduler/measure.h>
+#include <tvm/auto_scheduler/search_policy.h>
 
-#include "measure.h"
-#include "search_policy/search_policy.h"
+#include <utility>
 
 namespace tvm {
 namespace auto_scheduler {
@@ -38,9 +36,9 @@ namespace auto_scheduler {
 /*! \brief Tuning and measurement options. */
 class TuningOptionsNode : public Object {
  public:
-  /*! \brief Number of total measurement trials. */
+  /*! \brief The number of total measurement trials. */
   int num_measure_trials;
-  /*! \brief Stops early the tuning if no improvement after n measurements. */
+  /*! \brief Stops the tuning early if no improvement after n measurements. */
   int early_stopping;
   /*! \brief The number of programs to be measured at each search round. */
   int num_measures_per_round;
@@ -51,7 +49,7 @@ class TuningOptionsNode : public Object {
   int verbose;
   /*! \brief ProgramBuilder which builds the program */
   ProgramBuilder builder;
-  /*! \brief ProgramRunner which runs the program and measure time costs */
+  /*! \brief ProgramRunner which runs the program and measures time costs */
   ProgramRunner runner;
   /*! \brief MeasureCallback functions to be called after each measure batch */
   Optional<Array<MeasureCallback>> measure_callbacks;
@@ -81,8 +79,8 @@ class TuningOptions : public ObjectRef {
  public:
   /*!
    * \brief The constructor
-   * \param num_measure_trials Number of total measurement trials.
-   * \param early_stopping Stops early the tuning if no improvement after n measurements.
+   * \param num_measure_trials The number of total measurement trials.
+   * \param early_stopping Stops the tuning early if no improvement after n measurements.
    * \param num_measures_per_round The number of programs to be measured at each search round.
    * \param verbose Verbosity level. 0 for silent, 1 to output information during schedule
    * search.
@@ -100,11 +98,11 @@ class TuningOptions : public ObjectRef {
 };
 
 /*!
- * \brief Auto schedule search for a given compute declaration.
+ * \brief Run schedule search for a given compute declaration.
  * \param task The search task of the compute declaration.
- * \param search_policy The search policy to be used for schedule search.
+ * \param search_policy The search policy to be used.
  * \param tuning_options Tuning and measurement options.
- * \return A `te::schedule` and the a Array of `te::Tensor` to be used in `tvm.lower` or
+ * \return A `te::schedule` and the an Array of `te::Tensor` to be used in `tvm.lower` or
  * `tvm.build`.
  */
 TVM_DLL std::pair<te::Schedule, Array<te::Tensor>> AutoSchedule(SearchTask task,

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -147,8 +147,8 @@ class AccessAnalyzer : public ObjectRef {
    * \param target_op The target operation
    * \note This function propagates the relation for chains with multiple ops.
    */
-  TVM_DLL int GetNumCommonOuterIterator(
-      const te::Operation& op, const te::Operation& target_op) const;
+  TVM_DLL int GetNumCommonOuterIterator(const te::Operation& op,
+                                        const te::Operation& target_op) const;
 
   /*!
    * \brief Return whether two operations are elementwise-matched

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -68,7 +68,8 @@ class AccessAnalyzerNode : public Object {
    *  (e.g., injective, broadcast and elementwise ops without reduction) */
   OperationMap<bool> is_simple_access;
   /*! \brief Store whether the operation is strictly-inlineable
-   * (e.g., injective, broadcast and elementwise without reduction, branch or expenive operations) */
+   * (e.g., injective, broadcast and elementwise without reduction, branch or expenive operations)
+   */
   OperationMap<bool> is_strict_inlineable;
   /*! \brief Store whether the operation needs multi-level tiling
    * (e.g., computation-intensive ops with data reuse opportunity like matmul, conv2d) */

--- a/include/tvm/auto_scheduler/loop_state.h
+++ b/include/tvm/auto_scheduler/loop_state.h
@@ -159,7 +159,7 @@ using IterKey = std::pair<int, int>;
  */
 class AttachMapNode : public Object {
  public:
-  struct key_hash : public std::function<std::size_t(IterKey)> {
+  struct IterKeyHash {
     std::size_t operator()(const IterKey& k) const {
       return ::dmlc::HashCombine(std::hash<int>()(k.first), std::hash<int>()(k.second));
     }
@@ -168,7 +168,7 @@ class AttachMapNode : public Object {
   /*! \brief A Map to store the mapping of stage to its attached iterator. */
   std::unordered_map<StageKey, IterKey> stage_to_attach_iter;
   /*! \brief A Map to store the mapping of iterator to the stage attached to it. */
-  std::unordered_map<IterKey, std::vector<StageKey>, key_hash> iter_to_attached_stages;
+  std::unordered_map<IterKey, std::vector<StageKey>, IterKeyHash> iter_to_attached_stages;
 
   static constexpr const char* _type_key = "auto_scheduler.AttachMap";
   TVM_DECLARE_FINAL_OBJECT_INFO(AttachMapNode, Object);

--- a/include/tvm/auto_scheduler/loop_state.h
+++ b/include/tvm/auto_scheduler/loop_state.h
@@ -346,9 +346,9 @@ class State : public ObjectRef {
    * \note If we do split on an iterator which has stages attached at it(by compute_at), the inner
    * most iterator of split results will become the new attach point.
    */
-  TVM_DLL Array<Iterator> split(
-      int stage_id, const Iterator& it, const Array<Optional<Integer>>& lengths,
-      bool inner_to_outer = true);
+  TVM_DLL Array<Iterator> split(int stage_id, const Iterator& it,
+                                const Array<Optional<Integer>>& lengths,
+                                bool inner_to_outer = true);
 
   /********** Step APIs working on multiple stages **********/
 

--- a/include/tvm/auto_scheduler/loop_state.h
+++ b/include/tvm/auto_scheduler/loop_state.h
@@ -297,14 +297,14 @@ class State : public ObjectRef {
    * this input.
    * \return The iterator result after binded.
    */
-  Iterator bind(int stage_id, const Iterator& it, IteratorAnnotation thread_type);
+  TVM_DLL Iterator bind(int stage_id, const Iterator& it, IteratorAnnotation thread_type);
   /*!
    * \brief Schedule primitive corresponds to te.parallel.
    * \param stage_id The index of the stage to be paralleled.
    * \param it The iterator to be paralleled.
    * \return The iterator result after parallel.
    */
-  Iterator parallel(int stage_id, const Iterator& it);
+  TVM_DLL Iterator parallel(int stage_id, const Iterator& it);
   /*!
    * \brief Schedule primitive corresponds to te.unroll.
    * \param stage_id The index of the stage to be unrolled.
@@ -313,14 +313,14 @@ class State : public ObjectRef {
    * skipped.
    * \return The iterator result after unrolled.
    */
-  Iterator unroll(int stage_id, const Iterator& it, int max_unroll = -1);
+  TVM_DLL Iterator unroll(int stage_id, const Iterator& it, int max_unroll = -1);
   /*!
    * \brief Schedule primitive corresponds to te.vectorize.
    * \param stage_id The index of the stage to be vectorized.
    * \param it The iterator to be vectorized.
    * \return The iterator result after vectorize.
    */
-  Iterator vectorize(int stage_id, const Iterator& it);
+  TVM_DLL Iterator vectorize(int stage_id, const Iterator& it);
   /*!
    * \brief Schedule primitive corresponds to te.fuse.
    * \param stage_id The index of the stage to be fused.
@@ -329,13 +329,13 @@ class State : public ObjectRef {
    * \note If the iterators to be fused have stages attached at them(by compute_at), the fused
    * result will become the new attach point.
    */
-  Iterator fuse(int stage_id, const Array<Iterator>& iters);
+  TVM_DLL Iterator fuse(int stage_id, const Array<Iterator>& iters);
   /*!
    * \brief Schedule primitive corresponds to te.reorder.
    * \param stage_id The index of the stage to be reordered.
    * \param order The expected iterator order.
    */
-  void reorder(int stage_id, const Array<Iterator>& order);
+  TVM_DLL void reorder(int stage_id, const Array<Iterator>& order);
   /*!
    * \brief Schedule primitive corresponds to te.split.
    * \param stage_id The index of the stage to be split.
@@ -346,8 +346,9 @@ class State : public ObjectRef {
    * \note If we do split on an iterator which has stages attached at it(by compute_at), the inner
    * most iterator of split results will become the new attach point.
    */
-  Array<Iterator> split(int stage_id, const Iterator& it, const Array<Optional<Integer>>& lengths,
-                        bool inner_to_outer = true);
+  TVM_DLL Array<Iterator> split(
+      int stage_id, const Iterator& it, const Array<Optional<Integer>>& lengths,
+      bool inner_to_outer = true);
 
   /********** Step APIs working on multiple stages **********/
 
@@ -361,12 +362,12 @@ class State : public ObjectRef {
    * bound for the newly created iterators.
    * Call ComputeDAG::InferBound on the updated state to get the complete bound information.
    */
-  void compute_at(int stage_id, int target_stage_id, const Iterator& target_iter);
+  TVM_DLL void compute_at(int stage_id, int target_stage_id, const Iterator& target_iter);
   /*!
    * \brief Schedule primitive corresponds to te.compute_inline.
    * \param stage_id The index of the stage to be reordered.
    */
-  void compute_inline(int stage_id);
+  TVM_DLL void compute_inline(int stage_id);
   /*!
    * \brief Schedule primitive corresponds to te.compute_root.
    * \param stage_id The index of the stage to be reordered.
@@ -375,7 +376,7 @@ class State : public ObjectRef {
    * bound for the newly created iterators.
    * Call ComputeDAG::InferBound on the updated state to get the complete bound information.
    */
-  void compute_root(int stage_id);
+  TVM_DLL void compute_root(int stage_id);
 
   TVM_DEFINE_OBJECT_REF_METHODS(State, ObjectRef, StateNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(StateNode);

--- a/include/tvm/auto_scheduler/measure_record.h
+++ b/include/tvm/auto_scheduler/measure_record.h
@@ -18,18 +18,18 @@
  */
 
 /*!
- * \file auto_scheduler/measure_record.h
- * \brief Json serialization format for dumping and loading tuning records.
+ * \file tvm/auto_scheduler/measure_record.h
+ * \brief Json serialization format for dumping and loading measurement records.
  */
 
 #ifndef TVM_AUTO_SCHEDULER_MEASURE_RECORD_H_
 #define TVM_AUTO_SCHEDULER_MEASURE_RECORD_H_
 
+#include <tvm/auto_scheduler/measure.h>
+
 #include <fstream>
 #include <string>
 #include <utility>
-
-#include "measure.h"
 
 namespace tvm {
 namespace auto_scheduler {
@@ -37,7 +37,7 @@ namespace auto_scheduler {
 /*! \brief Callback for logging the input and results of measurements to file */
 class RecordToFileNode : public MeasureCallbackNode {
  public:
-  /*! \brief File name for this callback to write log to. */
+  /*! \brief The name of output file. */
   String filename;
 
   void Callback(const SearchPolicy& policy, const Array<MeasureInput>& inputs,
@@ -55,7 +55,7 @@ class RecordToFile : public MeasureCallback {
  public:
   /*!
    * \brief The constructor.
-   * \param filename File name for this callback to write log.
+   * \param filename The name of output file
    */
   explicit RecordToFile(String filename);
 
@@ -65,7 +65,7 @@ class RecordToFile : public MeasureCallback {
 /*! \brief Log reader to load step logs from a file.*/
 class RecordReaderNode : public Object {
  public:
-  /*! \brief File name for this reader to load log from. */
+  /*! \brief The name of input file. */
   String filename;
   /*! \brief The reading file stream. */
   std::ifstream infile;
@@ -92,7 +92,7 @@ class RecordReaderNode : public Object {
   TVM_DECLARE_FINAL_OBJECT_INFO(RecordReaderNode, Object);
 
  private:
-  /*! \brief A string object to store the next line. */
+  /*! \brief A string storing the current line. */
   std::string cur_line_;
 };
 
@@ -104,7 +104,7 @@ class RecordReader : public ObjectRef {
  public:
   /*!
    * \brief The constructor.
-   * \param filename File name for this callback to write log.
+   * \param filename The name of input file
    */
   explicit RecordReader(String filename);
 
@@ -112,7 +112,7 @@ class RecordReader : public ObjectRef {
 };
 
 /*!
- * \brief Write measure records to an output stream.
+ * \brief Append measure records to an output stream.
  * \param os A pointer to a output stream.
  * \param inputs The MeasureInputs to be written.
  * \param results The MeasureResults to be written.
@@ -122,10 +122,10 @@ void WriteMeasureRecords(std::ostream* os, const Array<MeasureInput>& inputs,
 
 /*!
  * \brief Read one measure record from a string.
- * \param str The record string to be extract.
- * \param inp A pointer to a MeasureInputNode, this is used as output.
- * \param res A pointer to a MeasureResultNode, this is used as output.
- * \param log_version A pointer to a log version string.
+ * \param str The record string to be parsed.
+ * \param inp A pointer to a MeasureInputNode used to store the return value.
+ * \param res A pointer to a MeasureResultNode used to store the return value.
+ * \param log_version A pointer to a string used to store the log version.
  */
 void ReadMeasureRecord(const std::string& str, MeasureInputNode* inp, MeasureResultNode* res,
                        std::string* log_version);

--- a/include/tvm/auto_scheduler/search_task.h
+++ b/include/tvm/auto_scheduler/search_task.h
@@ -25,16 +25,15 @@
 #ifndef TVM_AUTO_SCHEDULER_SEARCH_TASK_H_
 #define TVM_AUTO_SCHEDULER_SEARCH_TASK_H_
 
+#include <tvm/auto_scheduler/compute_dag.h>
 #include <tvm/target/target.h>
-
-#include "compute_dag.h"
 
 namespace tvm {
 namespace auto_scheduler {
 
 class HardwareParams;
 
-/*! \brief The parameters of target hardware used to guide the search process of SearchPolicy. */
+/*! \brief The parameters of target hardware used to guide the SearchPolicy. */
 class HardwareParamsNode : public Object {
  public:
   /*! \brief The number of cores. */

--- a/include/tvm/auto_scheduler/transform_step.h
+++ b/include/tvm/auto_scheduler/transform_step.h
@@ -19,10 +19,10 @@
 
 /*!
  * \file auto_scheduler/transform_step.h
- * \brief Transformation steps. For each schedule primitive, there is a corresponding transform
- * step.
+ * \brief Transformation steps. These steps are used to manipulate the LoopState.
+ *        They are similar to the schedule primitives in te::Stage.
  *
- * \note To add a new transform step:
+ * \note How to add a new transform step:
  * Take fuse step for example:
  * 1. Define class `FuseStepNode`, `FuseStep` in `transform_steps.h`, and implement its first
  *    construction function `FuseStep::FuseStep()` in `transform_steps.cc`.
@@ -50,8 +50,6 @@
 #include <dmlc/json.h>
 #include <tvm/node/node.h>
 #include <tvm/te/schedule.h>
-
-#include "utils.h"
 
 namespace tvm {
 namespace auto_scheduler {
@@ -187,7 +185,6 @@ Step StepReadFromRecord(dmlc::JSONReader* reader);
  * \param step The step to be applied to State.
  * \param state A mutable pointer to State.
  * \param dag The original ComputeDAG of this state.
- * \return The iterator result after annotate.
  */
 void StepApplyToState(const Step& step, State* state, const ComputeDAG& dag);
 
@@ -209,7 +206,7 @@ void StepApplyToSchedule(const Step& step, Array<te::Stage>* stages, StageToAxes
 String StepPrintAsPythonAPI(const Step& step, Array<te::Stage>* stages,
                             StageToAxesMap* stage_to_axes);
 
-/********** Primitives working on single stage **********/
+/********** Steps working on single stage **********/
 
 /*!
  * \brief Annotation step that corresponds to vectorize, parallel, unroll and thread binding.
@@ -478,7 +475,7 @@ class SplitStep : public Step {
   TVM_DEFINE_OBJECT_REF_METHODS(SplitStep, Step, SplitStepNode);
 };
 
-/********** Primitives working on multiple stages **********/
+/********** Steps working on multiple stages **********/
 
 /*! \brief Compute at step that corresponds to te::Stage::compute_at */
 class ComputeAtStepNode : public StepNode {

--- a/python/tvm/auto_scheduler/auto_schedule.py
+++ b/python/tvm/auto_scheduler/auto_schedule.py
@@ -57,7 +57,7 @@ class HardwareParams(Object):
 
 @tvm._ffi.register_object("auto_scheduler.SearchTask")
 class SearchTask(Object):
-    """ The computation information and hardware parameters for a specific schedule search task.
+    """ The computation information and hardware parameters for a schedule search task.
 
     Parameters
     ----------
@@ -157,9 +157,6 @@ class TuningOptions(Object):
 
 def auto_schedule(task, search_policy='default', tuning_options=None):
     """ Do auto scheduling for a computation declaration.
-
-    The task parameter can be a `string` as workload_key, or directly
-    passing a `SearchTask` as input.
 
     Parameters
     ----------

--- a/python/tvm/auto_scheduler/workload_registry.py
+++ b/python/tvm/auto_scheduler/workload_registry.py
@@ -95,7 +95,7 @@ def make_workload_key(func, args):
 
     Returns
     -------
-    workload_key : Str
+    workload_key : str
         The workload key of the function.
     """
     global WORKLOAD_FUNC_REGISTRY

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -26,6 +26,7 @@ import logging
 import tvm
 from .task import create
 from .topi_integration import TaskExtractEnv
+from .dispatcher import FallbackContext
 
 logger = logging.getLogger('autotvm')
 

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -26,7 +26,6 @@ import logging
 import tvm
 from .task import create
 from .topi_integration import TaskExtractEnv
-from .dispatcher import FallbackContext
 
 logger = logging.getLogger('autotvm')
 

--- a/src/auto_scheduler/auto_schedule.cc
+++ b/src/auto_scheduler/auto_schedule.cc
@@ -24,8 +24,7 @@
  * schedule after search process.
  */
 
-#include "auto_schedule.h"
-
+#include <tvm/auto_scheduler/auto_schedule.h>
 #include <tvm/runtime/registry.h>
 
 namespace tvm {

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -37,8 +37,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include "utils.h"
 #include "../arith/pattern_match.h"
+#include "utils.h"
 
 namespace tvm {
 namespace auto_scheduler {
@@ -517,7 +517,7 @@ bool AccessAnalyzer::ElementWiseMatch(const te::Operation& op,
     bool is_simple_access, axis_missing, axis_duplicated, same_order;
     for (const auto& read : reads) {
       is_simple_access = auto_scheduler::IsSimpleAccess(next_op, read, &axis_missing,
-                                                    &axis_duplicated, &same_order);
+                                                        &axis_duplicated, &same_order);
       if (!is_simple_access || axis_missing || axis_duplicated || !same_order) {
         return false;
       }

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -22,8 +22,8 @@
  * \brief Compute declaration graph and its related analysis tools.
  */
 
-#include "compute_dag.h"
-
+#include <tvm/auto_scheduler/compute_dag.h>
+#include <tvm/auto_scheduler/loop_state.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/te/operation.h>
 #include <tvm/te/schedule.h>
@@ -37,7 +37,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "loop_state.h"
 #include "utils.h"
 
 namespace tvm {

--- a/src/auto_scheduler/compute_dag.h
+++ b/src/auto_scheduler/compute_dag.h
@@ -59,8 +59,8 @@ class AccessAnalyzerNode : public Object {
   /*! \brief Map an operation to all operations it is read by.
    * For each operation pair, use a two-dimentional array to multiple multi-dimentional accesses*/
   OperationMap<OperationMap<std::vector<std::vector<PrimExpr>>>> read_by;
-  /*! \brief Store the number of common outer iterators for operation pairs that have read-write
-   * relations. */
+  /*! \brief Store the number of common outer iterators for operation pairs that have
+   * read-write relations. */
   OperationMap<OperationMap<int>> num_common_outer_iterators;
   /*! \brief Store whether the operation is injective */
   OperationMap<bool> is_injective;
@@ -145,12 +145,12 @@ class AccessAnalyzer : public ObjectRef {
    * \param target_op The target operation
    * \note This function propagates the relation for chains with multiple ops.
    */
-  int GetNumCommonOuterIterator(const State& state, const te::Operation& op,
-                                const te::Operation& target_op) const;
+  int GetNumCommonOuterIterator(const te::Operation& op, const te::Operation& target_op) const;
 
   /*!
    * \brief Return whether two operations are elementwise-matched
    *  (e.g. conv2d and relu are elementwise matched)
+   * \note This function propagates the relation for chains with multiple ops.
    */
   bool ElementWiseMatch(const te::Operation& op, const te::Operation& target_op) const;
 
@@ -171,7 +171,8 @@ class ComputeDAGNode : public Object {
   double flop_ct;
   /*! \brief The initial state without any transform steps. */
   State init_state;
-  // TODO(merrymercy): Add more analyses later.
+  /*! \brief Static read-write access analyzer */
+  AccessAnalyzer access_analyzer;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("tensors", &tensors);

--- a/src/auto_scheduler/loop_state.cc
+++ b/src/auto_scheduler/loop_state.cc
@@ -23,14 +23,13 @@
  * see auto_scheduler/loop_state.h for more explanation.
  */
 
-#include "loop_state.h"
-
+#include <tvm/auto_scheduler/loop_state.h>
+#include <tvm/auto_scheduler/transform_step.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/te/operation.h>
 
 #include <utility>
 
-#include "transform_step.h"
 #include "utils.h"
 
 namespace tvm {

--- a/src/auto_scheduler/measure.cc
+++ b/src/auto_scheduler/measure.cc
@@ -22,8 +22,7 @@
  * \brief Distributed measurement infrastructure to measure the runtime costs of tensor programs.
  */
 
-#include "measure.h"
-
+#include <tvm/auto_scheduler/measure.h>
 #include <tvm/runtime/registry.h>
 
 #include <algorithm>

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -22,9 +22,10 @@
  * \brief Json serialization format for dumping and loading tuning records.
  */
 
-#include "measure_record.h"
-
 #include <dmlc/json.h>
+#include <tvm/auto_scheduler/loop_state.h>
+#include <tvm/auto_scheduler/measure_record.h>
+#include <tvm/auto_scheduler/transform_step.h>
 #include <tvm/runtime/registry.h>
 
 #include <fstream>
@@ -33,8 +34,6 @@
 #include <utility>
 #include <vector>
 
-#include "loop_state.h"
-#include "transform_step.h"
 #include "utils.h"
 
 // Json serialization handler for MeasureInput, MeasureResult

--- a/src/auto_scheduler/search_policy/empty_policy.cc
+++ b/src/auto_scheduler/search_policy/empty_policy.cc
@@ -24,9 +24,8 @@
 
 #include "empty_policy.h"
 
+#include <tvm/auto_scheduler/measure.h>
 #include <tvm/runtime/registry.h>
-
-#include "../measure.h"
 
 namespace tvm {
 namespace auto_scheduler {

--- a/src/auto_scheduler/search_policy/empty_policy.h
+++ b/src/auto_scheduler/search_policy/empty_policy.h
@@ -26,8 +26,8 @@
 #ifndef TVM_AUTO_SCHEDULER_SEARCH_POLICY_EMPTY_POLICY_H_
 #define TVM_AUTO_SCHEDULER_SEARCH_POLICY_EMPTY_POLICY_H_
 
-#include "../loop_state.h"
-#include "search_policy.h"
+#include <tvm/auto_scheduler/loop_state.h>
+#include <tvm/auto_scheduler/search_policy.h>
 
 namespace tvm {
 namespace auto_scheduler {

--- a/src/auto_scheduler/search_policy/search_policy.cc
+++ b/src/auto_scheduler/search_policy/search_policy.cc
@@ -22,8 +22,7 @@
  * \brief The base class of search policies.
  */
 
-#include "search_policy.h"
-
+#include <tvm/auto_scheduler/search_policy.h>
 #include <tvm/runtime/registry.h>
 
 namespace tvm {

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -22,8 +22,7 @@
  * \brief Meta information and hardware parameters for a search task.
  */
 
-#include "search_task.h"
-
+#include <tvm/auto_scheduler/search_task.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/threading_backend.h>
 

--- a/src/auto_scheduler/transform_step.cc
+++ b/src/auto_scheduler/transform_step.cc
@@ -19,12 +19,12 @@
 
 /*!
  * \file auto_scheduler/transform_step.cc
- * \brief Transformation steps. For each schedule primitive, there is a corresponding transform
- * step.
+ * \brief Transformation steps. These steps are used to manipulate the LoopState.
+ *        They are similar to the schedule primitives in te::Stage.
  */
 
-#include "transform_step.h"
-
+#include <tvm/auto_scheduler/loop_state.h>
+#include <tvm/auto_scheduler/transform_step.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/te/operation.h>
 
@@ -32,7 +32,6 @@
 #include <utility>
 #include <vector>
 
-#include "loop_state.h"
 #include "utils.h"
 
 namespace tvm {
@@ -80,6 +79,7 @@ Step StepReadFromRecord(dmlc::JSONReader* reader) {
 }
 
 void StepApplyToState(const Step& step, State* state, const ComputeDAG& dag) {
+  // We need this runtime dispatcher because different steps have different function signatures
   if (auto ps = step.as<AnnotationStepNode>()) {
     ps->ApplyToState(state);
   } else if (auto ps = step.as<FuseStepNode>()) {
@@ -101,6 +101,7 @@ void StepApplyToState(const Step& step, State* state, const ComputeDAG& dag) {
 
 void StepApplyToSchedule(const Step& step, Array<te::Stage>* stages,
                          StageToAxesMap* stage_to_axes) {
+  // We need this runtime dispatcher because different steps have different function signatures
   if (auto ps = step.as<AnnotationStepNode>()) {
     ps->ApplyToSchedule(stages, stage_to_axes);
   } else if (auto ps = step.as<FuseStepNode>()) {
@@ -122,6 +123,7 @@ void StepApplyToSchedule(const Step& step, Array<te::Stage>* stages,
 
 String StepPrintAsPythonAPI(const Step& step, Array<te::Stage>* stages,
                             StageToAxesMap* stage_to_axes) {
+  // We need this runtime dispatcher because different steps have different function signatures
   if (auto ps = step.as<AnnotationStepNode>()) {
     return ps->PrintAsPythonAPI(stages, stage_to_axes);
   } else if (auto ps = step.as<FuseStepNode>()) {
@@ -142,7 +144,7 @@ String StepPrintAsPythonAPI(const Step& step, Array<te::Stage>* stages,
   return "";
 }
 
-/********** Primitives working on single stage **********/
+/********** Steps working on single stage **********/
 
 /********** Annotation **********/
 AnnotationStep::AnnotationStep(int stage_id, int iter_id, IteratorAnnotation ann) {
@@ -741,7 +743,7 @@ String SplitStepNode::PrintAsPythonAPI(Array<te::Stage>* stages,
   return PrintSplitAsPythonAPI(stages, stage_to_axes, stage_id, iter_id, lengths, inner_to_outer);
 }
 
-/********** Primitives working on multiple stages **********/
+/********** Steps working on multiple stages **********/
 
 /********** Compute At **********/
 ComputeAtStep::ComputeAtStep(int stage_id, int target_stage_id, int target_iter_id) {

--- a/src/auto_scheduler/utils.h
+++ b/src/auto_scheduler/utils.h
@@ -128,6 +128,24 @@ inline std::vector<int> IntArrayToVector(
   return out;
 }
 
+/*! \brief Return whether two int arrays are elementwise-equal */
+inline bool IntArrayEqual(const Array<PrimExpr>& arr1, const Array<PrimExpr>& arr2) {
+  if (arr1.size() != arr2.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < arr1.size(); ++i) {
+    auto int1 = arr1[i].as<IntImmNode>();
+    auto int2 = arr2[i].as<IntImmNode>();
+    CHECK(int1 != nullptr);
+    CHECK(int2 != nullptr);
+    if (int1->value != int2->value) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /********** Utilities for TVM Containers / ByteArray **********/
 /*! \brief Compute mean of a FloatImm array */
 inline double FloatArrayMean(const Array<PrimExpr>& float_array) {

--- a/tests/cpp/auto_scheduler_test.cc
+++ b/tests/cpp/auto_scheduler_test.cc
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <dmlc/logging.h>
+#include <gtest/gtest.h>
+#include <topi/nn.h>
+#include <tvm/runtime/container.h>
+#include <tvm/te/operation.h>
+
+#include <unordered_set>
+
+// todo(merrymercy): expose auto_scheduler header files to `include/tvm`
+//  and do not use relative path here
+#include "../../src/auto_scheduler/compute_dag.h"
+#include "../../src/auto_scheduler/loop_state.h"
+
+// Compute declaration for test
+tvm::Array<tvm::te::Tensor> conv2d_nchw_bn_relu_func(int N, int H, int W, int CI, int CO,
+                                                     int kernel_size, int strides, int padding,
+                                                     int dilation = 1) {
+  using namespace tvm;
+  using namespace tvm::te;
+
+  Tensor data = placeholder({N, CI, H, W}, DataType::Float(32), "Data");
+  Tensor kernel = placeholder({CO, CI, kernel_size, kernel_size}, DataType::Float(32), "Kernel");
+  Tensor bias = placeholder({CO, 1, 1}, DataType::Float(32), "Bias");
+  Tensor bn_scale = placeholder({CO, 1, 1}, DataType::Float(32), "Bn_scale");
+  Tensor bn_offset = placeholder({CO, 1, 1}, DataType::Float(32), "Bn_offset");
+
+  int OH = (H + 2 * padding - (kernel_size - 1) * dilation - 1) / strides + 1;
+  int OW = (W + 2 * padding - (kernel_size - 1) * dilation - 1) / strides + 1;
+
+  const auto& conv = topi::conv2d_nchw(data, kernel, padding, padding, strides, strides);
+  CHECK(conv->shape[2].as<IntImmNode>()->value == OH);
+  CHECK(conv->shape[3].as<IntImmNode>()->value == OW);
+
+  const auto& bias_add = compute(
+      {N, CO, OH, OW}, [&](Var i, Var j, Var k, Var l) { return conv[i][j][k][l] + bias[j][0][0]; },
+      "Bias_add");
+  const auto& bn_mul = compute(
+      {N, CO, OH, OW},
+      [&](Var i, Var j, Var k, Var l) { return bias_add[i][j][k][l] * bn_scale[j][0][0]; },
+      "Bn_mul");
+  const auto& bn_add = compute(
+      {N, CO, OH, OW},
+      [&](Var i, Var j, Var k, Var l) { return bn_mul[i][j][k][l] + bn_offset[j][0][0]; },
+      "Bn_add");
+  const auto& out = topi::relu<float>(bn_add);
+
+  return {data, kernel, bias, bn_scale, bn_offset, out};
+}
+
+using namespace tvm::auto_scheduler;
+
+// Test Access Analyzer
+TEST(ComputeDAG, AccessAnalyzer) {
+  const auto& tensors = conv2d_nchw_bn_relu_func(1, 224, 224, 3, 64, 7, 2, 3);
+  const auto& dag = tvm::auto_scheduler::ComputeDAG(tensors);
+  const auto& s0 = dag->init_state;
+
+  int data = 0, padding = 1, kernel = 2, conv = 3, bias = 4, bias_add = 5;
+  int bn_scale = 6, bn_mul = 7, bn_offset = 8, bn_add = 9, relu = 10;
+
+  std::set<int> needs_multi_level_tiling = {conv};
+  for (size_t stage_id = 0; stage_id < dag->ops.size(); stage_id++) {
+    if (needs_multi_level_tiling.count(stage_id)) {
+      CHECK(dag->access_analyzer.NeedsMultiLevelTiling(dag->ops[stage_id]));
+    } else {
+      CHECK(!dag->access_analyzer.NeedsMultiLevelTiling(dag->ops[stage_id]));
+    }
+  }
+
+  std::set<int> is_injective = {data,     padding, kernel,    bias,   bias_add,
+                                bn_scale, bn_mul,  bn_offset, bn_add, relu};
+  for (size_t stage_id = 0; stage_id < dag->ops.size(); stage_id++) {
+    if (is_injective.count(stage_id)) {
+      CHECK(dag->access_analyzer.IsInjective(dag->ops[stage_id]));
+    } else {
+      CHECK(!dag->access_analyzer.IsInjective(dag->ops[stage_id]));
+    }
+  }
+
+  std::set<int> is_strictly_inlinable = {bias_add, bn_mul, bn_add, relu};
+  for (size_t stage_id = 0; stage_id < dag->ops.size(); stage_id++) {
+    if (is_strictly_inlinable.count(stage_id)) {
+      CHECK(dag->access_analyzer.IsStrictInlineable(dag->ops[stage_id]));
+    } else {
+      CHECK(!dag->access_analyzer.IsStrictInlineable(dag->ops[stage_id]));
+    }
+  }
+
+  std::set<int> is_output = {relu};
+  for (size_t stage_id = 0; stage_id < dag->ops.size(); stage_id++) {
+    if (is_output.count(stage_id)) {
+      CHECK(dag->access_analyzer.IsOutput(dag->ops[stage_id]));
+    } else {
+      CHECK(!dag->access_analyzer.IsOutput(dag->ops[stage_id]));
+    }
+  }
+
+  CHECK_EQ(dag->access_analyzer.GetNumCommonOuterIterator(dag->ops[conv], dag->ops[bias_add]), 4);
+  CHECK_EQ(dag->access_analyzer.GetNumCommonOuterIterator(dag->ops[conv], dag->ops[relu]), 4);
+  CHECK_EQ(dag->access_analyzer.GetNumCommonOuterIterator(dag->ops[data], dag->ops[relu]), 1);
+
+  CHECK(dag->access_analyzer.ElementWiseMatch(dag->ops[conv], dag->ops[bias_add]));
+  CHECK(dag->access_analyzer.ElementWiseMatch(dag->ops[conv], dag->ops[relu]));
+  CHECK(!dag->access_analyzer.ElementWiseMatch(dag->ops[data], dag->ops[padding]));
+
+  std::unordered_set<tvm::te::Operation, tvm::ObjectHash, tvm::ObjectEqual> op_set;
+  {
+    std::vector<std::pair<int, int>> consumer_list = {
+        {data, padding},     {padding, conv},    {kernel, conv},     {conv, bias_add},
+        {bias, bias_add},    {bias_add, bn_mul}, {bn_scale, bn_mul}, {bn_mul, bn_add},
+        {bn_offset, bn_add}, {bn_add, relu}};
+    for (const auto& pair : consumer_list) {
+      dag->access_analyzer.GetConsumers(s0, s0->stages[pair.first]->op, &op_set);
+      CHECK_EQ(op_set.size(), 1);
+      CHECK_EQ((*op_set.begin()), s0->stages[pair.second]->op);
+    }
+    std::vector<std::pair<int, std::vector<int>>> producer_list = {{padding, {data}},
+                                                                   {conv, {padding, kernel}},
+                                                                   {bias_add, {conv, bias}},
+                                                                   {bn_mul, {bias_add, bn_scale}},
+                                                                   {bn_add, {bn_mul, bn_offset}},
+                                                                   {relu, {bn_add}}};
+    for (const auto& pair : producer_list) {
+      dag->access_analyzer.GetProducers(s0, s0->stages[pair.first]->op, &op_set);
+      CHECK_EQ(op_set.size(), pair.second.size());
+      for (const auto& target : pair.second) {
+        CHECK(op_set.count(s0->stages[target]->op));
+      }
+    }
+  }
+
+  // todo(lmzheng): Add more test cases for GetConsumer and GetProducesr after we have
+  // compute_inline
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  return RUN_ALL_TESTS();
+}

--- a/tests/python/unittest/test_auto_scheduler_common.py
+++ b/tests/python/unittest/test_auto_scheduler_common.py
@@ -33,7 +33,7 @@ def matmul_auto_scheduler_test(N, M, K):
 
 
 @auto_scheduler.register_workload("matmul_auto_scheduler_test_rename_1")
-def matmul_auto_scheduler_test_rename_0(N, M, K):
+def matmul_auto_scheduler_test_rename_1(N, M, K):
     A = te.placeholder((N, K), name='A')
     B = te.placeholder((K, M), name='B')
     k = te.reduce_axis((0, K), name='k')

--- a/tests/python/unittest/test_auto_scheduler_common.py
+++ b/tests/python/unittest/test_auto_scheduler_common.py
@@ -33,7 +33,7 @@ def matmul_auto_scheduler_test(N, M, K):
 
 
 @auto_scheduler.register_workload("matmul_auto_scheduler_test_rename_1")
-def matmul_auto_scheduler_test_rename_1(N, M, K):
+def matmul_auto_scheduler_test_rename_0(N, M, K):
     A = te.placeholder((N, K), name='A')
     B = te.placeholder((K, M), name='B')
     k = te.reduce_axis((0, K), name='k')

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -17,10 +17,10 @@
 
 """Test ComputeDAG (replay, infer bound)"""
 
-import tvm
+import tvm, topi
 from tvm import auto_scheduler, te
 
-from test_auto_scheduler_common import get_tiled_matmul
+from test_auto_scheduler_common import get_tiled_matmul, matmul_auto_scheduler_test
 
 
 def test_apply_steps():
@@ -36,8 +36,19 @@ def test_infer_bound():
 
 
 def test_estimate_flop():
-    dag, s = get_tiled_matmul()
-    assert abs(dag.flop_ct - 2 * 512 ** 3) < 0.5
+    N = 512
+    A, B, C = matmul_auto_scheduler_test(N, N, N)
+    dag = auto_scheduler.ComputeDAG([A, B, C])
+    assert abs(dag.flop_ct - 2 * N ** 3) < 0.5
+
+    D = topi.nn.relu(C)
+    dag = auto_scheduler.ComputeDAG([A, B, D])
+    assert abs(dag.flop_ct - 2 * N ** 3 - N * N) < 0.5
+
+    # should not count the comparison operations in padding
+    D = topi.nn.pad(C, [1, 1])
+    dag = auto_scheduler.ComputeDAG([A, B, D])
+    assert abs(dag.flop_ct - 2 * N ** 3) < 0.5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For the full upstream plan, see [Ansor RFC](https://discuss.tvm.ai/t/rfc-ansor-an-auto-scheduler-for-tvm-autotvm-v2-0/7005/32).

This pr
- Introduces the access analyzer which analyzes the read-write relations in a compute declaration.
The search policy will use the analysis results to make decisions such as doing multi-level tiling for an op or strictly inlining an op.
- Moves ansor related header files to `include/tvm/auto_scheduler` and polishes some comments.
