### PR TITLE
[Frontend][Relay] Keras softmax and prelu fix under NHWC

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -63,7 +63,7 @@ def _convert_recurrent_activation(inexpr, keras_layer):
     return _convert_activation(inexpr, act_type, None)
 
 
-def _convert_activation(inexpr, keras_layer, _):
+def _convert_activation(inexpr, keras_layer, etab):
     if isinstance(keras_layer, str):
         act_type = keras_layer
     else:
@@ -80,7 +80,8 @@ def _convert_activation(inexpr, keras_layer, _):
         beta = _expr.const(beta, dtype='float32')
         return _op.add(_op.multiply(inexpr, alpha), beta)
     if act_type == 'softmax':
-        return _op.nn.softmax(inexpr, axis=1)
+        axis = 1 if etab.data_layout == 'NCHW' else -1
+        return _op.nn.softmax(inexpr, axis)
     if act_type == 'sigmoid':
         return _op.sigmoid(inexpr)
     if act_type == 'tanh':
@@ -123,10 +124,11 @@ def _convert_advanced_activation(inexpr, keras_layer, etab):
         if isinstance(axis, list):
             raise tvm.error.OpAttributeUnImplemented(
                 'Softmax with axes {} is not supported.'.format(axis))
-        if axis == -1:
-            axis = 1
-        else:
-            axis = axis + 1 if axis < dims - 1 else 1
+        if etab.data_layout == 'NCHW':
+            if axis == -1:
+                axis = 1
+            else:
+                axis = axis + 1 if axis < dims - 1 else 1
         return _op.nn.softmax(inexpr, axis=axis)
     if act_type == 'ReLU':
         threshold = _expr.const(keras_layer.threshold, dtype='float32')
@@ -149,8 +151,11 @@ def _convert_advanced_activation(inexpr, keras_layer, etab):
         assert hasattr(keras_layer, 'alpha'), "alpha required for PReLU."
         _check_data_format(keras_layer)
         size = len(keras_layer.alpha.shape)
-        alpha = etab.new_const(keras_layer.get_weights()[0] \
-                               .transpose(np.roll(range(size), 1)))
+        if etab.data_layout == 'NCHW':
+            alpha = etab.new_const(keras_layer.get_weights()[0]
+                                   .transpose(np.roll(range(size), 1)))
+        else:
+            alpha = etab.new_const(keras_layer.get_weights()[0])
         return _op.negative(alpha) * _op.nn.relu(_op.negative(inexpr)) + _op.nn.relu(inexpr)
     if act_type == 'ThresholdedReLU':
         theta = keras_layer.theta if hasattr(keras_layer, 'theta') else 1.

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -182,6 +182,7 @@ class TestKeras:
             x = act_func(data)
             keras_model = keras.models.Model(data, x)
             verify_keras_frontend(keras_model)
+            verify_keras_frontend(keras_model, need_transpose=False, layout='NHWC')
 
 
     def test_forward_dense(self, keras):


### PR DESCRIPTION
Hi,
Tvm error occurred when I imported a pre-trained keras model with NHWC layout:

TVMError:
Error(s) have occurred. The program has been annotated with them:
In main:
%0 = negative(%v_param_3);
%1 = nn.conv2d(%input_1, %v_param_1, padding=[4, 4], channels=64, kernel_size=[9, 9], data_layout="NHWC", kernel_layout="HWIO");
%2 = nn.bias_add(%1, %v_param_2, axis=-1);
%3 = negative(%2);
%4 = nn.relu(%3);
%5 = multiply(%0, %4) Incompatible broadcast type TensorType([64, 1, 1], float32) and TensorType([1, (int64)96, (int64)96, 64], float32); ;
%6 = nn.relu(%2);

softmax and prelu convertion should take layout into consideration.
@siju-samuel @yongwww @jwfromm
