### PR TITLE
[CI] Remove topi from the CI cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,6 @@ tvm_lib = "build/libtvm.so, " + tvm_runtime
 tvm_multilib = "build/libtvm.so, " +
                "build/libvta_tsim.so, " +
                "build/libvta_fsim.so, " +
-               "build/libtvm_topi.so, " +
                tvm_runtime
 
 // command to start a docker container


### PR DESCRIPTION
This is a followup step to cleanup topi->tvm/topi. We can then open another PR to remove libtvm_topi from the CMake build target
