### PR TITLE
[Ansor][AutoTVM v2.0] Phase 1: XGBoost Cost Model

### DIFF
--- a/include/tvm/auto_scheduler/feature.h
+++ b/include/tvm/auto_scheduler/feature.h
@@ -21,7 +21,7 @@
  * \file auto_scheduler/feature.h
  * \brief Feature extraction for the cost model.
  * We extract one feature vector per BufferStoreNode statement in a TIR Stmt,
- * so we call this feature as "Per Store" feature.
+ * so we call this feature as "per-store" feature.
  * The cost model also does prediction for each BufferStoreNode statement and aggregates
  * the predictions as the whole score for a TVM IR (Stmt).
  *

--- a/python/tvm/auto_scheduler/__init__.py
+++ b/python/tvm/auto_scheduler/__init__.py
@@ -29,8 +29,8 @@ from . import feature
 from .auto_schedule import SearchTask, TuningOptions, HardwareParams, \
     auto_schedule, EmptyPolicy, SketchPolicy
 from .compute_dag import ComputeDAG
-from .cost_model import RandomModel
-from .measure import MeasureInput, LocalBuilder, LocalRunner, RPCRunner, \
+from .cost_model import RandomModel, XGBModel
+from .measure import MeasureInput, MeasureResult, LocalBuilder, LocalRunner, RPCRunner, \
     LocalRPCMeasureContext
 from .measure_record import RecordToFile, RecordReader, load_best, \
     load_records, save_records

--- a/python/tvm/auto_scheduler/auto_schedule.py
+++ b/python/tvm/auto_scheduler/auto_schedule.py
@@ -161,7 +161,9 @@ class SketchPolicy(SearchPolicy):
             seed or random.randint(1, 1 << 30), verbose, init_search_callbacks)
 
     def generate_sketches(self, print_for_debug=False):
-        """ Generate the sketches. This is mainly used for debugging and testing.
+        """ Generate the sketches.
+        This python interface is mainly used for debugging and testing.
+        The actual search is all doen in c++.
 
         Parameters
         ----------
@@ -181,7 +183,9 @@ class SketchPolicy(SearchPolicy):
         return sketches
 
     def sample_initial_population(self, pop_size):
-        """Sample initial population. This is mainly used for debugging and testing.
+        """Sample initial population.
+        This python interface is mainly used for debugging and testing.
+        The actual search is all doen in c++.
 
         Parameters
         ----------

--- a/python/tvm/auto_scheduler/auto_schedule.py
+++ b/python/tvm/auto_scheduler/auto_schedule.py
@@ -161,7 +161,7 @@ class SketchPolicy(SearchPolicy):
             seed or random.randint(1, 1 << 30), verbose, init_search_callbacks)
 
     def generate_sketches(self, print_for_debug=False):
-        """ Generate the sketches, this is mainly used for debug.
+        """ Generate the sketches. This is mainly used for debugging and testing.
 
         Parameters
         ----------
@@ -179,6 +179,22 @@ class SketchPolicy(SearchPolicy):
                 print("=" * 20 + " %d " % i + "=" * 20)
                 print(s)
         return sketches
+
+    def sample_initial_population(self, pop_size):
+        """Sample initial population. This is mainly used for debugging and testing.
+
+        Parameters
+        ----------
+        pop_size : int
+            The size of sampled population
+
+        Returns
+        -------
+        states: List[State]
+            The sampled states
+        """
+        states = _ffi_api.SketchPolicySampleInitialPopulation(self, pop_size)
+        return states
 
 @tvm._ffi.register_object("auto_scheduler.TuningOptions")
 class TuningOptions(Object):

--- a/python/tvm/auto_scheduler/cost_model/__init__.py
+++ b/python/tvm/auto_scheduler/cost_model/__init__.py
@@ -18,3 +18,4 @@
 """ Cost model that estimates the performance of programs """
 
 from .cost_model import RandomModel
