### PR TITLE
[Relay]Refine tensorflow frontend 1.x & 2.x compatibility

### DIFF
--- a/python/tvm/relay/frontend/tensorflow_parser.py
+++ b/python/tvm/relay/frontend/tensorflow_parser.py
@@ -67,12 +67,16 @@ class TFParser(object):
     def _get_tag_set(self):
         """Return the tag set of saved model, multiple metagraphs are not supported"""
         try:
-            from tensorflow.contrib.saved_model.python.saved_model import reader
+            from tensorflow.contrib.saved_model.python.saved_model.reader \
+                import get_saved_model_tag_sets
         except ImportError:
-            raise ImportError(
-                "InputConfiguration: Unable to import saved_model.reader which is "
-                "required to get tag set from saved model.")
-        tag_sets = reader.get_saved_model_tag_sets(self._model_dir)
+            try:
+                from tensorflow.python.tools.saved_model_utils import get_saved_model_tag_sets
+            except ImportError:
+                raise ImportError(
+                    "InputConfiguration: Unable to import get_saved_model_tag_sets which is "
+                    "required to get tag set from saved model.")
+        tag_sets = get_saved_model_tag_sets(self._model_dir)
         return tag_sets[0]
 
     def _get_output_names(self):
@@ -85,7 +89,9 @@ class TFParser(object):
                 "required to restore from saved model.")
         tags = self._get_tag_set()
         output_names = set()
-        with tf.Session() as sess:
+        config = tf.ConfigProto()
+        config.gpu_options.allow_growth = True
+        with tf.Session(config = config) as sess:
             meta_graph_def = tf.saved_model.loader.load(sess,
                                                         tags,
                                                         self._model_dir)

--- a/python/tvm/relay/frontend/tensorflow_parser.py
+++ b/python/tvm/relay/frontend/tensorflow_parser.py
@@ -89,9 +89,7 @@ class TFParser(object):
                 "required to restore from saved model.")
         tags = self._get_tag_set()
         output_names = set()
-        config = tf.ConfigProto()
-        config.gpu_options.allow_growth = True
-        with tf.Session(config=config) as sess:
+        with tf.Session() as sess:
             meta_graph_def = tf.saved_model.loader.load(sess,
                                                         tags,
                                                         self._model_dir)

--- a/python/tvm/relay/frontend/tensorflow_parser.py
+++ b/python/tvm/relay/frontend/tensorflow_parser.py
@@ -91,7 +91,7 @@ class TFParser(object):
         output_names = set()
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
-        with tf.Session(config = config) as sess:
+        with tf.Session(config=config) as sess:
             meta_graph_def = tf.saved_model.loader.load(sess,
                                                         tags,
                                                         self._model_dir)


### PR DESCRIPTION
I was compiling a TensorFlow saved model exported by TensorFlow 2.x. I encountered `ImportError` from `_get_tag_set` of `tensorflow_parser.py`.

For TensorFlow 2.x, `get_saved_model_tag_sets` has been moved into `tensorflow.python.tools.saved_model_utils`.

This pull request refined above tiny issue.
