### PR TITLE
Add `init` member to ReduceNode

### DIFF
--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -1026,6 +1026,8 @@ class ReduceNode : public PrimExprNode {
   CommReducer combiner;
   /*! \brief The source operand */
   Array<PrimExpr> source;
+  /*! \brief The init operand */
+  Array<PrimExpr> init;
   /*! \brief The reduction axis */
   Array<IterVar> axis;
   /*!
@@ -1040,6 +1042,7 @@ class ReduceNode : public PrimExprNode {
     v->Visit("dtype", &dtype);
     v->Visit("combiner", &combiner);
     v->Visit("source", &source);
+    v->Visit("init", &init);
     v->Visit("axis", &axis);
     v->Visit("condition", &condition);
     v->Visit("value_index", &value_index);
@@ -1049,7 +1052,8 @@ class ReduceNode : public PrimExprNode {
     // check axis first so IterVars can define the necessary variables.
     return equal(dtype, other->dtype) && equal(axis, other->axis) &&
            equal(combiner, other->combiner) && equal(source, other->source) &&
-           equal(condition, other->condition) && equal(value_index, other->value_index);
+           equal(init, other->init) && equal(condition, other->condition) &&
+           equal(value_index, other->value_index);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
@@ -1057,6 +1061,7 @@ class ReduceNode : public PrimExprNode {
     hash_reduce(axis);
     hash_reduce(combiner);
     hash_reduce(source);
+    hash_reduce(init);
     hash_reduce(condition);
     hash_reduce(value_index);
   }
@@ -1072,7 +1077,7 @@ class ReduceNode : public PrimExprNode {
 class Reduce : public PrimExpr {
  public:
   TVM_DLL Reduce(CommReducer combiner, Array<PrimExpr> src, Array<IterVar> rdom, PrimExpr condition,
-                 int value_index);
+                 int value_index, Array<PrimExpr> init);
 
   TVM_DEFINE_OBJECT_REF_METHODS(Reduce, PrimExpr, ReduceNode);
 };

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -464,48 +464,54 @@ TVM_DLL PrimExpr isinf(PrimExpr x);
  * \brief sum of of source expression over axis
  * \param source The source expression.
  * \param axis List of iteration variables that will be used for reduction.
+ * \param init The value with which to initialize the output.
  * \return The result.
  */
-TVM_DLL PrimExpr sum(PrimExpr source, Array<tir::IterVar> axis);
+TVM_DLL PrimExpr sum(PrimExpr source, Array<tir::IterVar> axis, Array<PrimExpr> init = {});
 
 /*!
  * \brief logical And of of source expression over axis
  * \param source The source expression.
  * \param axis List of iteration variables that will be used for reduction.
+ * \param init The value with which to initialize the output.
  */
-TVM_DLL PrimExpr all(PrimExpr source, Array<tir::IterVar> axis);
+TVM_DLL PrimExpr all(PrimExpr source, Array<tir::IterVar> axis, Array<PrimExpr> init = {});
 
 /*!
  * \brief logical Or of of source expression over axis
  * \param source The source expression.
  * \param axis List of iteration variables that will be used for reduction.
+ * \param init The value with which to initialize the output.
  * \return The result.
  */
-TVM_DLL PrimExpr any(PrimExpr source, Array<tir::IterVar> axis);
+TVM_DLL PrimExpr any(PrimExpr source, Array<tir::IterVar> axis, Array<PrimExpr> init = {});
 
 /*!
  * \brief max of of source expression over axis
  * \param source The source expression.
  * \param axis List of iteration variables that will be used for reduction.
+ * \param init The value with which to initialize the output.
  * \return The result.
  */
-TVM_DLL PrimExpr max(PrimExpr source, Array<tir::IterVar> axis);
+TVM_DLL PrimExpr max(PrimExpr source, Array<tir::IterVar> axis, Array<PrimExpr> init = {});
 
 /*!
  * \brief max of of source expression over axis
  * \param source The source expression.
  * \param axis List of iteration variables that will be used for reduction.
+ * \param init The value with which to initialize the output.
  * \return The result.
  */
-TVM_DLL PrimExpr min(PrimExpr source, Array<tir::IterVar> axis);
+TVM_DLL PrimExpr min(PrimExpr source, Array<tir::IterVar> axis, Array<PrimExpr> init = {});
 
 /*!
  * \brief product of of source expression over axis
  * \param source The source expression.
  * \param axis List of iteration variables that will be used for reduction.
+ * \param init The value with which to initialize the output.
  * \return The result.
  */
-TVM_DLL PrimExpr prod(PrimExpr source, Array<tir::IterVar> axis);
+TVM_DLL PrimExpr prod(PrimExpr source, Array<tir::IterVar> axis, Array<PrimExpr> init = {});
 
 /*!
  * \brief Calculate floor(x)

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -433,11 +433,14 @@ class Reduce(PrimExprWithOp):
 
     value_index : int
         The value index.
+
+    init : list of Expr
+        The initial value for output. This can be an int, float or ProducerLoad
     """
-    def __init__(self, combiner, src, rdom, condition, value_index):
+    def __init__(self, combiner, src, rdom, condition, value_index, init=None):
         self.__init_handle_by_constructor__(
             _ffi_api.Reduce, combiner, src, rdom,
-            condition, value_index)
+            condition, value_index, init)
 
 
 @tvm._ffi.register_object

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -1013,7 +1013,8 @@ PrimExpr CanonicalSimplifier::Impl::SimplifyReduceCombiner(const ReduceNode* op)
   for (size_t i = 0; i < used.size(); ++i) {
     if (SideEffect(op->source[i]) > CallEffectKind::kReadState ||
         SideEffect(op->combiner->identity_element[i]) > CallEffectKind::kReadState ||
-        SideEffect(op->combiner->result[i]) > CallEffectKind::kReadState) {
+        SideEffect(op->combiner->result[i]) > CallEffectKind::kReadState ||
+        (!op->init.empty() && SideEffect(op->init[i]) > CallEffectKind::kReadState)) {
       mark_used(i);
     }
   }
@@ -1024,6 +1025,7 @@ PrimExpr CanonicalSimplifier::Impl::SimplifyReduceCombiner(const ReduceNode* op)
   Array<Var> new_lhs;
   Array<Var> new_rhs;
   Array<PrimExpr> new_source;
+  Array<PrimExpr> new_init;
 
   // new stuff is old stuff which is used
   for (size_t i = 0; i < used.size(); ++i) {
@@ -1034,6 +1036,7 @@ PrimExpr CanonicalSimplifier::Impl::SimplifyReduceCombiner(const ReduceNode* op)
       new_lhs.push_back(op->combiner->lhs[i]);
       new_rhs.push_back(op->combiner->rhs[i]);
       new_source.push_back(op->source[i]);
+      if (!op->init.empty()) new_init.push_back(op->init[i]);
     } else if (static_cast<int>(i) < op->value_index) {
       // value_index should also be adjusted
       new_value_index--;
@@ -1041,7 +1044,7 @@ PrimExpr CanonicalSimplifier::Impl::SimplifyReduceCombiner(const ReduceNode* op)
   }
 
   CommReducer new_combiner = CommReducer(new_lhs, new_rhs, new_result, new_identity);
-  return Reduce(new_combiner, new_source, op->axis, op->condition, new_value_index);
+  return Reduce(new_combiner, new_source, op->axis, op->condition, new_value_index, new_init);
 }
 
 PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const ReduceNode* op) {
@@ -1051,6 +1054,11 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const ReduceNode* op) {
   // already been simplified by const reduction axis removal
   if (op == nullptr) return ret;
   if (op->axis.empty()) {
+    if (!op->init.empty()) {
+      return this->VisitExpr(Select(op->condition,
+                                    (*op->combiner.get())(op->init, op->source)[op->value_index],
+                                    op->init[op->value_index]));
+    }
     // Note that here we assume that the identity element is indeed identity. Without this
     // assumption we would have to perform a single iteration of the loop, i.e. use
     // `(*op->combiner.get())(op->combineop->identity_element, op->source)[op->value_index]`

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -373,7 +373,7 @@ Doc TIRTextPrinter::VisitExpr_(const ShuffleNode* op) {
 Doc TIRTextPrinter::VisitExpr_(const ReduceNode* op) {
   Doc doc;
   doc << "reduce(" << Print(op->combiner) << ", " << Print(op->source) << ", " << Print(op->axis)
-      << ", " << op->value_index << ")";
+      << ", " << op->value_index << ", " << Print(op->init) << ")";
   return doc;
 }
 

--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -805,9 +805,9 @@ PrimExpr SimplifyReductionDomain(const PrimExpr& expr, const Map<Var, Range>& ou
 
     // Perform simplification mainly to remove a possibly empty reduction.
     arith::Analyzer analyzer;
-    return analyzer.Simplify(
-        Reduce(red->combiner, new_source, new_axis, All(res->dst->relations), red->value_index),
-        kSimplifyRewriteCanonicalRewrite);
+    return analyzer.Simplify(Reduce(red->combiner, new_source, new_axis, All(res->dst->relations),
+                                    red->value_index, red->init),
+                             kSimplifyRewriteCanonicalRewrite);
   } else {
     return expr;
   }
@@ -937,6 +937,7 @@ class RemoveRedundantInequalitiesMutator : public ExprMutator {
 
   virtual PrimExpr VisitExpr_(const ReduceNode* op) {
     Array<PrimExpr> known_with_axes = known_;
+    CHECK(op->init.empty()) << "Derivative of Reduction with initialization is not implemented";
     for (const PrimExpr& axis_cond : IterVarsToInequalities(op->axis)) {
       known_with_axes.push_back(axis_cond);
     }
@@ -955,7 +956,7 @@ class RemoveRedundantInequalitiesMutator : public ExprMutator {
       new_source.push_back(new_mutator(src));
     }
 
-    return Reduce(op->combiner, new_source, op->axis, new_cond, op->value_index);
+    return Reduce(op->combiner, new_source, op->axis, new_cond, op->value_index, op->init);
   }
 
   virtual PrimExpr VisitExpr_(const EQNode* op) { return MutateAtomic_(GetRef<PrimExpr>(op)); }
@@ -1067,13 +1068,14 @@ class ReductionAsTensorAccessMutator : public ExprMutator {
     ReductionAsTensorAccessMutator new_mutator(Concat(IterVarsToVars(op->axis), outer_axis_),
                                                Merge(vranges_, IterVarsToMap(op->axis)), name_);
 
+    CHECK(op->init.empty()) << "Derivative of Reduction with initialization is not implemented";
     Array<PrimExpr> new_source;
     for (const PrimExpr& src : op->source) {
       new_source.push_back(new_mutator(src));
     }
 
     PrimExpr new_reduce =
-        Reduce(op->combiner, new_source, op->axis, op->condition, op->value_index);
+        Reduce(op->combiner, new_source, op->axis, op->condition, op->value_index, op->init);
 
     Array<Var> undefined_vars = UndefinedVars(new_reduce);
     std::unordered_set<const VarNode*> undefined_var_set;
@@ -1132,7 +1134,7 @@ PrimExpr LiftReductions(const PrimExpr& expr, const Array<Var>& outer_axis,
     }
     PrimExpr new_condition = ReductionAsTensorAccess(red->condition, new_outer_axis, new_vranges);
 
-    return Reduce(red->combiner, new_source, red->axis, new_condition, red->value_index);
+    return Reduce(red->combiner, new_source, red->axis, new_condition, red->value_index, red->init);
   } else {
     return ReductionAsTensorAccess(expr, outer_axis, vranges);
   }
@@ -1149,6 +1151,7 @@ PrimExpr RemoveJacobianAndLiftNonzeroCondImpl(const PrimExpr& expr_orig, const A
   PrimExpr expr = analyzer.Simplify(expr_orig, kSimplifyRewriteCanonicalRewrite);
 
   if (const ReduceNode* red = expr.as<ReduceNode>()) {
+    CHECK(red->init.empty()) << "Derivative of Reduction with initialization is not implemented";
     // TODO(sgrechanik-h): There are some other operations which behave like sum
     bool is_sum = IsSumCombiner(red->combiner, vranges);
     if (is_sum || CanFactorZeroFromCombiner(red->combiner, red->value_index, vranges)) {
@@ -1166,7 +1169,7 @@ PrimExpr RemoveJacobianAndLiftNonzeroCondImpl(const PrimExpr& expr_orig, const A
         source.Set(0, nz.value);
       }
 
-      new_red = Reduce(red->combiner, source, red->axis, cond, red->value_index);
+      new_red = Reduce(red->combiner, source, red->axis, cond, red->value_index, red->init);
       new_red = SimplifyReductionDomain(new_red, combined_vranges);
       // If the reduction disappears completely then transform the result as a non-reduction
       if (!new_red.as<ReduceNode>()) {
@@ -1192,8 +1195,8 @@ PrimExpr RemoveJacobianAndLiftNonzeroCondImpl(const PrimExpr& expr_orig, const A
         new_source.Set(red->value_index, Select(nz_cond, nz_source, make_zero(nz_source.dtype())));
       }
 
-      PrimExpr new_reduce =
-          Reduce(red->combiner, new_source, red->axis, new_reduce_cond, red->value_index);
+      PrimExpr new_reduce = Reduce(red->combiner, new_source, red->axis, new_reduce_cond,
+                                   red->value_index, red->init);
       new_reduce =
           TrySimplifyCompute(new_reduce, new_outer_cond, IterVarsToVars(axis), combined_vranges);
       result = Select(new_outer_cond, new_reduce, make_zero(new_reduce.dtype()));

--- a/src/te/autodiff/ad_util.cc
+++ b/src/te/autodiff/ad_util.cc
@@ -55,9 +55,13 @@ PrimExpr CloneReduction(const PrimExpr& expr) {
     for (const auto& src : red->source) {
       src_with_newaxis.push_back(tir::Substitute(src, vmap));
     }
+    Array<PrimExpr> init_with_newaxis;
+    for (const auto& init : red->init) {
+      init_with_newaxis.push_back(tir::Substitute(init, vmap));
+    }
 
     return Reduce(red->combiner, src_with_newaxis, new_axis, tir::Substitute(red->condition, vmap),
-                  red->value_index);
+                  red->value_index, init_with_newaxis);
   } else {
     return expr;
   }
@@ -82,7 +86,8 @@ Operation ComputeOpFromExprs(const Array<PrimExpr>& exprs, const Array<IterVar>&
   // If this is a reduction then we have to replicate it
   if (const ReduceNode* red = exprs[0].as<ReduceNode>()) {
     for (size_t i = 0; i < red->source.size(); ++i) {
-      PrimExpr ith_red = Reduce(red->combiner, red->source, red->axis, red->condition, i);
+      PrimExpr ith_red =
+          Reduce(red->combiner, red->source, red->axis, red->condition, i, red->init);
       new_exprs.push_back(ith_red);
     }
   } else {

--- a/src/te/autodiff/jacobian.cc
+++ b/src/te/autodiff/jacobian.cc
@@ -181,6 +181,8 @@ class JacobianMutator : public ExprMutator {
     PrimExpr expr_with_new_axes = te::CloneReduction(GetRef<PrimExpr>(op));
     const ReduceNode* new_op = expr_with_new_axes.as<ReduceNode>();
 
+    CHECK(new_op->init.empty()) << "Derivative of Reduction with initialization is not implemented";
+
     // New lhs and rhs variables of the new combiner consist of
     // variables representing derivatives (which are later derived from new_op->source)
     // followed by the original variables.
@@ -245,8 +247,8 @@ class JacobianMutator : public ExprMutator {
     CommReducer new_combiner = CommReducer(new_lhs, new_rhs, new_result, new_identity);
     // Also simplify the resulting combiner
     // (mostly to get rid of unused components, e.g., the original expressions)
-    return analyzer_.Simplify(
-        Reduce(new_combiner, new_source, new_op->axis, new_op->condition, new_op->value_index));
+    return analyzer_.Simplify(Reduce(new_combiner, new_source, new_op->axis, new_op->condition,
+                                     new_op->value_index, new_op->init));
   }
 
   PrimExpr VisitExpr_(const CastNode* op) {
@@ -342,7 +344,8 @@ Tensor Jacobian(const Tensor& output, const Tensor& input) {
   if (const ReduceNode* red = new_body.as<ReduceNode>()) {
     value_index = red->value_index;
     for (size_t idx = 0; idx < red->source.size(); ++idx) {
-      new_bodies.push_back(Reduce(red->combiner, red->source, red->axis, red->condition, idx));
+      new_bodies.push_back(
+          Reduce(red->combiner, red->source, red->axis, red->condition, idx, red->init));
     }
   } else {
     new_bodies.push_back(new_body);

--- a/src/te/operation/compute_op.cc
+++ b/src/te/operation/compute_op.cc
@@ -56,7 +56,8 @@ static void VerifyComputeOp(const ComputeOpNode* op);
 
 inline bool ReduceEqual(const tir::ReduceNode* a, const tir::ReduceNode* b) {
   return (a->combiner.same_as(b->combiner)) && (a->source.same_as(b->source)) &&
-         (a->axis.same_as(b->axis)) && (a->condition.same_as(b->condition));
+         (a->axis.same_as(b->axis)) && (a->condition.same_as(b->condition)) &&
+         ((a->init.empty() && b->init.empty()) || (a->init.same_as(b->init)));
 }
 
 int ComputeOpNode::num_outputs() const { return body.size(); }
@@ -307,6 +308,13 @@ void MakeReduction(const ComputeOpNode* op, const Array<Tensor>& tensors, Stmt* 
   }
   Array<PrimExpr> init_value = combiner->identity_element;
   Array<PrimExpr> update_value = (*combiner)(lhs, reduce->source);
+
+  // If an init was passed to ReduceNode, use that for initialization
+  // instead of combiner->identity_element
+  Array<PrimExpr> reduce_init = reduce->init;
+  if (!reduce_init.empty()) {
+    init_value = reduce_init;
+  }
   for (size_t i = 0; i < size; ++i) {
     Tensor t = tensors[i];
     inits.emplace_back(ProducerStore(t, init_value[i], args));

--- a/src/te/operation/cross_thread_reduction.cc
+++ b/src/te/operation/cross_thread_reduction.cc
@@ -97,6 +97,7 @@ Stmt MakeCrossThreadReduction(const ComputeOpNode* self, const Stage& stage,
   for (size_t i = 0; i < size; ++i) {
     const ReduceNode* reduce = self->body[i].as<ReduceNode>();
     CHECK(reduce);
+    CHECK(reduce->init.empty()) << "Cannot perform cross_thread_reduction for reductions with init";
     reduces[i] = reduce;
   }
 

--- a/src/te/operation/tensorize.cc
+++ b/src/te/operation/tensorize.cc
@@ -192,7 +192,7 @@ class TensorIntrinMatcher final : public StmtExprMutator {
         axis.push_back(it->second);
       }
     }
-    return Reduce(op->combiner, op->source, axis, op->condition, op->value_index);
+    return Reduce(op->combiner, op->source, axis, op->condition, op->value_index, op->init);
   }
 
   void Init(const ComputeOpNode* self, const Stage& stage,

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -632,54 +632,54 @@ PrimExpr isinf(PrimExpr x) {
 // isfinite
 PrimExpr isfinite(PrimExpr x) { return !isinf(x) && !isnan(x); }
 
-PrimExpr sum(PrimExpr source, Array<IterVar> rdom) {
+PrimExpr sum(PrimExpr source, Array<IterVar> rdom, Array<PrimExpr> init) {
   Var x("x", source.dtype()), y("y", source.dtype());
   PrimExpr result = tir::Add(x, y);
   PrimExpr identity_element = make_zero(source.dtype());
   tir::CommReducer combiner = tir::CommReducer({x}, {y}, {result}, {identity_element});
-  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0);
+  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0, init);
 }
 
-PrimExpr all(PrimExpr source, Array<IterVar> rdom) {
+PrimExpr all(PrimExpr source, Array<IterVar> rdom, Array<PrimExpr> init) {
   CHECK(source.dtype().is_bool());
   Var x("x", source.dtype()), y("y", source.dtype());
   PrimExpr result = tir::And(x, y);
   PrimExpr identity_element = make_const(source.dtype(), true);
   tir::CommReducer combiner = tir::CommReducer({x}, {y}, {result}, {identity_element});
-  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0);
+  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0, init);
 }
 
-PrimExpr any(PrimExpr source, Array<IterVar> rdom) {
+PrimExpr any(PrimExpr source, Array<IterVar> rdom, Array<PrimExpr> init) {
   CHECK(source.dtype().is_bool());
   Var x("x", source.dtype()), y("y", source.dtype());
   PrimExpr result = tir::Or(x, y);
   PrimExpr identity_element = make_const(source.dtype(), false);
   tir::CommReducer combiner = tir::CommReducer({x}, {y}, {result}, {identity_element});
-  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0);
+  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0, init);
 }
 
-PrimExpr max(PrimExpr source, Array<IterVar> rdom) {
+PrimExpr max(PrimExpr source, Array<IterVar> rdom, Array<PrimExpr> init) {
   Var x("x", source.dtype()), y("y", source.dtype());
   PrimExpr result = tir::Max(x, y);
   PrimExpr identity_element = min_value(source.dtype());
   tir::CommReducer combiner = tir::CommReducer({x}, {y}, {result}, {identity_element});
-  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0);
+  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0, init);
 }
 
-PrimExpr min(PrimExpr source, Array<IterVar> rdom) {
+PrimExpr min(PrimExpr source, Array<IterVar> rdom, Array<PrimExpr> init) {
   Var x("x", source.dtype()), y("y", source.dtype());
   PrimExpr result = tir::Min(x, y);
   PrimExpr identity_element = max_value(source.dtype());
   tir::CommReducer combiner = tir::CommReducer({x}, {y}, {result}, {identity_element});
-  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0);
+  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0, init);
 }
 
-PrimExpr prod(PrimExpr source, Array<IterVar> rdom) {
+PrimExpr prod(PrimExpr source, Array<IterVar> rdom, Array<PrimExpr> init) {
   Var x("x", source.dtype()), y("y", source.dtype());
   PrimExpr result = tir::Mul(x, y);
   PrimExpr identity_element = make_const(source.dtype(), 1);
   tir::CommReducer combiner = tir::CommReducer({x}, {y}, {result}, {identity_element});
-  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0);
+  return tir::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(1), true), 0, init);
 }
 
 // fmod

--- a/tests/python/unittest/test_arith_canonical_simplify.py
+++ b/tests/python/unittest/test_arith_canonical_simplify.py
@@ -181,8 +181,10 @@ def test_reduce_combiner_simplify():
     # Test that SimplifyCombiner makes use of vranges
     ck.analyzer.update(dummy, tvm.arith.ConstIntBound(-10, -4))
     ck.verify(sum_or_prod(A[k], k), te.sum(A[k], k))
+    ck.verify(sum_or_prod(A[k], k, init=1), te.sum(A[k], k, init=1))
     ck.analyzer.update(dummy, tvm.arith.ConstIntBound(5, 9), True)
     ck.verify(sum_or_prod(A[k], k), prod(A[k], k))
+    ck.verify(sum_or_prod(A[k], k, init=1), prod(A[k], k, init=1))
     ck.analyzer.update(dummy, tvm.arith.ConstIntBound(-10, 100), True)
     ck.verify(sum_and_prod((A[k], A[10-k]), k)[0], te.sum(A[k], k))
     ck.verify(sum_and_prod((A[k], A[10-k]), k)[1], prod(A[10-k], k))
@@ -219,6 +221,7 @@ def test_reduce_simplify():
     ck.verify(te.sum(tvm.tir.Select(k + j < 12, k + j, 0), [k, j]),
               te.sum(k + j, [k, j]))
     ck.verify(te.sum(A[3], []), A[3])
+    ck.verify(te.sum(A[3], [], where=k > 12, init=1.0), tvm.tir.const(1.0, dtype='float32'))
     # The rule below is not typical, removed for now
     ck.verify(te.sum(te.div(k, 10), k), te.sum(tvm.tir.const(0, "int32"), k))
 

--- a/tests/python/unittest/test_te_autodiff.py
+++ b/tests/python/unittest/test_te_autodiff.py
@@ -20,6 +20,7 @@ from tvm import te
 from tvm.testing import check_numerical_grads, assert_allclose
 from tvm import topi
 from tvm.topi.util import get_const_tuple
+import pytest
 
 import numpy as np
 
@@ -324,6 +325,15 @@ def test_stride_dilation():
     Y = topi.nn.pool(X, [3, 3], [3, 3], [0, 0, 0, 0], 'max')
     check_grad(Y, [X])
 
+@pytest.mark.xfail
+def test_reduction_init():
+    np.random.seed(0)
+    shape = (10, 10)
+    k = te.reduce_axis((0, 10), name="k")
+    A0 = te.placeholder(shape, name='A0')
+
+    B = te.compute((10,), lambda i: te.sum(A0[i, k]*A0[k, i], axis=k, init=0.0), name='B')
+    check_grad(B, A0)
 
 if __name__ == "__main__":
     test_basic_operation()


### PR DESCRIPTION
- This patch adds a new member to ReduceNode called init which allows
  initialization with a custom ProducerLoad or a Float/Int immediate.
- This allows initialization of the output Tensor of a reduction with
  another Tensor instead of the `identity_element` defined in the
  CommReducer
- One example use case for this node is to initialize the Output of a
  convolution reduction with the Bias values thereby saving the
  Bias-add computation.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
