### PR TITLE
Trivial fix, up the rodata section for the discovery board to 512 bytes.

### DIFF
--- a/python/tvm/micro/device/arm/stm32f746xx.py
+++ b/python/tvm/micro/device/arm/stm32f746xx.py
@@ -30,7 +30,7 @@ BASE_ADDR = 0x20000000
 AVAILABLE_MEM = 320000
 DEFAULT_SECTION_CONSTRAINTS = {
     "text": (18000, MemConstraint.ABSOLUTE_BYTES),
-    "rodata": (100, MemConstraint.ABSOLUTE_BYTES),
+    "rodata": (512, MemConstraint.ABSOLUTE_BYTES),
     "data": (100, MemConstraint.ABSOLUTE_BYTES),
     "bss": (640, MemConstraint.ABSOLUTE_BYTES),
     "args": (4096, MemConstraint.ABSOLUTE_BYTES),


### PR DESCRIPTION
This is more reasonable as the trivial tflite example module needs 208 bytes.
Fixes : https://github.com/apache/incubator-tvm/issues/6246

Signed-off-by: Tom Gall <tom.gall@linaro.org>


