### PR TITLE
[uTVM] fix crt building and running error

### DIFF
--- a/include/tvm/runtime/crt/module.h
+++ b/include/tvm/runtime/crt/module.h
@@ -27,6 +27,10 @@
 #include <tvm/runtime/c_backend_api.h>
 #include <tvm/runtime/crt/func_registry.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*!
  * \brief Module container of TVM.
  */
@@ -38,4 +42,7 @@ typedef struct TVMModule {
 /*! \brief Entry point for the system lib module. */
 const TVMModule* TVMSystemLibEntryPoint(void);
 
+#ifdef __cplusplus
+}
+#endif
 #endif  // TVM_RUNTIME_CRT_MODULE_H_

--- a/src/support/str_escape.h
+++ b/src/support/str_escape.h
@@ -65,7 +65,9 @@ inline std::string StrEscape(const char* data, size_t size, bool use_octal_escap
           break;
         default:
           if (use_octal_escape) {
-            stream << '0' + ((c >> 6) & 0x03) << '0' + ((c >> 3) & 0x07) << '0' + (c & 0x03);
+            stream << static_cast<unsigned char>('0' + ((c >> 6) & 0x03))
+                   << static_cast<unsigned char>('0' + ((c >> 3) & 0x07))
+                   << static_cast<unsigned char>('0' + (c & 0x07));
           } else {
             const char* hex_digits = "0123456789ABCDEF";
             stream << 'x' << hex_digits[c >> 4] << hex_digits[c & 0xf];

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -279,8 +279,9 @@ void CodeGenCHost::GenerateFuncRegistry() {
   decl_stream << "#include <tvm/runtime/crt/module.h>\n";
   stream << "static TVMBackendPackedCFunc _tvm_func_array[] = {\n";
   for (auto f : function_names_) {
-    stream << "    " << f << ",\n";
+    stream << "    (TVMBackendPackedCFunc)" << f << ",\n";
   }
+  stream << "};\n";
   auto registry = target::GenerateFuncRegistryNames(function_names_);
   stream << "static const TVMFuncRegistry _tvm_func_registry = {\n"
          << "    \"" << ::tvm::support::StrEscape(registry.data(), registry.size(), true) << "\","
@@ -290,10 +291,10 @@ void CodeGenCHost::GenerateFuncRegistry() {
 
 void CodeGenCHost::GenerateCrtSystemLib() {
   stream << "static const TVMModule _tvm_system_lib = {\n"
-         << "    &system_lib_registry,\n"
+         << "    &_tvm_func_registry,\n"
          << "};\n"
          << "const TVMModule* TVMSystemLibEntryPoint(void) {\n"
-         << "    return &system_lib;\n"
+         << "    return &_tvm_system_lib;\n"
          << "}\n";
 }
 


### PR DESCRIPTION
1. include\tvm\runtime\crt\module.h function TVMSystemLibEntryPoint:  need extern "C", or else linker complain this symbol can't be found.

2. src\target\source\codegen_c_host.cc  function GenerateFuncRegistry:   f need cast, or else C++ compiler say type not match

    L291 array _tvm_func_array miss "};", so build fail

    system_lib_registry and system_lib name need use new name in PR #6145 

3. src\support\str_escape.h  function StrEscape: convert to octal need 3bit, but unsigned char c should use LSB 3bit, but only use LSB 2bit, because mask macro is 0x03, it should be 0x07.

    '0' + ((c >> 6) & 0x03) need cast to unsigned char,  because ostringstream treat it as int, not unsigned char, so value is error. ex. c = 0x17, means  we have 23  functions to register, so ((c >> 6) & 0x03) == 0,  and '0' + ((c >> 6) & 0x03)  is the int value of '0', which is  48,  but  ostringstream treat it as int, so  we get  a string "485055",  in fact it should be "027"




