### PR TITLE
fix cuda half math function is undefined: hpow, htanh

### DIFF
--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -293,6 +293,19 @@ __pack_half2(const half x, const half y) {
   unsigned v1 = *((unsigned short *)&y);
   return (v1 << 16) | v0;
 }
+
+static inline __device__ __host__ half hpow(half x, half y) {
+  float tmp_x = __half2float(x);
+  float tmp_y = __half2float(y);
+  float result = powf(tmp_x, tmp_y);
+  return __float2half(result);
+}
+
+static inline __device__ __host__ half htanh(half x) {
+  float tmp_x = __half2float(x);
+  float result = tanhf(tmp_x);
+  return __float2half(result);
+}
 )";
 
 static constexpr const char* _cuda_warp_intrinsic_util = R"(


### PR DESCRIPTION
I was trying to transfer BERT model to TVM, but encountered some problems with undefined function: hpow, htanh.
![image](https://user-images.githubusercontent.com/68592047/89543223-3dcd0700-d833-11ea-9706-b05e6586c4e8.png)
![image](https://user-images.githubusercontent.com/68592047/89543244-445b7e80-d833-11ea-8f1f-10e9ad544951.png)

with refer to the [cuda user manual](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____HALF__FUNCTIONS.html#group__CUDA__MATH____HALF__FUNCTIONS), I just simulate with float32 function. 

Thanks !
