### PR TITLE
Improve error messages in graph tuner, graph runtime, and module loader.

### DIFF
--- a/python/tvm/autotvm/graph_tuner/base_graph_tuner.py
+++ b/python/tvm/autotvm/graph_tuner/base_graph_tuner.py
@@ -152,6 +152,9 @@ class BaseGraphTuner(object):
 
         self._graph = graph
         self._in_nodes_dict = get_in_nodes(self._node_list, self._target_ops, input_shapes.keys())
+        if len(self._in_nodes_dict) == 0:
+            raise RuntimeError("Could not find any input nodes with whose "
+                               "operator is one of %s" % self._target_ops)
         self._out_nodes_dict = get_out_nodes(self._in_nodes_dict)
         self._fetch_cfg()
         self._opt_out_op = OPT_OUT_OP

--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -152,7 +152,10 @@ class GraphModule(object):
            Additional arguments
         """
         if key is not None:
-            self._get_input(key).copyfrom(value)
+            v = self._get_input(key)
+            if v is None:
+                raise RuntimeError("Could not find '%s' in graph's inputs" % key)
+            v.copyfrom(value)
 
         if params:
             # upload big arrays first to avoid memory issue in rpc mode


### PR DESCRIPTION
I ran into a couple of confusing errors, so I've improved the error messages for them. The error message for loading a module when its TVM is missing the runtime for it was particularly confusing, so I think this should help make it more clear.