### PR TITLE
[DYN][RELAY] Resize support for NCHW-convertible layouts

### DIFF
--- a/python/tvm/relay/op/dyn/image/_image.py
+++ b/python/tvm/relay/op/dyn/image/_image.py
@@ -41,15 +41,13 @@ def compute_resize(attrs, inputs, out_type):
 reg.register_injective_schedule("dyn.image.resize")
 
 @script
-def _resize_shape_func(dshape, size, ndim, height_axis, width_axis, channel_axis):
+def _resize_shape_func(dshape, size, ndim, height_axis, width_axis):
     out = output_tensor((ndim, ), "int64")
     for i in const_range(ndim):
         out[i] = int64(dshape[i])
     out[height_axis] = int64(size[0])
     out[width_axis] = int64(size[1])
-    out[channel_axis] = int64(dshape[channel_axis])
     return out
-
 
 @reg.register_shape_func("dyn.image.resize", True)
 def resize_shape_func(attrs, inputs, _):
@@ -59,7 +57,7 @@ def resize_shape_func(attrs, inputs, _):
     layout = attrs.layout
     if nchw_pack_layout(layout) or nchw_xc_layout(layout):
         out = [_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)),
-                                  convert(2), convert(3), convert(1))]
+                                  convert(2), convert(3))]
     else:
         height_axis = width_axis = channel_axis = 1
         for i, letter in enumerate(layout):
@@ -67,9 +65,6 @@ def resize_shape_func(attrs, inputs, _):
                 height_axis = i
             if letter == "W":
                 width_axis = i
-            if letter == "C":
-                channel_axis = i
         out = [_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)),
-                                  convert(height_axis), convert(width_axis),
-                                  convert(channel_axis))]
+                                  convert(height_axis), convert(width_axis))]
     return out

--- a/python/tvm/relay/op/dyn/image/_image.py
+++ b/python/tvm/relay/op/dyn/image/_image.py
@@ -70,6 +70,6 @@ def resize_shape_func(attrs, inputs, _):
             if letter == "C":
                 channel_axis = i
         out = [_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)),
-                                  convert(height_axis), convert(widht_axis),
+                                  convert(height_axis), convert(width_axis),
                                   convert(channel_axis))]
     return out

--- a/python/tvm/relay/op/dyn/image/_image.py
+++ b/python/tvm/relay/op/dyn/image/_image.py
@@ -59,7 +59,7 @@ def resize_shape_func(attrs, inputs, _):
         out = [_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)),
                                   convert(2), convert(3))]
     else:
-        height_axis = width_axis = channel_axis = 1
+        height_axis = width_axis = 1
         for i, letter in enumerate(layout):
             if letter == "H":
                 height_axis = i

--- a/python/tvm/relay/op/dyn/image/_image.py
+++ b/python/tvm/relay/op/dyn/image/_image.py
@@ -40,24 +40,14 @@ def compute_resize(attrs, inputs, out_type):
 
 reg.register_injective_schedule("dyn.image.resize")
 
-
 @script
-def _NCHW_resize_shape_func(dshape, size, ndim):
+def _resize_shape_func(dshape, size, ndim, height_axis, width_axis, channel_axis):
     out = output_tensor((ndim, ), "int64")
     for i in const_range(ndim):
         out[i] = int64(dshape[i])
-    out[2] = int64(size[0])
-    out[3] = int64(size[1])
-    return out
-
-
-@script
-def _NHWC_resize_shape_func(dshape, size, ndim):
-    out = output_tensor((ndim, ), "int64")
-    for i in const_range(ndim):
-        out[i] = int64(dshape[i])
-    out[1] = int64(size[0])
-    out[2] = int64(size[1])
+    out[height_axis] = int64(size[0])
+    out[width_axis] = int64(size[1])
+    out[channel_axis] = int64(dshape[channel_axis])
     return out
 
 
@@ -67,10 +57,19 @@ def resize_shape_func(attrs, inputs, _):
     Shape function for dyn.image.resize op.
     """
     layout = attrs.layout
-    if layout == 'NHWC':
-        out = [_NHWC_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)))]
-    elif (layout == 'NCHW') or nchw_pack_layout(layout) or nchw_xc_layout(layout):
-        out = [_NCHW_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)))]
+    if nchw_pack_layout(layout) or nchw_xc_layout(layout):
+        out = [_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)),
+                                  convert(2), convert(3), convert(1))]
     else:
-        raise ValueError("Resize Unsupported Layout", layout)
+        height_axis = width_axis = channel_axis = 1
+        for i, letter in enumerate(layout):
+            if letter == "H":
+                height_axis = i
+            if letter == "W":
+                width_axis = i
+            if letter == "C":
+                channel_axis = i
+        out = [_resize_shape_func(inputs[0].shape, inputs[1], convert(len(inputs[0].shape)),
+                                  convert(height_axis), convert(widht_axis),
+                                  convert(channel_axis))]
     return out


### PR DESCRIPTION
@icemelon9 pointed out that we can support more layouts than just NCHW and NHWC in shape functions for resize and upsampling. This PR adds support for NCHW convertible layouts to resize's shape function. 

cc @mbrookhart @zhiics 
