### PR TITLE
[Frontend][Relay] Keras frontend prelu bug fix

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -148,10 +148,9 @@ def _convert_advanced_activation(inexpr, keras_layer, etab):
     if act_type == 'PReLU':
         assert hasattr(keras_layer, 'alpha'), "alpha required for PReLU."
         _check_data_format(keras_layer)
-        size = len(keras_layer.alpha.shape)
-        alpha = etab.new_const(keras_layer.get_weights()[0] \
-                               .transpose(np.roll(range(size), 1)))
-        return _op.negative(alpha) * _op.nn.relu(_op.negative(inexpr)) + _op.nn.relu(inexpr)
+        alpha = etab.new_const(keras_layer.get_weights()[0].flatten())
+        axis = len(keras_layer.input_shape) - 1
+        return _op.nn.prelu(inexpr, alpha, axis)
     if act_type == 'ThresholdedReLU':
         theta = keras_layer.theta if hasattr(keras_layer, 'theta') else 1.
         return _op.multiply(inexpr, _op.greater(inexpr, \

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -182,6 +182,7 @@ class TestKeras:
             x = act_func(data)
             keras_model = keras.models.Model(data, x)
             verify_keras_frontend(keras_model)
+            verify_keras_frontend(keras_model, False, 'NHWC')
 
 
     def test_forward_dense(self, keras):


### PR DESCRIPTION
Hi,
A tvm error occurred when I imported a pre-trained keras model:
![image](https://user-images.githubusercontent.com/50566938/90131599-fa2c4d00-dd9e-11ea-8524-f0a080b50da1.png)

TVMError: 
Error(s) have occurred. The program has been annotated with them:

In `main`:
  %0 = negative(%v_param_3);
  %1 = nn.conv2d(%input_1, %v_param_1, padding=[4, 4], channels=64, kernel_size=[9, 9], data_layout="NHWC", kernel_layout="HWIO");
  %2 = nn.bias_add(%1, %v_param_2, axis=-1);
  %3 = negative(%2);
  %4 = nn.relu(%3);
  %5 = multiply(%0, %4) Incompatible broadcast type TensorType([64, 1, 1], float32) and TensorType([1, (int64)96, (int64)96, 64], float32); ;
  %6 = nn.relu(%2);

There is something wrong with the prelu convert function in Keras frontend which would result in this shape inferred mis-match error. We would better use relay.nn.prelu op directly.

Tests passed using tests/python/frontend/keras/test_forward.py.

@siju-samuel @yongwww
