### PR TITLE
[COMMUNITY] @kparzysz-quic -> committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,6 +55,7 @@ We do encourage everyone to work anything they are interested in.
 - [Masahiro Masuda](https://github.com/masahi) (PPMC): @masahi - topi, relay
 - [Thierry Moreau](https://github.com/tmoreau89) (PPMC): @tmoreau89 - vta
 - [Kazutaka Morita](https://github.com/kazum): @kazum - frontends, opencl
+- [Krzysztof Parzyszek](https://github.com/kparzysz-quic): @kparzysz-quic - hexagon, llvm
 - [Jared Roesch](https://github.com/jroesch) (PPMC): @jroesch - relay
 - [Siju Samuel](https://github.com/siju-samuel): @siju-samuel - frontends
 - [Siva](https://github.com/srkreddy1238): @srkreddy1238 - frontends, golang


### PR DESCRIPTION
Please join us to welcome @kparzysz-quic  as a new committer.  He contributes the initial scaffolding of the TVM hexagon backend. He is also an expert in LLVM, and regularly sends patches to improve our LLVM backend. He also frequently provides useful suggestions to compiler infra design

- [Commits History](https://github.com/apache/incubator-tvm/commits?author=kparzysz-quic)
- [Code Review](https://github.com/apache/incubator-tvm/pulls?q=reviewed-by%3Akparzysz-quic)
- [Community Forum Summary](https://discuss.tvm.ai/u/kparzysz/summary)
