### PR TITLE
[Relay][TF][BugFix] when converting constant nodes with types of int64 or float64

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -2835,7 +2835,7 @@ class GraphProto(object):
 
             array_ndim = len(np_array.shape)
             if array_ndim == 0:
-                self._nodes[name] = [tvm.relay.const(np_array)]
+                self._nodes[name] = [tvm.relay.const(np_array, np_array.dtype)]
             else:
                 self._params[name] = tvm.nd.array(np_array)
                 self._nodes[name] = [_expr.var(name,


### PR DESCRIPTION
when creating a constant node in relay, if dtype is not specified, inputs with int64 type will be converted to int32 type, which may cause error in following data type checks.
