### PR TITLE
[Parser] Add support for parsing the any dimension. 

### DIFF
--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -1502,6 +1502,8 @@ class Parser {
           tvm::PrimExpr dim;
           if (Peek()->token_type == TokenType::kMetaReference) {
             dim = Downcast<tvm::PrimExpr>(ParseMetaRef());
+          } else if (WhenMatch(TokenType::kQuestion)) {
+            dim = tvm::tir::Any();
           } else {
             dim = Downcast<tvm::PrimExpr>(Match(TokenType::kInteger)->data);
           }
@@ -1585,8 +1587,7 @@ class Parser {
           return ParseNonPrimitiveType(tok);
         }
       }
-    }
-    if (WhenMatch(TokenType::kUnderscore)) {
+    } else if (WhenMatch(TokenType::kUnderscore)) {
       return IncompleteType();
     } else {
       this->diag_ctx->EmitFatal(Diagnostic::Error(tok->span)

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -591,6 +591,16 @@ def test_tensor_type():
         )
     )
 
+    assert_parses_as(
+        "let %_ : Tensor[(?, 1), float32] = (); ()",
+        relay.Let(
+            relay.Var("_", relay.TensorType((tvm.Any(), 1), "float32")),
+            UNIT,
+            UNIT
+        )
+    )
+
+
 
 def test_function_type():
     assert_parses_as(
@@ -677,6 +687,24 @@ def test_adt_defn():
         """,
         mod
     )
+
+def test_adt_any():
+    code = """
+    type my_dtype {
+        my_cons(Tensor[(?, 1), uint16]),
+    }
+    """
+    mod = parse_module(code)
+    items = mod.type_definitions.items()
+    global_type_var, type_data = items[0]
+    assert global_type_var.name_hint == "my_dtype"
+    ctors = type_data.constructors
+    assert len(ctors) == 1
+    my_cons = ctors[0]
+    assert my_cons.name_hint == "my_cons"
+    ty_shape = my_cons.inputs[0].shape
+    assert isinstance(ty_shape[0], tvm.tir.Any)
+    assert ty_shape[1] == 1
 
 
 def test_empty_adt_defn():

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -594,7 +594,7 @@ def test_tensor_type():
     assert_parses_as(
         "let %_ : Tensor[(?, 1), float32] = (); ()",
         relay.Let(
-            relay.Var("_", relay.TensorType((tvm.Any(), 1), "float32")),
+            relay.Var("_", relay.TensorType((tvm.tir.Any(), 1), "float32")),
             UNIT,
             UNIT
         )


### PR DESCRIPTION
This adds support for parsing the any dimension to the Relay parser, this was not taken care of in the existing test suite so we ensure that any dimensions are in fact parseable. 

cc @chanwutk this should fix your issue
cc @mbrookhart 
cc @zhiics 