### PR TITLE
[TOPI] Fix CUDA Library Tuning

### DIFF
--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -733,9 +733,11 @@ class ConfigSpace(object):
 
         Parameters
         ---------
-        flop: int or float
+        flop: int or float or IntImm or FloatImm
             number of float operations
         """
+        if not isinstance(flop, (int, float)):
+            flop = flop.value
         self.flop += flop
 
     def raise_error(self, msg):

--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -33,6 +33,7 @@ from collections import namedtuple, OrderedDict
 import numpy as np
 
 from tvm.te import schedule, thread_axis
+from tvm.tir import expr
 from tvm.autotvm.util import get_const_int
 
 Axis = namedtuple('Axis', ['space', 'index'])
@@ -736,9 +737,9 @@ class ConfigSpace(object):
         flop: int or float or IntImm or FloatImm
             number of float operations
         """
-        if not isinstance(flop, (int, float)):
+        if isinstance(flop, (expr.IntImm, expr.FloatImm)):
             flop = flop.value
-        self.flop += flop
+        self.flop += float(flop)
 
     def raise_error(self, msg):
         """register error in config

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -111,7 +111,7 @@ def conv2d_cudnn(cfg, data, kernel, strides, padding, dilation, groups=1,
                               [dilation_h, dilation_w],
                               conv_mode=1,
                               tensor_format=tensor_format,
-                              algo=cfg['algo'],
+                              algo=cfg['algo'].val,
                               conv_dtype=dtype,
                               groups=groups)
 

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -18,6 +18,7 @@
 """Compute definition for conv2d with cuda backend"""
 from tvm import te
 from tvm import autotvm
+from tvm.autotvm.task.space import OtherOptionEntity
 from tvm.contrib import cudnn
 
 from .. import nn, generic
@@ -99,6 +100,10 @@ def conv2d_cudnn(cfg, data, kernel, strides, padding, dilation, groups=1,
     else:
         dtype = data.dtype
 
+    cfg.define_knob('algo', range(8))
+    if cfg.is_fallback: # Let CUDNN choose the best algo
+        cfg['algo'] = OtherOptionEntity(-1)
+
     return cudnn.conv_forward(data,
                               kernel,
                               [pt, pl], # cudnn padding pt, pl on both sides of input
@@ -106,7 +111,7 @@ def conv2d_cudnn(cfg, data, kernel, strides, padding, dilation, groups=1,
                               [dilation_h, dilation_w],
                               conv_mode=1,
                               tensor_format=tensor_format,
-                              algo=-1,         # let CUDNN choose the best algo
+                              algo=cfg['algo'],
                               conv_dtype=dtype,
                               groups=groups)
 


### PR DESCRIPTION
Although we make `conv2d_cudnn.cuda` and `dense_cublas.cuda` as AutoTVM tasks so that they can be "tuned" and compared with other implementations, there have some issues prevent us from actually "tuning" them.

- `conv2d_cudnn.cuda`: I constantly got the following errors in `cudnnFindConvolutionForwardAlgorithm` (on T4 GPU). Note that this function is called when extracting tasks without issues. I guess it might be the issue of CUDA context and threading.

    ```
    cuDNN: Check failed: e == CUDNN_STATUS_SUCCESS (2 vs. 0) : CUDNN_STATUS_ALLOC_FAILED
    ```

   The solution in this PR is to create a knob so that it becomes a template with 8 candidates. In this case, `cudnnFindConvolutionForwardAlgorithm` will not be called during tuning and everything works well. We still set the knob value to `-1` in the fallback config to achieve the same behavoir as now.

- `dense_cblas.cuda`: The error comes from the callback function that tries to display the FLOPS. The reason is that `task.flops` is `FloatImm` instead of `float`, so `float(flops)` will throw type error. This PR lets `add_flop` function support `FloatImm` and `IntImm` types.

cc @icemelon9 @merrymercy 