+from .xgb_model import XGBModel

--- a/python/tvm/auto_scheduler/cost_model/cost_model.py
+++ b/python/tvm/auto_scheduler/cost_model/cost_model.py
@@ -146,5 +146,25 @@ class PythonBasedModel(CostModel):
         -------
         scores: List[float]
             The predicted scores for all stages in all states in the packed format
+
+        Note
+        ----
+        For faster data copy between c++ and python, the python part returns scores in a
+        single flatten array using a packed format. The c++ part then unpacks the flatten array.
+
+        The packed format is:
+        {
+          float  scores[N];                 // scores[i] is the score for states[i].
+          int    n_stage_0;                 // the number of stages in states[0]
+          float  stage_scores_0[[n_stage_0] // the scores for all stages in states[0]
+          int    n_stage_1;                 // the number of stages in states[1]
+          float  stage_scores_1[n_stage_1]; // the scores for all stages in states[1]
+          ...
+          int    n_stage_i;                 // the number of stages in states[i]
+          float  stage_scores_1[n_stage_i]; // the scores for all stages in states[i]
+          ...  // untill i == N - 1
+        }
+        To implement this format, we also store int as float, so we can store all numbers
+        into a single float array.
         """
         raise NotImplementedError

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -248,8 +248,9 @@ class XGBModel(PythonBasedModel):
 
         return breakdown
 
-    def load_log_file(self, file_name, n_lines=None):
-        """Load measure records from a log file to pre-train the cost model
+    def update_from_file(self, file_name, n_lines=None):
+        """Load measure records from a log file to update the cost model.
+        This function can be used to pre-train the cost model with history log files.
 
         Parameters
         ----------

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -1,0 +1,498 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Cost model based on xgboost"""
+import multiprocessing
+import logging
+from collections import defaultdict
+
+import numpy as np
+import xgboost as xgb
+
+from tvm.autotvm.tuner.xgboost_cost_model import get_rank, recall_curve, max_curve
+from .cost_model import PythonBasedModel
+from ..feature import get_per_store_features_from_measure_pairs, get_per_store_features_from_states
+from ..measure_record import RecordReader
+
+logger = logging.getLogger('ansor')
+
+class XGBDMatrixContext:
+    """A global context to hold additional attributes of xgb.DMatrix"""
+    def __init__(self):
+        self.context_dict = defaultdict(dict)
+
+    def get(self, key, matrix, default=None):
+        """
+        Get an attribute of a xgb.DMatrix
+
+        Parameters
+        ----------
+        key: str
+            The name of the attribute
+        matrix: xgb.DMatrix
+            The matrix
+        default: Optional
+            The default value if the item does not exist
+        """
+        return self.context_dict[key].get(matrix.handle.value, default)
+
+    def set(self, key, matrix, value):
+        """
+        Set an attribute for a xgb.DMatrix
+
+        Parameters
+        ----------
+        key: str
+            The name of the attribute
+        matrix: xgb.DMatrix
+            The matrix
+        value: Optional
+            The new value
+        """
+        self.context_dict[key][matrix.handle.value] = value
+
+dmatrix_context = XGBDMatrixContext()
+
+class XGBModel(PythonBasedModel):
+    """Train a XGBoost model to predict the runtime cost of a program.
+    The cost of a program = the sum of the costs of all stages in this program.
+    i.e. Cost(p) = cost_s0 + cost_s1 + ... + cost_sn, where cost_si is the cost of Stage i
+
+    The xgboost model makes prediction per stage, then we sum them up.
+    The final predction made by this class is normalized throughtput (from 0 to 1, larger is better)
+
+    To support this stage decomposition, we have to implement a custom loss function for
+    XGBoost, which is the `pack_sum` in the code below.
+    """
+    def __init__(self, verbose_eval=25, num_warmup_sample=100, seed=None):
+        self.xgb_params = {
+            'max_depth': 10,
+            'gamma': 0.001,
+            'min_child_weight': 0,
+            'eta': 0.2,
+            # todo(lmzheng): automatically decrease learning rate when the loss is too large
+
+            'n_gpus': 0,
+            'nthread': multiprocessing.cpu_count() // 2,
+            'verbosity': 0,
+            'seed': seed or 43,
+            'disable_default_eval_metric': 1
+        }
+        self.bst = None
+        self.plan_size = 32
+        self.num_warmup_sample = num_warmup_sample
+        self.verbose_eval = verbose_eval
+
+        super().__init__()
+
+        # measurement input/result pairs
+        self.inputs = []
+        self.results = []
+        self.inputs_feature_cache = []
+
+    def update(self, inputs, results):
+        if len(inputs) <= 0:
+            return
+
+        self.inputs.extend(inputs)
+        self.results.extend(results)
+
+        # extract feature
+        n_cached = len(self.inputs_feature_cache)
+        features, normalized_throughputs, task_ids = \
+            get_per_store_features_from_measure_pairs(self.inputs, self.results,
+                                                      skip_first_n_feature_extraction=n_cached)
+        if n_cached > 0:
+            features = list(features)
+            features[:n_cached] = self.inputs_feature_cache
+            features = np.array(features, dtype=object)
+        self.inputs_feature_cache = features
+        dtrain = pack_sum_xgbmatrix(features, normalized_throughputs,
+                                    task_ids, normalized_throughputs)
+
+        # train xgb model
+        self.bst = xgb.train(self.xgb_params, dtrain,
+                             num_boost_round=10000,
+                             obj=pack_sum_square_error,
+                             callbacks=[custom_callback(
+                                 stopping_rounds=50,
+                                 metric='tr-p-rmse',
+                                 fevals=[
+                                     pack_sum_rmse, pack_sum_average_peak_score(self.plan_size),
+                                 ],
+                                 evals=[(dtrain, 'tr')],
+                                 maximize=False,
+                                 verbose_eval=self.verbose_eval)])
+
+    def predict(self, task, states):
+        features = get_per_store_features_from_states(states, task)
+        if self.bst is not None and len(self.inputs) > self.num_warmup_sample:
+            dtest, pack_ids = pack_sum_xgbmatrix_for_prediction(features)
+            raw_preds = self.bst.predict(dtest)
+            ret = pack_sum_predict_throughput(raw_preds, pack_ids)
+        else:
+            ret = np.random.uniform(0, 1, (len(states),))
+
+        # Predict 0 for invalid states that failed to be lowered.
+        for idx, feature in enumerate(features):
+            if feature.min() == feature.max() == 0:
+                ret[idx] = float('-inf')
+
+        return ret
+
+    def predict_stages(self, task, states):
+        # Format: (s0 score, ..., sN score, s0 n_stage, s0 stage 0, ..., s1 n_stage, s1 stage 0,)
+        features = get_per_store_features_from_states(states, task)
+        if self.bst is not None and len(self.inputs) > self.num_warmup_sample:
+            dtest, pack_ids = pack_sum_xgbmatrix_for_prediction(features)
+            raw_preds = self.bst.predict(dtest)
+            breakdown = pack_sum_predict_throughput(raw_preds, pack_ids)
+            stage_scores = [[] for _ in range(len(states))]
+            for pred, pack_id in zip(raw_preds, pack_ids):
+                stage_scores[pack_id].append(pred)
+            for idx, stage_score in enumerate(stage_scores):
+                breakdown = np.append(breakdown, len(stage_score))
+                breakdown = np.concatenate((breakdown, -np.array(stage_score)))
+        else:
+            breakdown = np.concatenate(
+                (np.random.uniform(0, 1, (len(states), )), np.zeros(len(states), )))
+
+        # Predict 0 for invalid states that failed to be lowered.
+        for idx, feature in enumerate(features):
+            if feature.min() == feature.max() == 0:
+                breakdown[idx] = float('-inf')
+
+        return breakdown
+
+    def load_log_file(self, file_name, n_lines=-1):
+        inputs, results = LogReader(file_name).read_lines(n_lines)
+        logger.info("XGBModel: Loaded %s measurement records from %s", len(inputs), file_name)
+        self.update(inputs, results)
+
+    def save(self, file_name: str):
+        self.bst.save_model(file_name)
+
+    def load(self, file_name: str):
+        if self.bst is None:
+            self.bst = xgb.Booster(self.xgb_params)
+        self.bst.load_model(file_name)
+        self.num_warmup_sample = -1
+
+
+def pack_sum_xgbmatrix_for_prediction(xs):
+    x_flatten = []
+    pack_ids = []
+
+    for ct, x in enumerate(xs):
+        for row in x:
+            x_flatten.append(row)
+            pack_ids.append(ct)
+
+    return xgb.DMatrix(np.array(x_flatten)), pack_ids
+
+
+def pack_sum_xgbmatrix(xs, ys, gids=None, weights=None):
+    if gids is not None:
+        # sort by group
+        indices = gids.argsort()
+        xs, ys = xs[indices], ys[indices]
+        group_sizes = np.bincount(gids)
+        if weights is not None:
+            weights = weights[indices]
+    else:
+        # assume it has only one group
+        group_sizes = [len(xs)]
+
+    x_flatten = []
+    y_flatten = []
+    weights_flatten = []
+    pack_ids = []
+
+    if weights is not None:
+        for ct, (x, y, w) in enumerate(zip(xs, ys, weights)):
+            for row in x:
+                x_flatten.append(row)
+                y_flatten.append(y)
+                weights_flatten.append(w)
+                pack_ids.append(ct)
+    else:
+        for ct, (x, y) in enumerate(zip(xs, ys)):
+            for row in x:
+                x_flatten.append(row)
+                y_flatten.append(y)
+                pack_ids.append(ct)
+
+    ret = xgb.DMatrix(np.array(x_flatten), y_flatten)
+    if weights is not None:
+        ret.set_weight(weights_flatten)
+    dmatrix_context.set('pack_ids', ret, np.array(pack_ids))
+    dmatrix_context.set('group_sizes', ret, group_sizes)
+    return ret
+
+LOSS_TYPE = 3
+
+# Type 0
+# The model predicts cost. Use square error of throughput as loss
+# loss = 1/2 * (1 / sum(x_i) - y) ^ 2
+#
+# Type 1
+# The model predicts cost. Use square error of cost as loss
+# loss = 1/2 * (sum(x_i) - 1 / y) ^ 2
+#
+# Type 2
+# The model predicts throughput. Use square error of throughput as loss.
+# loss = 1/2 * (1 / sum(1 / x_i) - y) ^ 2
+#
+# Type 3
+# The model predicts throughput. Use square error of throughput as loss.
+# But approximate 1 / (1 / a_1 + 1 / a_2 + ... + 1 / a_n) with -(b_1 + b_2 + b_3)
+# loss = 1/2 * (-sum(x_i) - y) ^ 2
+#
+# Type 4
+# The model predicts throughput. Use square error of throughput as loss.
+# But approximate 1 / (1 / a_1 + 1 / a_2 + ... + 1 / a_n) with -(b_1 + b_2 + b_3)
+# Also add a sigmoid to force the prediction to be within the range of (0, 1)
+# loss = 1/2 * (sigmoid(-sum(x_i)) - y) ^ 2
+#
+
+def pack_sum_predict_throughput(raw_preds, pack_ids):
+    if LOSS_TYPE == 0:
+        sum_pred = np.bincount(pack_ids, weights=raw_preds)
+        return 1 / sum_pred
+    elif LOSS_TYPE == 1:
+        sum_pred = np.bincount(pack_ids, weights=raw_preds)
+        return 1 / sum_pred
+    elif LOSS_TYPE == 2:
+        sum_inverse_preds = np.bincount(pack_ids, weights=1 / raw_preds)
+        return 1 / sum_inverse_preds
+    elif LOSS_TYPE == 3:
+        sum_pred = np.bincount(pack_ids, weights=raw_preds)
+        return - sum_pred # pylint: disable=invalid-unary-operand-type
+    elif LOSS_TYPE == 4:
+        sum_pred = np.bincount(pack_ids, weights=raw_preds)
+        return 1 / (1 + np.exp(sum_pred))
+    else:
+        raise ValueError("Invalid loss type: " + LOSS_TYPE)
+
+def pack_sum_square_error(preds, dtrain):
+    pack_ids = dmatrix_context.get("pack_ids", dtrain)
+    weight = dtrain.get_weight()
+
+    if LOSS_TYPE == 0:
+        sum_pred = np.bincount(pack_ids, weights=preds)
+        x = sum_pred[pack_ids]
+        y = dtrain.get_label()
+        gradient = (x * y - 1) / np.power(x, 3)
+        hessian = (3 - 2 * x * y) / np.power(x, 4)
+    elif LOSS_TYPE == 1:
+        sum_pred = np.bincount(pack_ids, weights=preds)
+        x = sum_pred[pack_ids]
+        y = dtrain.get_label()
+        gradient = x - 1 / np.minimum(y, 1e6)
+        hessian = np.ones_like(gradient)
+    elif LOSS_TYPE == 2:
+        sum_inverse_preds = np.bincount(pack_ids, weights=1 / preds)[pack_ids]
+        y = dtrain.get_label()
+        gradient = (1 / sum_inverse_preds - y) / (np.power(preds * sum_inverse_preds, 2))
+        hessian = (2 * preds * y * np.power(sum_inverse_preds, 2) - 2 * y * sum_inverse_preds - 2 * preds * sum_inverse_preds + 3) / (np.power(preds * sum_inverse_preds, 4))
+    elif LOSS_TYPE == 3:
+        sum_pred = np.bincount(pack_ids, weights=preds)
+        x = sum_pred[pack_ids]
+        y = dtrain.get_label()
+        gradient = x + y
+        hessian = np.ones_like(gradient)
+    elif LOSS_TYPE == 4:
+        sum_pred = np.bincount(pack_ids, weights=preds)
+        exp_x = np.exp(sum_pred[pack_ids])
+        exp_2x = np.power(exp_x, 2)
+        y = dtrain.get_label()
+        gradient = exp_x * (exp_x * y + y - 1) / np.power(exp_x + 1, 3)
+        hessian = exp_x * (-exp_2x * y + 2 * exp_x + y - 1) / np.power(exp_x + 1, 4)
+    else:
+        raise ValueError("Invalid loss type: " + LOSS_TYPE)
+
+    if len(weight) == 0:
+        return gradient, hessian
+    else:
+        return gradient * weight, hessian * weight
+
+def pack_sum_rmse(raw_preds, dtrain):
+    pack_ids = dmatrix_context.get("pack_ids", dtrain)
+    preds = pack_sum_predict_throughput(raw_preds, pack_ids)[pack_ids]
+    return 'p-rmse', np.sqrt(np.mean(np.square((preds - dtrain.get_label()))))
+
+def pack_sum_average_peak_score(N):
+    """Evaluate pack sum average peak score for xgb"""
+
+    def feval(preds, labels):
+        group_sizes = dmatrix_context.get('group_sizes', labels, [len(preds)])
+        pack_ids = dmatrix_context.get("pack_ids", labels)
+
+        preds = pack_sum_predict_throughput(preds, pack_ids)
+        labels = (np.bincount(pack_ids, weights=labels.get_label())
+                  / np.unique(pack_ids, return_counts=True)[1])
+
+        scores = []
+        offset = 0
+        for size in group_sizes:
+            preds_group = preds[offset:offset + size]
+            labels_group = labels[offset:offset + size]
+            offset += size
+
+            trials = np.argsort(preds_group)[::-1][:N]
+            trial_scores = labels_group[trials]
+            curve = max_curve(trial_scores) / np.max(labels_group)
+            scores.append(np.mean(curve))
+        return "a-peak@%d" % N, np.mean(scores)
+    return feval
+
+def pack_sum_average_recall_score(N):
+    """Evaluate average recall score for xgb"""
+
+    def feval(preds, labels):
+        group_sizes = dmatrix_context.get('group_sizes', labels, [len(preds)])
+        pack_ids = dmatrix_context.get("pack_ids", labels)
+
+        preds = pack_sum_predict_throughput(preds, pack_ids)
+        labels = (np.bincount(pack_ids, weights=labels.get_label())
+                  / np.unique(pack_ids, return_counts=True)[1])
+
+        scores = []
+        offset = 0
+        for size in group_sizes:
+            preds_group = preds[offset:offset + size]
+            labels_group = labels[offset:offset + size]
+            offset += size
+
+            trials = np.argsort(preds_group)[::-1]
+            ranks = get_rank(labels_group[trials])[:N]
+            curve = recall_curve(ranks)
+            scores.append(np.mean(curve))
+        return "a-recall@%d" % N, np.mean(scores)
+    return feval
+
+
+def custom_callback(stopping_rounds, metric, fevals, evals=(), log_file=None,
+                    maximize=False, verbose_eval=True, skip_every=2):
+    """Callback function for xgboost to support multiple custom evaluation functions"""
+    from xgboost.core import EarlyStopException
+    from xgboost.callback import _fmt_metric
+    from xgboost.training import aggcv
+
+    state = {}
+    metric_shortname = metric.split("-")[1]
+
+    def init(env):
+        """internal function"""
+        bst = env.model
+
+        state['maximize_score'] = maximize
+        state['best_iteration'] = 0
+        if maximize:
+            state['best_score'] = float('-inf')
+        else:
+            state['best_score'] = float('inf')
+
+        if bst is not None:
+            if bst.attr('best_score') is not None:
+                state['best_score'] = float(bst.attr('best_score'))
+                state['best_iteration'] = int(bst.attr('best_iteration'))
+                state['best_msg'] = bst.attr('best_msg')
+            else:
+                bst.set_attr(best_iteration=str(state['best_iteration']))
+                bst.set_attr(best_score=str(state['best_score']))
+        else:
+            assert env.cvfolds is not None
+
+    def callback(env):
+        """internal function"""
+        if not state:
+            init(env)
+
+        bst = env.model
+        i = env.iteration
+        cvfolds = env.cvfolds
+
+        res_dict = {}
+
+        if i % skip_every == 1:
+            return
+
+        ##### evaluation #####
+        if cvfolds is not None:
+            for feval in fevals:
+                tmp = aggcv([f.eval(i, feval) for f in cvfolds])
+                for k, mean, std in tmp:
+                    res_dict[k] = [mean, std]
+        else:
+            for feval in fevals:
+                bst_eval = bst.eval_set(evals, i, feval)
+                res = [x.split(':') for x in bst_eval.split()]
+                for kv in res[1:]:
+                    res_dict[kv[0]] = [float(kv[1])]
+
+        eval_res = []
+        keys = list(res_dict.keys())
+        keys.sort(key=lambda x: x if metric_shortname not in x else "a" + x)
+        for key in keys:
+            v = res_dict[key]
+            eval_res.append([key] + v)
+
+        ##### print eval result #####
+        if not isinstance(verbose_eval, bool) and verbose_eval and i % verbose_eval == 0:
+            infos = ["XGB iter: %3d" % i]
+            for item in eval_res:
+                if 'null' in item[0]:
+                    continue
+                infos.append("%s: %.6f" % (item[0], item[1]))
+
+            logger.debug("\t".join(infos))
+            if log_file:
+                with open(log_file, "a") as fout:
+                    fout.write("\t".join(infos) + '\n')
+
+        ##### choose score and do early stopping #####
+        score = None
+        for item in eval_res:
+            if item[0] == metric:
+                score = item[1]
+                break
+        assert score is not None
+
+        best_score = state['best_score']
+        best_iteration = state['best_iteration']
+        maximize_score = state['maximize_score']
+        if (maximize_score and score > best_score) or \
+                (not maximize_score and score < best_score):
+            msg = '[%d] %s' % (
+                env.iteration,
+                '\t'.join([_fmt_metric(x) for x in eval_res]))
+            state['best_msg'] = msg
+            state['best_score'] = score
+            state['best_iteration'] = env.iteration
+            # save the property to attributes, so they will occur in checkpoint.
+            if env.model is not None:
+                env.model.set_attr(best_score=str(state['best_score']),
+                                   best_iteration=str(state['best_iteration']),
+                                   best_msg=state['best_msg'])
+        elif env.iteration - best_iteration >= stopping_rounds:
+            best_msg = state['best_msg']
+            if verbose_eval and env.rank == 0:
+                logger.debug("XGB stopped. Best iteration: %s ", best_msg)
+            raise EarlyStopException(best_iteration)
+
+    return callback

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -119,6 +119,7 @@ class XGBModel(PythonBasedModel):
 
     def update(self, inputs, results):
         """Update the cost model according to new measurement results (training data).
+        XGBoost does not support incremental training, so we re-train a new model every time.
 
         Parameters
         ----------

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -76,7 +76,7 @@ class MeasureInput(Object):
         The State to be measured.
     """
     def __init__(self, task, state):
-        self.__init_handle_by_constructor__(_ffi_api.MeasureInput, task, state.state_object)
+        self.__init_handle_by_constructor__(_ffi_api.MeasureInput, task, state)
 
 
 @tvm._ffi.register_object("auto_scheduler.BuildResult")

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -48,6 +48,7 @@ from tvm.autotvm.measure.measure_methods import set_cuda_target_arch
 from tvm.contrib import tar, ndk
 
 from . import _ffi_api
+from .loop_state import StateObject
 from .utils import get_const_tuple, NoDaemonPool, call_func_with_timeout, request_remote, \
     check_remote
 
@@ -71,11 +72,12 @@ class MeasureInput(Object):
     Parameters
     ----------
     task : SearchTask
-        The SearchTask of this measure.
-    state : State
+        The SearchTask of this measurement.
+    state : Union[State, StateObject]
         The State to be measured.
     """
     def __init__(self, task, state):
+        state = state if isinstance(state, StateObject) else state.state_object
         self.__init_handle_by_constructor__(_ffi_api.MeasureInput, task, state)
 
 

--- a/src/auto_scheduler/search_policy/sketch_policy.h
+++ b/src/auto_scheduler/search_policy/sketch_policy.h
@@ -83,7 +83,7 @@ class SketchPolicyNode : public SearchPolicyNode {
  public:
   /*! \brief The cost model to estimate the complete schedules. */
   CostModel schedule_cost_model;
-  /*! \brief The parameters map for this search process. */
+  /*! \brief The parameters map for this search policy. */
   Map<String, ObjectRef> params;
   /*! \brief The rules to generate sketches. */
   std::vector<SketchGenerationRule*> sketch_rules;
@@ -103,6 +103,14 @@ class SketchPolicyNode : public SearchPolicyNode {
    */
   Array<State> GenerateSketches();
 
+  /*!
+   * \brief Sample the init population.
+   * \param sketches The initial sketches for the sampled population
+   * \param out_size The number of output states.
+   * \return The generated states (the initial population).
+   */
+  Array<State> SampleInitPopulation(const Array<State>& sketches, int out_size);
+
   static constexpr const char* _type_key = "auto_scheduler.SketchPolicy";
 
   TVM_DECLARE_FINAL_OBJECT_INFO(SketchPolicyNode, SearchPolicyNode);
@@ -116,14 +124,6 @@ class SketchPolicyNode : public SearchPolicyNode {
    * \return The best several states generated in this search round.
    */
   Array<State> SearchOneRound(int num_random_states, Array<State>* random_states = nullptr);
-
-  /*!
-   * \brief Sample init population.
-   * \param sketches The initial sketches to process population.
-   * \param out_size The number of expected output states.
-   * \return The generated states after initial population.
-   */
-  Array<State> SampleInitPopulation(const Array<State>& sketches, int out_size);
 
   /*!
    * \brief Perform evolutionary search.

--- a/tests/python/unittest/test_auto_scheduler_cost_model.py
+++ b/tests/python/unittest/test_auto_scheduler_cost_model.py
@@ -17,6 +17,8 @@
 
 """Test cost models"""
 
+import tempfile
+
 import numpy as np
 
 import tvm
@@ -36,14 +38,14 @@ def get_sample_records(number):
     states = policy.sample_initial_population(number)
 
     inputs = [auto_scheduler.MeasureInput(task, s) for s in states]
-    results = [auto_scheduler.MeasureResult([np.random.uniform(0.1, 0.2)], 0, "", 0.1, 0)
+    results = [auto_scheduler.MeasureResult([np.random.uniform(0.5, 1.0)], 0, "", 0.1, 0)
                for _ in range(len(inputs))]
 
     return task, dag, inputs, results
 
 
 def test_random_model():
-    task, dag, inputs, results = get_sample_records(100)
+    task, dag, inputs, results = get_sample_records(50)
 
     model = auto_scheduler.RandomModel()
     model.update(inputs, results)
@@ -52,12 +54,26 @@ def test_random_model():
 
 
 def test_xgb_model():
-    task, dag, inputs, results = get_sample_records(100)
+    task, dag, inputs, results = get_sample_records(50)
 
-    model = auto_scheduler.XGBModel()
+    model = auto_scheduler.XGBModel(num_warmup_sample=-1)
     model.update(inputs, results)
-    scores = model.predict(task, [x.state for x in inputs])
-    assert len(scores) == len(inputs)
+    preds = model.predict(task, [x.state for x in inputs])
+    assert len(preds) == len(inputs)
+
+    costs = [np.mean([x.value for x in res.costs]) for res in results]
+    throughputs = np.min(costs) / costs
+
+    rmse = np.sqrt(np.mean([np.square(pred - label) for pred, label in zip(preds, throughputs)]))
+    assert rmse <= 0.05
+
+    with tempfile.NamedTemporaryFile() as fp:
+        auto_scheduler.save_records(fp.name, inputs, results)
+        model.load_log_file(fp.name)
+
+    with tempfile.NamedTemporaryFile() as fp:
+        model.save(fp.name)
+        model.load(fp.name)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_auto_scheduler_cost_model.py
+++ b/tests/python/unittest/test_auto_scheduler_cost_model.py
@@ -69,7 +69,7 @@ def test_xgb_model():
 
     with tempfile.NamedTemporaryFile() as fp:
         auto_scheduler.save_records(fp.name, inputs, results)
-        model.load_log_file(fp.name)
+        model.update_from_file(fp.name)
 
     with tempfile.NamedTemporaryFile() as fp:
         model.save(fp.name)


### PR DESCRIPTION
For the full upstream plan, see [Ansor RFC](https://discuss.tvm.ai/t/rfc-ansor-an-auto-scheduler-for-tvm-autotvm-v2-0/7005/32).

This PR adds a xgboost-based cost model.
It is similar to the existing xgboost model in autotvm but works on the more general feature representation introduced by #6190 .

RMSE is used as the loss function, but the general feature representation needs slight modification to the loss function.
To support the new loss function, this PR implements a custom xgboost loss function "pack-sum-RMSE".
It is called "pack-sum" because we combine several samples into a "pack" and sum up their predictions.
