### PR TITLE
[Build] Reflect Compile-Time CMake Options into libtvm.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ include(cmake/modules/contrib/TF_TVMDSOOP.cmake)
 include(cmake/modules/contrib/CoreML.cmake)
 include(cmake/modules/contrib/ONNX.cmake)
 include(cmake/modules/contrib/ArmComputeLib.cmake)
+include(cmake/modules/Git.cmake)
 
 include(CheckCXXCompilerFlag)
 if(NOT MSVC)
@@ -365,6 +366,15 @@ if(BUILD_FOR_HEXAGON)
     PUBLIC "${USE_HEXAGON_SDK}/libs/common/qurt/ADSPv62MP/include/qurt"
     PUBLIC "${USE_HEXAGON_SDK}/incs"
     PUBLIC "${USE_HEXAGON_SDK}/incs/stddef")
+endif()
+
+if (${GIT_FOUND})
+  set_property(
+    SOURCE ${CMAKE_CURRENT_LIST_DIR}/src/support/libinfo.cc
+    APPEND
+    PROPERTY COMPILE_DEFINITIONS
+    TVM_GIT_COMMIT_HASH="${TVM_GIT_COMMIT_HASH}"
+  )
 endif()
 
 if(USE_THREADS AND NOT BUILD_FOR_HEXAGON)

--- a/cmake/modules/Git.cmake
+++ b/cmake/modules/Git.cmake
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# This script provides
+#   - GIT_FOUND - true if the command line client was found
+#   - GIT_EXECUTABLE - path to git command line client
+#   - TVM_GIT_COMMIT_HASH
+find_package(Git QUIET)
+if (${GIT_FOUND})
+  message(STATUS "Git found: ${GIT_EXECUTABLE}")
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+                  OUTPUT_VARIABLE TVM_GIT_COMMIT_HASH
+                  ERROR_QUIET
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  message(STATUS "Found TVM_GIT_COMMIT_HASH=${TVM_GIT_COMMIT_HASH}")
+else()
+  message(WARNING "Git not found")
+  set(TVM_GIT_COMMIT_HASH "git-not-found")
+endif()

--- a/cmake/modules/Git.cmake
+++ b/cmake/modules/Git.cmake
@@ -24,10 +24,17 @@ if (${GIT_FOUND})
   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
                   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
                   OUTPUT_VARIABLE TVM_GIT_COMMIT_HASH
-                  ERROR_QUIET
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-  message(STATUS "Found TVM_GIT_COMMIT_HASH=${TVM_GIT_COMMIT_HASH}")
+                  RESULT_VARIABLE _TVM_GIT_RESULT
+                  ERROR_VARIABLE _TVM_GIT_ERROR
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_STRIP_TRAILING_WHITESPACE)
+  if (${_TVM_GIT_RESULT} EQUAL 0)
+    message(STATUS "Found TVM_GIT_COMMIT_HASH=${TVM_GIT_COMMIT_HASH}")
+  else()
+    message(STATUS "Not a git repo")
+    set(TVM_GIT_COMMIT_HASH "NOT-FOUND")
+  endif()
 else()
   message(WARNING "Git not found")
-  set(TVM_GIT_COMMIT_HASH "git-not-found")
+  set(TVM_GIT_COMMIT_HASH "NOT-FOUND")
 endif()

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -66,8 +66,12 @@ from . import hybrid
 # others
 from . import arith
 
+# support infra
+from . import support
+
 # Contrib initializers
 from .contrib import rocm as _rocm, nvcc as _nvcc, sdaccel as _sdaccel
+
 
 def tvm_wrap_excepthook(exception_hook):
     """Wrap given excepthook with TVM additional work."""
@@ -81,5 +85,6 @@ def tvm_wrap_excepthook(exception_hook):
                 p.terminate()
 
     return wrapper
+
 
 sys.excepthook = tvm_wrap_excepthook(sys.excepthook)

--- a/python/tvm/support.py
+++ b/python/tvm/support.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Support infra of TVM."""
+import tvm._ffi
+
+
+def libinfo():
+    return GetLibInfo()
+
+
+tvm._ffi._init_api("support", __name__)

--- a/src/support/libinfo.cc
+++ b/src/support/libinfo.cc
@@ -21,7 +21,7 @@
 #include <tvm/runtime/registry.h>
 
 #ifndef TVM_GIT_COMMIT_HASH
-#define TVM_GIT_COMMIT_HASH "not-found"
+#define TVM_GIT_COMMIT_HASH "NOT-FOUND"
 #endif
 
 namespace tvm {

--- a/src/support/libinfo.cc
+++ b/src/support/libinfo.cc
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/node/container.h>
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/registry.h>
+
+#ifndef TVM_GIT_COMMIT_HASH
+#define TVM_GIT_COMMIT_HASH "not-found"
+#endif
+
+namespace tvm {
+
+Map<String, String> GetLibInfo() {
+  Map<String, String> result = {
+      {"GIT_COMMIT_HASH", TVM_GIT_COMMIT_HASH},
+  };
+  return result;
+}
+
+TVM_REGISTER_GLOBAL("support.GetLibInfo").set_body_typed(GetLibInfo);
+
+}  // namespace tvm


### PR DESCRIPTION
Reflecting build time info (git commit hash, cmake flags and options, etc) is very helpful in TVM development, packaging, and especially trouble shooting. This PR showcases how to incorporate compile-time information into TVM library, specifically, git commit hash in this PR. Other flags can be done in similar fashion, by just appending lines like "TVM_USE_CUDA=${USE_CUDA}" in the CMakeList.txt.

**How to use this functionality.** Run the command below:
```
> python -c "import tvm; print(tvm.support.libinfo())"
{"GIT_COMMIT_HASH": "921d4e0efea280c149940669bb23ef8c4de366e9"}
```

Per discussion with @jroesch. CC: @jwfromm @tqchen.