### PR TITLE
[Target] Add python binding to new JSON target construction.

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -347,13 +347,43 @@ def hexagon(cpu_ver='v66', sim_args=None, llvm_args=None, hvx=128):
     return _ffi_api.TargetCreate('hexagon', *args_list)
 
 
-def create(target_str):
+def create(target):
     """Get a target given target string.
 
     Parameters
     ----------
-    target_str : str
-        The target string.
+    target : str or dict
+        The target string or configuration dictionary.
+        When using a dictionary to configure target, the
+        possible values are:
+        {
+            kind :  str (required)
+                Which codegen path to use, for example 'llvm' or 'cuda'.
+            keys : List of str (optional)
+                A set of strategies that can be dispatched to. When using
+                "kind=opencl" for example, one could set keys to ["mali", "opencl", "gpu"].
+            device : str (optional)
+                A single key that corresponds to the actual device being run on.
+                This will be effectively appended to the keys.
+            libs : List of str (optional)
+                The set of external libraries to use. For example ['cblas', 'mkl'].
+            system-lib : bool (optional)
+                If True, build a module that contains self registered functions.
+                Useful for environments where dynamic loading like dlopen is banned.
+            mcpu : str (optional)
+                The specific cpu being run on. Serves only as an annotation.
+            model : str (optional)
+                An annotation indicating what model a workload came from.
+            runtime : str (optional)
+                An annotation indicating which runtime to use with a workload.
+            mtriple : str (optional)
+                The llvm triplet describing the target, for example "arm64-linux-android".
+            mattr : List of str (optional)
+                The llvm features to compile with, for example ["+avx512f", "+mmx"].
+            mfloat-abi : str (optional)
+                An llvm setting that is one of 'hard' or 'soft' indicating whether to use
+                hardware or software floating-point operations.
+        }
 
     Returns
     -------
@@ -364,9 +394,11 @@ def create(target_str):
     ----
     See the note on :py:mod:`tvm.target` on target string format.
     """
-    if isinstance(target_str, Target):
+    if isinstance(target, Target):
         return target_str
-    if not isinstance(target_str, str):
-        raise ValueError("target_str has to be string type")
+    if isinstance(target, dict):
+        return _ffi_api.TargetFromConfig(target)
+    if isinstance(target, str):
+        return _ffi_api.TargetFromString(target)
 
-    return _ffi_api.TargetFromString(target_str)
+    raise ValueError("target has to be a string or dictionary.")

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -410,7 +410,7 @@ Target Target::FromConfig(const Map<String, ObjectRef>& config_dict) {
     const auto* cfg_keys = config[kKeys].as<ArrayNode>();
     CHECK(cfg_keys != nullptr)
         << "AttributeError: Expect type of field 'keys' is an Array, but get: "
-        << config[kTag]->GetTypeKey();
+        << config[kKeys]->GetTypeKey();
     for (const ObjectRef& e : *cfg_keys) {
       const auto* key = e.as<StringObj>();
       CHECK(key != nullptr) << "AttributeError: Expect 'keys' to be an array of strings, but it "
@@ -524,6 +524,8 @@ TVM_REGISTER_GLOBAL("target.ExitTargetScope").set_body_typed(Target::Internal::E
 TVM_REGISTER_GLOBAL("target.GetCurrentTarget").set_body_typed(Target::Current);
 
 TVM_REGISTER_GLOBAL("target.TargetFromString").set_body_typed(Target::Create);
+
+TVM_REGISTER_GLOBAL("target.TargetFromConfig").set_body_typed(Target::FromConfig);
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<TargetNode>([](const ObjectRef& node, ReprPrinter* p) {

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -80,7 +80,31 @@ def test_target_create():
         assert tgt is not None
 
 
+def test_target_config():
+    """
+    Test that constructing a target from a dictionary works.
+    """
+    target_config = {
+        'kind': 'llvm',
+        'keys': ['arm_cpu', 'cpu'],
+        'device': 'arm_cpu',
+        'libs': ['cblas'],
+        'system-lib': True,
+        'mfloat-abi': 'hard',
+        'mattr': ['+neon', '-avx512f'],
+    }
+    target = tvm.target.create(target_config)
+    assert target.kind.name == 'llvm'
+    assert all([key in target.keys for key in ['arm_cpu', 'cpu']])
+    assert target.device_name == 'arm_cpu'
+    assert target.libs == ['cblas']
+    assert 'system-lib' in str(target)
+    assert target.attrs['mfloat-abi'] == 'hard'
+    assert all([attr in target.attrs['mattr'] for attr in ['+neon', '-avx512f']])
+
+
 if __name__ == "__main__":
     test_target_dispatch()
     test_target_string_parse()
     test_target_create()
+    test_target_config()


### PR DESCRIPTION
This PR adds the ability to create targets from a configuration dictionary. It's a very thin wrapper around the c++ version of this feature introduced in #6218. 