### PR TITLE
[Frontend][Relay] Fix node indices attribute error for tensorflow 2.3

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1073,7 +1073,18 @@ def from_keras(model, shape=None, layout='NCHW'):
                 # The one exception is InputLayer. Changing input variable names after conversion
                 # would confuse users, so we should keep them as far as possible. Fortunately,
                 # they are named uniquely to input_1, input_2, input_3... by default.
-                for inbound_layer, n_idx, t_idx, _ in node.iterate_inbound():
+                # node_indices attribute removed in tensorflow 2.3, however iterate_inbound() can
+                # be used
+                if hasattr(node, 'node_indices'):
+                    zip_node = zip(
+                        _as_list(node.inbound_layers),
+                        _as_list(node.node_indices),
+                        _as_list(node.tensor_indices),
+                        _as_list(node.input_tensors))
+                    node_attributes = zip_node
+                else:
+                    node_attributes = node.iterate_inbound()
+                for inbound_layer, n_idx, t_idx, _ in node_attributes:
                     if isinstance(inbound_layer, input_layer_class):
                         expr_name = inbound_layer.name
                         _convert_input_layer(inbound_layer)

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1073,11 +1073,7 @@ def from_keras(model, shape=None, layout='NCHW'):
                 # The one exception is InputLayer. Changing input variable names after conversion
                 # would confuse users, so we should keep them as far as possible. Fortunately,
                 # they are named uniquely to input_1, input_2, input_3... by default.
-                zip_node = zip(
-                    _as_list(node.node_indices),
-                    _as_list(node.tensor_indices),
-                    _as_list(node.inbound_layers))
-                for n_idx, t_idx, inbound_layer in zip_node:
+                for inbound_layer, n_idx, t_idx, _ in node.iterate_inbound():
                     if isinstance(inbound_layer, input_layer_class):
                         expr_name = inbound_layer.name
                         _convert_input_layer(inbound_layer)


### PR DESCRIPTION
The Node class Tensorflow 2.3 no longer has the attributes node_indices and tensor_indices as explained in #6287. However, the values of these attributes can be obtained using [iterate_inbound](https://github.com/tensorflow/tensorflow/blob/ee598066c4cb31ec5ed3106e61ba99ef004a4bae/tensorflow/python/keras/engine/node.py#L134). Using this method also allows relay.frontend.from_keras() to be backward compatible with previous tensorflow versions.

Closes #6287 
