### PR TITLE
[Torch] Fix dtype handling for modules with integer parameters

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2141,16 +2141,10 @@ def _getattr_full_name(getattrs):
     return ".".join([_getattr_attr_name(node) for node in getattrs])
 
 
-def _get_pytorch_value_type(ivalue, outputs, default_dtype="float32"):
-    typ = ivalue.type()
+def _get_pytorch_value_type(typ, default_dtype="float32"):
     kind = typ.kind()
     if kind == 'TensorType':
-        if ivalue.node().kind() == "prim::GetAttr":
-            # GetAttr nodes always return None when we call scalarType() on it
-            name = ivalue.debugName()
-            assert name in outputs and isinstance(outputs[name], _expr.Var)
-            return outputs[name].type_annotation.dtype
-        elif typ.scalarType() is None:
+        if typ.scalarType() is None:
             # Tensor's type can be unknown if we use torch.jit.script(...)
             # Defaults can be passed in, if not it is float32
             logging.warning("Untyped Tensor found, assume it is %s", default_dtype)
@@ -2171,8 +2165,17 @@ def _get_pytorch_value_type(ivalue, outputs, default_dtype="float32"):
 
 def _get_input_types(op_node, outputs, default_dtype="float32"):
     """Returns a TVM dtype for each input nodes derived from the torch type"""
-    return [_get_pytorch_value_type(i, outputs, default_dtype=default_dtype)
-            for i in op_node.inputs()]
+    in_types = []
+    for inp in op_node.inputs():
+        if inp.node().kind() == "prim::GetAttr":
+            # GetAttr nodes always return None when we call scalarType() on it
+            name = inp.debugName()
+            assert name in outputs and isinstance(outputs[name], _expr.Var)
+            in_types.append(outputs[name].type_annotation.dtype)
+        else:
+            in_types.append(_get_pytorch_value_type(inp.type(), default_dtype=default_dtype))
+
+    return in_types
 
 
 def _get_constant(node):

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2550,6 +2550,19 @@ def test_forward_dtypes():
         tensor2 = torch.randn(3, 4).to(dtype=dt)
         verify_model(fn, input_data=[tensor1, tensor2])
 
+    class ModuleWithIntParameters(Module):
+        def __init__(self, arr):
+            super().__init__()
+            self.param = torch.nn.Parameter(torch.LongTensor(arr), requires_grad=False)
+
+        def forward(self, x):
+            return x.long() + self.param
+
+    shape = (10, 10)
+    param = torch.ones(shape, dtype=torch.long)
+    inp = torch.ones(shape, dtype=torch.int)
+    verify_model(ModuleWithIntParameters(param), input_data=inp)
+
 
 def test_weight_names():
     tm = torch.jit.trace(torch.nn.Linear(3, 4), [torch.randn(2, 3)])


### PR DESCRIPTION
This fixes the interesting typing problem raised in https://github.com/apache/incubator-tvm/issues/6300.

In Torchscript,  parameters of operations like conv are always accessed via `prim::GetAttr` nodes. For example, when we see 

```
 %input : Float(1, 6, 4) = aten::_convolution(%input.1, %6, %7, %9, %11, %13, %14, %16, %17, %18, %19, %20)
```

The input weight %6 is accessed in this way:
```
%3 : Module = prim::GetAttr[name="conv"](%self.1)
%6 : Tensor = prim::GetAttr[name="weight"](%3)
``` 

The problem is, Torch cannot figure out the correct type of GetAttr nodes. So when we visit `aten::_convolution` to get its input types, we have to assume that this is an untyped tensor and get annoying warnings `Untyped Tensor found, assume it is float`. 

This hasn't been a big issue so far because parameters are usually float anyways. But https://github.com/apache/incubator-tvm/issues/6300 brought a use case where there are integer parameters as well as float ones. Changing `default_dtype` to int doesn't solve it. 

So I added a workaround  when we try to get the dtype of GetAttr nodes. For every GetAttr node there is a corresponding parameter from the original PyTorch module with known, correct dtype. And for every PyTorch parameter tensor we have a corresponding Relay Var (via `convert_params(...)` function).  So inside `_get_input_types` when we find `GetAttr` node, we return the dtype of corresponding Relay Var, instead of returning `default_type`.

This is the solution I came up with minimal change. It fixes the problem, but I feel it is a bit hacky. Please let me know if there are better ways to handle this.  The test case I added is a minimal reproduction of the issue raised in https://github.com/apache/incubator-tvm/issues/6300.

As a bonus, there would be no more annoying warnings `Untyped Tensor found...` when working with traced models.

please review @siju-samuel @t-vi 