### PR TITLE
[TIR][Logger] Buffer & Var unique_name pool should be disjoint

### DIFF
--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -256,8 +256,12 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   std::unordered_map<Var, Doc, ObjectPtrHash, ObjectPtrEqual> memo_var_;
   /*! \brief Map from Buffer to Doc */
   std::unordered_map<Buffer, Doc, ObjectPtrHash, ObjectPtrEqual> memo_buf_;
-  /*! \brief name allocation map */
-  std::unordered_map<std::string, int> name_alloc_map_;
+  /*! \brief variable name allocation map */
+  std::unordered_map<std::string, int> var_name_alloc_map_;
+  /*! \brief buffer name allocation map */
+  std::unordered_map<std::string, int> buf_name_alloc_map_;
+  /*! \brief whether buffer or variable name pool */
+  bool is_buf_;
 
   friend class tvm::TextPrinter;
 

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -558,7 +558,9 @@ Doc TIRTextPrinter::PrintConstScalar(DataType dtype, const T& data) {
 }
 
 Doc TIRTextPrinter::GetUniqueName(std::string prefix) {
-  // std::replace(prefix.begin(), prefix.end(), '.', '_');
+  std::unordered_map<std::string, int>& name_alloc_map_ =
+      is_buf_ ? buf_name_alloc_map_ : var_name_alloc_map_;
+
   std::string unique_prefix = prefix;
   auto it = name_alloc_map_.find(prefix);
   if (it != name_alloc_map_.end()) {
@@ -592,7 +594,11 @@ Doc TIRTextPrinter::AllocBuf(const Buffer& buffer) {
   if (name.length() == 0 || !std::isalpha(name[0])) {
     name = "buf_" + name;
   }
+  // Flag Buffer processing in visible scope to avoid unique name formation for variable node
+  is_buf_ = true;
   Doc val = GetUniqueName(name);
+  // End of scope
+  is_buf_ = false;
   memo_buf_[buffer] = val;
   return val;
 }


### PR DESCRIPTION
This PR resolves below trivial issue:

### **_Before Change:_**
![image](https://user-images.githubusercontent.com/32511895/90684308-9960b100-e285-11ea-8509-01510da10065.png)


### **_After Change:_**
![image](https://user-images.githubusercontent.com/32511895/90684455-da58c580-e285-11ea-8194-21997e5604c1.png)

cc @tqchen , @spectrometerHBH , @junrushao1994