### PR TITLE
[JVM] Support overriding RPCWatchdog termination behavior on Android and other platforms

### DIFF
--- a/apps/android_rpc/app/src/main/java/org/apache/tvm/tvmrpc/RPCActivity.java
+++ b/apps/android_rpc/app/src/main/java/org/apache/tvm/tvmrpc/RPCActivity.java
@@ -51,7 +51,7 @@ public class RPCActivity extends AppCompatActivity {
     int port = intent.getIntExtra("port", 9090);
     String key = intent.getStringExtra("key");
 
-    tvmServerWorker = new RPCProcessor();
+    tvmServerWorker = new RPCProcessor(this);
     tvmServerWorker.setDaemon(true);
     tvmServerWorker.start();
     tvmServerWorker.connect(host, port, key);
@@ -62,5 +62,6 @@ public class RPCActivity extends AppCompatActivity {
     System.err.println("rpc activity onDestroy");
     tvmServerWorker.disconnect();
     super.onDestroy();
+    android.os.Process.killProcess(android.os.Process.myPid());
   }
 }

--- a/apps/android_rpc/app/src/main/java/org/apache/tvm/tvmrpc/RPCAndroidWatchdog.java
+++ b/apps/android_rpc/app/src/main/java/org/apache/tvm/tvmrpc/RPCAndroidWatchdog.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tvm.tvmrpc;
+
+import android.app.Activity;
+import org.apache.tvm.rpc.RPCWatchdog;
+
+/**
+ * Watchdog for Android RPC.
+ */
+public class RPCAndroidWatchdog extends RPCWatchdog {
+  public Activity rpc_activity = null;
+  public RPCAndroidWatchdog(Activity activity) {
+    super();
+    rpc_activity = activity;
+  }
+
+  /**
+   * Method to non-destructively terminate the running thread on Android
+   */
+  @Override protected void terminate() {
+    rpc_activity.finish();
+  }
+}

--- a/apps/android_rpc/app/src/main/java/org/apache/tvm/tvmrpc/RPCProcessor.java
+++ b/apps/android_rpc/app/src/main/java/org/apache/tvm/tvmrpc/RPCProcessor.java
@@ -17,10 +17,10 @@
 
 package org.apache.tvm.tvmrpc;
 
+import android.app.Activity;
 import android.os.ParcelFileDescriptor;
 import java.net.Socket;
 import org.apache.tvm.rpc.ConnectTrackerServerProcessor;
-import org.apache.tvm.rpc.RPCWatchdog;
 
 /**
  * Connect to RPC proxy and deal with requests.
@@ -33,9 +33,15 @@ class RPCProcessor extends Thread {
   private long startTime;
   private ConnectTrackerServerProcessor currProcessor;
   private boolean first = true;
+  private Activity rpc_activity = null;
+
+  public RPCProcessor(Activity activity) {
+    super();
+    rpc_activity = activity;
+  }
 
   @Override public void run() {
-    RPCWatchdog watchdog = new RPCWatchdog();
+    RPCAndroidWatchdog watchdog = new RPCAndroidWatchdog(rpc_activity);
     watchdog.start();
     while (true) {
       synchronized (this) {

--- a/jvm/core/src/main/java/org/apache/tvm/rpc/RPCWatchdog.java
+++ b/jvm/core/src/main/java/org/apache/tvm/rpc/RPCWatchdog.java
@@ -71,7 +71,7 @@ public class RPCWatchdog extends Thread {
             } else {
               System.err.println("watchdog woke up!");
               System.err.println("terminating...");
-              System.exit(0);
+              terminate();
             }
           } catch (InterruptedException e) {
             System.err.println("watchdog interrupted...");
@@ -79,5 +79,12 @@ public class RPCWatchdog extends Thread {
         }
       }
     }
+  }
+
+  /**
+   * Method to terminate the running thread
+   */
+  protected void terminate() {
+    System.exit(0);
   }
 }

--- a/jvm/core/src/main/java/org/apache/tvm/rpc/RPCWatchdog.java
+++ b/jvm/core/src/main/java/org/apache/tvm/rpc/RPCWatchdog.java
@@ -82,7 +82,7 @@ public class RPCWatchdog extends Thread {
   }
 
   /**
-   * Method to terminate the running thread
+   * Default method to terminate the running RPCActivity process.
    */
   protected void terminate() {
     System.exit(0);


### PR DESCRIPTION
Calling System.exit(0) from the watchdog (RPCActivity) emits an interrupt request that goes uncaught in some Android environments resulting in a system crash. I believe the correct non-destructive behavior should be to finish the RPCActivity, thereby popping the activity stack and returning control to the MainActivity, from which the RPCActivity can be restarted using the normal auto-reboot sequence.