### PR TITLE
[C++ RPC] fix port_end wrong default value 9199 to 9099 for keeping same with source code

### DIFF
--- a/apps/cpp_rpc/main.cc
+++ b/apps/cpp_rpc/main.cc
@@ -51,7 +51,7 @@ static const string kUsage =
     " server       - Start the server\n"
     "--host        - The hostname of the server, Default=0.0.0.0\n"
     "--port        - The port of the RPC, Default=9090\n"
-    "--port-end    - The end search port of the RPC, Default=9199\n"
+    "--port-end    - The end search port of the RPC, Default=9099\n"
     "--tracker     - The RPC tracker address in host:port format e.g. 10.1.1.2:9190 Default=\"\"\n"
     "--key         - The key used to identify the device type in tracker. Default=\"\"\n"
     "--custom-addr - Custom IP Address to Report to RPC Tracker. Default=\"\"\n"
@@ -66,7 +66,7 @@ static const string kUsage =
  * \brief RpcServerArgs.
  * \arg host The hostname of the server, Default=0.0.0.0
  * \arg port The port of the RPC, Default=9090
- * \arg port_end The end search port of the RPC, Default=9199
+ * \arg port_end The end search port of the RPC, Default=9099
  * \arg tracker The address of RPC tracker in host:port format e.g. 10.77.1.234:9190 Default=""
  * \arg key The key used to identify the device type in tracker. Default=""
  * \arg custom_addr Custom IP Address to Report to RPC Tracker. Default=""

--- a/apps/cpp_rpc/rpc_server.cc
+++ b/apps/cpp_rpc/rpc_server.cc
@@ -86,7 +86,7 @@ static std::string getNextString(std::stringstream* iss) {
  * \brief RPCServer RPC Server class.
  * \param host The hostname of the server, Default=0.0.0.0
  * \param port The port of the RPC, Default=9090
- * \param port_end The end search port of the RPC, Default=9199
+ * \param port_end The end search port of the RPC, Default=9099
  * \param tracker The address of RPC tracker in host:port format e.g. 10.77.1.234:9190 Default=""
  * \param key The key used to identify the device type in tracker. Default=""
  * \param custom_addr Custom IP Address to Report to RPC Tracker. Default=""
@@ -362,7 +362,7 @@ void ServerLoopFromChild(SOCKET socket) {
  * \brief RPCServerCreate Creates the RPC Server.
  * \param host The hostname of the server, Default=0.0.0.0
  * \param port The port of the RPC, Default=9090
- * \param port_end The end search port of the RPC, Default=9199
+ * \param port_end The end search port of the RPC, Default=9099
  * \param tracker_addr The address of RPC tracker in host:port format e.g. 10.77.1.234:9190
  * Default="" \param key The key used to identify the device type in tracker. Default="" \param
  * custom_addr Custom IP Address to Report to RPC Tracker. Default="" \param silent Whether run in

--- a/apps/cpp_rpc/rpc_server.h
+++ b/apps/cpp_rpc/rpc_server.h
@@ -44,7 +44,7 @@ void ServerLoopFromChild(SOCKET socket);
  * \brief RPCServerCreate Creates the RPC Server.
  * \param host The hostname of the server, Default=0.0.0.0
  * \param port The port of the RPC, Default=9090
- * \param port_end The end search port of the RPC, Default=9199
+ * \param port_end The end search port of the RPC, Default=9099
  * \param tracker The address of RPC tracker in host:port format e.g. 10.77.1.234:9190 Default=""
  * \param key The key used to identify the device type in tracker. Default=""
  * \param custom_addr Custom IP Address to Report to RPC Tracker. Default=""


### PR DESCRIPTION
apps/cpp_rpc/main.cc  L78  int port_end = 9099, but  help message and some comment say it is 9199.
