### PR TITLE
[TFLite] axis can be a scalar

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1590,7 +1590,11 @@ class OperatorConverter(object):
         in_expr = self.get_expr(input_tensor.tensor_idx)
 
         # axis
-        axis = tuple(self.get_tensor_value(input_tensors[1]))
+        axis_value = self.get_tensor_value(input_tensors[1])
+        if axis_value.size == 1:
+            axis = (axis_value.item(),)
+        else:
+            axis = tuple(axis_value)
 
         # Options - keep_dims (bool)
         assert op.BuiltinOptionsType() == BuiltinOptions.ReducerOptions


### PR DESCRIPTION
if tensor is scalar, then "tuple(axis_value)" will raise "TypeError: iteration over a 0-d array"
