### PR TITLE
Improve reduction schedule on arm CPUs

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -26,6 +26,12 @@ from .. import op as _op
 
 logger = logging.getLogger('strategy')
 
+@schedule_reduce.register("arm_cpu")
+def schedule_reduce_cpu(attrs, outs, target):
+    """schedule reduction ops for arm_cpu"""
+    with target:
+        return topi.x86.schedule_reduce(outs)
+
 @schedule_injective.register(["arm_cpu", "micro_dev"])
 def schedule_injective_arm_cpu(_, outs, target):
     """schedule injective ops for arm cpu"""


### PR DESCRIPTION
This improves reduction by ~10x using x86 schedules. While for `float32` reduction is not common, it is widely used in quantized operations (`int8`, `uint8`) in order to compute the offset contributions. 

We might revisit this later to tailor the schedule for Arm CPUs. 

Change-Id: I9cd85deac6a57666b82ff7250d827652a4000d82
