### PR TITLE
[FIX][VM] Fix relay vm optimize

### DIFF
--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -139,7 +139,7 @@ class VMCompiler(object):
         """Generate the kernel library."""
         self._codegen()
 
-    def optimize(self, mod, target=None, params=None):
+    def optimize(self, mod, target=None, target_host=None, params=None):
         """Helper method that optimizes a Relay module via VM.
 
         Parameters
@@ -148,6 +148,11 @@ class VMCompiler(object):
 
         target : str, :any:`tvm.target.Target`, or dict of str (i.e.
             device/context name) to str/tvm.target.Target, optional
+
+        target_host : str or :any:`tvm.target.Target`, optional
+            The compilation target for host.
+            By default, llvm is used if it is enabled,
+            otherwise a stackvm intepreter is used.
 
         params : dict of str to NDArray
             Input parameters to the graph that do not change
@@ -162,9 +167,10 @@ class VMCompiler(object):
             The parameters of the final module.
         """
         target = self._update_target(target)
+        target_host = self._update_target_host(target, target_host)
         if params:
             self.set_params(params)
-        return self._optimize(mod, target), self.get_params()
+        return self._optimize(mod, target, target_host), self.get_params()
 
     def get_exec(self):
         """Get the VM executable.

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -112,7 +112,8 @@ class VMCompiler : public runtime::ModuleNode {
   void Codegen();
 
  protected:
-  IRModule OptimizeModule(const IRModule& mod, const TargetsMap& targets);
+  IRModule OptimizeModule(const IRModule& mod, const TargetsMap& targets,
+                          const Target& target_host);
 
   void PopulateGlobalMap();
 

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -593,10 +593,20 @@ def test_add_op_broadcast():
     mod["main"] = func
     check_result([x_data, y_data], x_data + y_data, mod=mod)
 
+def test_vm_optimize_dynamic():
+    dtype = 'float32'
+    x = relay.var('x', shape=(relay.Any(), relay.Any()), dtype=dtype)
+    y = relay.var('y', shape=(relay.Any(), relay.Any()), dtype=dtype)
+    mod = tvm.IRModule()
+    mod['main'] = relay.Function([x, y], relay.add(x, y))
+    comp = relay.vm.VMCompiler()
+    opt_mod, _ = comp.optimize(mod, target="llvm")
+    assert "shape_func" in opt_mod.astext(False)
+
 def test_vm_optimize():
     mod, params = testing.synthetic.get_workload()
     comp = relay.vm.VMCompiler()
-    opt_mod, _ = comp.optimize(mod, "llvm", params)
+    opt_mod, _ = comp.optimize(mod, target="llvm", params=params)
 
 def test_loop_free_var():
     x = relay.var('x', shape=(), dtype='int32')


### PR DESCRIPTION
We need to pass host_target to optimize because it is needed by memory_alloc 

https://github.com/apache/incubator-tvm/blob/4c728d532b987ae4de464597bbfccc687913ad2d/src/relay/backend/vm/compiler.cc#L991

The previous unit test with static graph didn't find the bug because the `host_target` is only used when emitting shape funcs
https://github.com/apache/incubator-tvm/blob/4c728d532b987ae4de464597bbfccc687913ad2d/python/tvm/relay/transform/memory_alloc.py#L154

cc @icemelon9 @jroesch 
