### PR TITLE
[TOPI, Cuda] Fix conv2d_transpose output padding

### DIFF
--- a/python/tvm/topi/cuda/conv2d_transpose_nchw.py
+++ b/python/tvm/topi/cuda/conv2d_transpose_nchw.py
@@ -65,13 +65,13 @@ def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype,
     out_width = (inp_width - 1) * stride_width + \
         kernel_width - pad_left - pad_right + outpad_width
     pad_left = kernel_width - 1 - pad_left
-    pad_right = kernel_width - 1 - pad_right
+    pad_right = kernel_width - 1 - pad_right + outpad_width
     dilated_width = stride_width * (inp_width - 1) + 1
 
     out_height = (inp_height - 1) * stride_height + \
         kernel_height - pad_top - pad_bottom + outpad_height
     pad_top = kernel_height - 1 - pad_top
-    pad_bottom = kernel_height - 1 - pad_bottom
+    pad_bottom = kernel_height - 1 - pad_bottom + outpad_height
     dilated_height = stride_height * (inp_height - 1) + 1
 
     # compute pad

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -151,8 +151,7 @@ def verify_conv2d_grad(dshape, wshape, strides, padding, dilation, groups=1, mod
 def test_conv2d_grad():
     verify_conv2d_grad((1, 4, 16, 16), (16, 4, 3, 3), [1, 1], [1, 1], [1, 1])
     verify_conv2d_grad((1, 4, 16, 16), (16, 4, 1, 1), [1, 1], [0, 0], [1, 1])
-    # TODO(@vinx13) recover the test after we fix the conv2d grad.
-    # verify_conv2d_grad((1, 4, 16, 16), (16, 4, 1, 1), [2, 2], [0, 0], [1, 1])
+    verify_conv2d_grad((1, 4, 16, 16), (16, 4, 1, 1), [2, 2], [0, 0], [1, 1])
     verify_conv2d_grad((1, 4, 16, 16), (16, 4, 3, 3), [1, 1], [1, 1], [1, 1], mode='first_order')
 
 


### PR DESCRIPTION
This PR fix out-of-boundary access in the implementation of conv2d transpose on CUDA.

Fixed #6179 

cc @areusch @abergeron @tqchen 