### PR TITLE
[BYOC][JSON] json_node.h should include data_type.h

### DIFF
--- a/src/runtime/contrib/json/json_node.h
+++ b/src/runtime/contrib/json/json_node.h
@@ -28,7 +28,7 @@
 #include <dlpack/dlpack.h>
 #include <dmlc/json.h>
 #include <dmlc/memory_io.h>
-#include <tvm/runtime/container.h>
+#include <tvm/runtime/data_type.h>
 
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
json_node uses the function String2DLDataType which an be found in data_type.h. #6214 reshuffled a few includes in container.h which meant String2DLDataType could not be found during compilation.

cc @comaniac @zhiics @tqchen 
