### PR TITLE
[Fix] avoid unexpected throw in AttrInitEntry

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -391,7 +391,7 @@ struct AttrInitEntry {
   }
   TSelf& describe(DMLC_ATTRIBUTE_UNUSED const char* str) { return *this; }
 };
-  
+
 // Template function to allow smart conversion
 // from Expr types into the constants.
 template <typename T>

--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -337,6 +337,18 @@ struct AttrInitEntry {
   T* value_;
   // whether the value is missing.
   bool value_missing_{true};
+
+  AttrInitEntry() = default;
+
+  AttrInitEntry(AttrInitEntry&& other) {
+    type_key_ = other.type_key_;
+    key_ = other.key_;
+    value_ = other.value_;
+    value_missing_ = other.value_missing_;
+    // avoid unexpected throw
+    other.value_missing_ = false;
+  }
+
   // If the value is still missing in destruction time throw an error.
   ~AttrInitEntry() DMLC_THROW_EXCEPTION {
     if (value_missing_) {
@@ -379,7 +391,7 @@ struct AttrInitEntry {
   }
   TSelf& describe(DMLC_ATTRIBUTE_UNUSED const char* str) { return *this; }
 };
-
+  
 // Template function to allow smart conversion
 // from Expr types into the constants.
 template <typename T>
@@ -463,7 +475,7 @@ class AttrInitVisitor {
     } else {
       opt.value_missing_ = true;
     }
-    return opt;
+    return std::move(opt);
   }
 
  private:


### PR DESCRIPTION
avoid unexpected throw in AttrInitEntry, as discussed in #6093
