### PR TITLE
Fix newer GCC compiler warnings.

### DIFF
--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -664,7 +664,7 @@ class Parser {
           auto global = GlobalVar(global_name);
           try {
             global_names.Add(global_name, global);
-          } catch (DuplicateKeyError e) {
+          } catch (const DuplicateKeyError& e) {
             this->diag_ctx->Emit(Diagnostic::Error(global_tok->span) << "a function with the name "
                                                                      << "`@" << global_name << "` "
                                                                      << "was previously defined");
@@ -703,7 +703,7 @@ class Parser {
 
     try {
       type_names.Add(type_id, type_global);
-    } catch (DuplicateKeyError e) {
+    } catch (const DuplicateKeyError& e) {
       this->diag_ctx->Emit(Diagnostic::Error(type_tok->span) << "a type definition with the name "
                                                              << "`" << type_id << "` "
                                                              << "was previously defined");
@@ -747,7 +747,7 @@ class Parser {
 
             try {
               this->ctors.Add(ctor_name, ctor);
-            } catch (DuplicateKeyError e) {
+            } catch (const DuplicateKeyError& e) {
               this->diag_ctx->EmitFatal(Diagnostic::Error(ctor_tok->span)
                                         << "a constructor with the name "
                                         << "`" << ctor_name << "` "
@@ -1341,7 +1341,7 @@ class Parser {
     DLOG(INFO) << "op_name=" << op_name << " token=" << tok;
     try {
       return Op::Get(op_name);
-    } catch (dmlc::Error e) {
+    } catch (const dmlc::Error& e) {
       this->diag_ctx->Emit(Diagnostic::Error(tok->span)
                            << "operator `" << op_name
                            << "` not found, perhaps you forgot to register it?");


### PR DESCRIPTION
Proposed PR fixes the compiler warnings below.

* The offending lines were introduced by PR #6162

* The fix is proposed in accord with discussions from [here](https://stackoverflow.com/questions/55318850/how-do-i-fix-this-warning-on-codeblocks-ide-warning-catching-polymorphic-type)

```
[ 27%] Building CXX object CMakeFiles/tvm.dir/src/printer/text_printer.cc.o
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc: In member function ‘tvm::parser::Definitions tvm::parser::Parser::ParseDefinitions()’:
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc:667:38: warning: catching polymorphic type ‘struct tvm::parser::DuplicateKeyError’ by value [-Wcatch-value=]
  667 |           } catch (DuplicateKeyError e) {
      |                                      ^
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc: In member function ‘tvm::relay::TypeData tvm::parser::Parser::ParseTypeDef()’:
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc:706:32: warning: catching polymorphic type ‘struct tvm::parser::DuplicateKeyError’ by value [-Wcatch-value=]
  706 |     } catch (DuplicateKeyError e) {
      |                                ^
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc: In lambda function:
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc:750:40: warning: catching polymorphic type ‘struct tvm::parser::DuplicateKeyError’ by value [-Wcatch-value=]
  750 |             } catch (DuplicateKeyError e) {
      |                                        ^
[ 28%] Building CXX object CMakeFiles/tvm.dir/src/printer/tir_hybrid_printer.cc.o
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc: In member function ‘tvm::parser::Expr tvm::parser::Parser::GetOp(const string&, const tvm::parser::Token&)’:
/home/cbalint/work/TVM/tvm.marlann/src/parser/parser.cc:1344:26: warning: catching polymorphic type ‘struct dmlc::Error’ by value [-Wcatch-value=]
 1344 |     } catch (dmlc::Error e) {

```
Used GCC compiler:
```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/10/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl --enable-offload-targets=nvptx-none --without-cuda-driver --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.2.1 20200804 (Red Hat 10.2.1-2) (GCC) 
```


@jroesch, please help with the review.

Thank You !
