### PR TITLE
[BUG_FIX] Fix resize test

### DIFF
--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -529,8 +529,12 @@ def resize(data, size, layout="NCHW", method="bilinear",
         or [batch, in_height*scale, in_width*scale, channel]
         or 5-D with shape [batch, channel-major, in_height*scale, in_width*scale, channel-minor]
     """
-
     method = method.lower()
+    if ((method == "nearest_neighbor" and coordinate_transformation_mode == "align_corners") or 
+            (method == "bilinear" and coordinate_transformation_mode != "align_corners")):
+        raise ValueError('Topi Resize does not support the combination of method %s ' \
+                         'and coordinate_transformation_mode %s' %
+                         (method, coordinate_transformation_mode))
     if layout == 'NHWC':
         in_n, in_h, in_w, in_c = data.shape
         if output_shape is None:

--- a/tests/python/relay/dyn/test_dynamic_op_level5.py
+++ b/tests/python/relay/dyn/test_dynamic_op_level5.py
@@ -49,7 +49,11 @@ def test_resize():
             ref_res = tvm.topi.testing.upsampling_python(x_data, (scale, scale), layout)
         x = relay.var("x", relay.TensorType(dshape, "float32"))
         size_var = relay.var("size", relay.TensorType((2,), "int64"))
-        z = relay.image.resize(x, size_var, layout, method, "align_corners")
+        
+        coord_trans = "asymmetric" if method == "nearest_neighbor" else "align_corners"
+        z = relay.image.resize(x, size_var, layout, method,
+                              coordinate_transformation_mode=coord_trans)
+
         zz = run_infer_type(z)
         func = relay.Function([x, size_var], z)
 
@@ -60,9 +64,11 @@ def test_resize():
                 intrp = relay.create_executor(kind, mod=mod, ctx=ctx, target=target)
                 op_res = intrp.evaluate()(x_data, size)
                 tvm.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=1e-4, atol=1e-6)
+
     for method in ["bilinear", "nearest_neighbor"]:
         for layout in ["NCHW", "NHWC"]:
             verify_resize((1, 4, 4, 4), 2, method, layout)
+            verify_resize((2, 8, 17, 20), 2, method, layout)
 
 if __name__ == "__main__":
     test_resize_infer_type()

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -53,7 +53,9 @@ def test_resize():
         else:
             ref_res = tvm.topi.testing.upsampling_python(x_data, (scale, scale), layout)
         x = relay.var("x", relay.TensorType(dshape, "float32"))
-        z = relay.image.resize(x, size, layout, method, "align_corners")
+        coord_trans = "asymmetric" if method == "nearest_neighbor" else "align_corners"
+        z = relay.image.resize(x, size, layout, method,
+                              coordinate_transformation_mode=coord_trans)
         assert "size=" in z.astext()
         zz = run_infer_type(z)
         assert zz.checked_type == relay.TensorType(ref_res.shape, "float32")
@@ -67,6 +69,7 @@ def test_resize():
     for method in ["bilinear", "nearest_neighbor"]:
         for layout in ["NHWC", "NCHW"]:
             verify_resize((1, 4, 4, 4), 2, method, layout)
+            verify_resize((2, 8, 17, 20), 2, method, layout)
 
 def test_resize3d_infer_type():
     n, c, d, h, w = te.size_var("n"), te.size_var("c"), te.size_var("d"), te.size_var("h"), te.size_var("w")


### PR DESCRIPTION
This PR fixes the bug in #6237. In resize, the method "nearest_neighbor" is not compatible with the coordinate_transform_mode "align_corners", and the method "bilinear" is not compatible with coordinate_transformation_modes other than "align_corners". 

I also added checks to the topi resize method to prevent the user from passing incompatible method and coordinate_transformation_mode combinations into resize.

@mbrookhart @masahi please take a look!