### PR TITLE
[CI] Add apt repository for clang-11 and llvm-11

### DIFF
--- a/docker/install/ubuntu1804_install_llvm.sh
+++ b/docker/install/ubuntu1804_install_llvm.sh
@@ -31,6 +31,11 @@ echo deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main\
 echo deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main\
      >> /etc/apt/sources.list.d/llvm.list
 
+echo deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main\
+     >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main\
+     >> /etc/apt/sources.list.d/llvm.list
+
 echo deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\
      >> /etc/apt/sources.list.d/llvm.list
 echo deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\


### PR DESCRIPTION
This patch add specific apt repositories to install clang-11 and llvm-11. Fix #6255.

cc @tqchen