### PR TITLE
[QNN] Excluding most negative value

### DIFF
--- a/src/relay/qnn/util.h
+++ b/src/relay/qnn/util.h
@@ -51,6 +51,12 @@ static inline int32_t GetQmin(const DataType& dtype) {
   if (dtype.is_int() || dtype.is_uint()) {
     auto* min_value = tir::as_const_int(tvm::min_value(dtype));
     CHECK(min_value != nullptr);
+    // For int datatypes, it is a common practice to ignore the most negative value.  This is useful
+    // in symmetric quantization, where by ignoring most negative value puts 0 exactly at the mid
+    // point of representation.
+    if (dtype.is_int()) {
+      return static_cast<int32_t>(min_value[0] + 1);
+    }
     return static_cast<int32_t>(min_value[0]);
   } else {
     LOG(FATAL) << "Type not supported " << dtype;

--- a/tests/python/relay/test_op_qnn_quantize.py
+++ b/tests/python/relay/test_op_qnn_quantize.py
@@ -57,7 +57,7 @@ def test_float32_to_int8():
     data = np.array([-63.5, -63, -62.5, -62, -61.5, 62, 62.5, 63, 63.5, 64]) \
         .astype('float32') \
         .reshape((2,5))
-    output = np.array([-128, -127, -126, -125, -124, 123, 124, 125, 126, 127]) \
+    output = np.array([-127, -127, -126, -125, -124, 123, 124, 125, 126, 127]) \
         .astype('int8') \
         .reshape((2,5))
     quant_args = {"out_zero_point":np.int32(-1), "out_scale":np.float32(0.5)}

--- a/tests/python/relay/test_op_qnn_requantize.py
+++ b/tests/python/relay/test_op_qnn_requantize.py
@@ -196,7 +196,7 @@ def test_saturation():
         golden_data = np.arange(0, -16, -1).astype('int32')
         golden_data = np.add(-120, golden_data)
         output = np.array([-120, -121, -122, -123, -124, -125, -126, -127,
-                           -128, -128, -128, -128, -128, -128, -128, -128])
+                           -127, -127, -127, -127, -127, -127, -127, -127])
         golden_output = output
         verify(mod, (golden_data, golden_output))
 


### PR DESCRIPTION
After going through multiple frameworks, I found that it is common to ignore -128 for int8 quantization.

TFLite - from Pete Warden's blog and TFLite paper - https://petewarden.com/2017/06/22/what-ive-learned-about-neural-network-quantization/

![image](https://user-images.githubusercontent.com/13822661/88244830-db2c1680-cc49-11ea-9ae6-fd6bf837936c.png)

MKLDNN - https://oneapi-src.github.io/oneDNN/ex_int8_simplenet.html

![image](https://user-images.githubusercontent.com/13822661/88244853-ee3ee680-cc49-11ea-8efd-5b4ac204ce2d.png)


TensorRT - https://blog.tensorflow.org/2019/06/high-performance-inference-with-TensorRT.html

![image](https://user-images.githubusercontent.com/13822661/88244877-00b92000-cc4a-11ea-9909-ea0fd7f6746e.png)

As this is a common practice now, this PR adapts to this change as well.



