### PR TITLE
[FIX] Verify that tensor reshape is valid.

### DIFF
--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -21,6 +21,7 @@ import pytest
 import tvm
 from tvm import te
 from tvm import relay
+from tvm.error import TVMError
 from tvm.relay import create_executor, transform
 from tvm.relay.testing import ctx_list, check_grad, run_infer_type
 
@@ -280,6 +281,13 @@ def test_reshape():
     verify_reshape((2, 3, 4), (-3, -2), (6, 4))
     verify_reshape((2, 3, 4), (-4, 1, 2, -2), (1, 2, 3, 4))
     verify_reshape((2, 3, 4), (2, -4, -1, 3, -2), (2, 1, 3, 4))
+
+
+def test_reshape_fail():
+    with pytest.raises(TVMError) as reshape_err:
+        x = relay.var("x", relay.TensorType([2,3], "float32"))
+        z = relay.reshape(x, [7])
+        zz = run_infer_type(z)
 
 
 def test_reshape_like_infer_type():
@@ -1070,6 +1078,7 @@ if __name__ == "__main__":
     test_transpose()
     test_reshape_infer_type()
     test_reshape()
+    test_reshape_fail()
     test_reshape_like_infer_type()
     test_reshape_like()
     test_take_infer_type()

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -187,7 +187,7 @@ def test_combine_parallel_dense_biasadd_scale_reshape():
         tvm.ir.assert_structural_equal(y, y_expected, map_free_vars=True)
 
     check(3, 5, 4, 0.5, 0.25, (1, 1, 15))
-    check(100, 200, 300, 0.5, 0.25, (1, 1, 200))
+    check(100, 200, 300, 0.5, 0.25, (1, 1, 20000))
 
 
 def test_combine_parallel_dense_flat():
@@ -369,7 +369,7 @@ def test_combine_parallel_dense_flat_biasadd_scale_reshape():
         tvm.ir.assert_structural_equal(y, y_expected, map_free_vars=True)
 
     check(3, 5, 4, 0.5, 0.25, (1, 1, 15), (1, 1, 30))
-    check(100, 200, 300, 0.5, 0.25, (1, 1, 200), (1, 1, 400))
+    check(100, 200, 300, 0.5, 0.25, (1, 1, 20000), (1, 1, 40000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a check to reshape to verify that the input and output dimensions are compatible.

Fixes #6210 

@mbrookhart 