### PR TITLE
update tutorial to new TARGET as micro_dev is no more

### DIFF
--- a/tutorials/micro/micro_tflite.py
+++ b/tutorials/micro/micro_tflite.py
@@ -152,7 +152,7 @@ mod, params = relay.frontend.from_tflite(tflite_model,
 #
 # Setup the device config which is what will be used to communicate
 # with the microcontroller (a STM32F746 Discovery board)
-TARGET = 'c -device=micro_dev'
+TARGET = 'c --system-lib  --runtime=c'
 dev_config = micro.device.arm.stm32f746xx.generate_config("127.0.0.1", 6666)
 
 ######################################################################


### PR DESCRIPTION
Trivial update to TARGET to use the new --system-lib and --runtime=c as micro_dev device is no more as of 

Signed-off-by: Tom Gall <tom.gall@linaro.org>

