### PR TITLE
[OpFusion] Make the max number of fused ops configurable

### DIFF
--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -83,7 +83,7 @@ constexpr uint32_t kMaxFusedOps = 256;
 
 static const Op& stop_fusion_op = Op::Get("annotation.stop_fusion");
 
-TVM_REGISTER_PASS_CONFIG_OPTION("relay.max_fuse_depth", Integer);
+TVM_REGISTER_PASS_CONFIG_OPTION("relay.FuseOps.max_fuse_depth", Integer);
 
 /*!
  * \brief Indexed data flow graph in forward direction.
@@ -967,7 +967,7 @@ Pass FuseOps(int fuse_opt_level) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
         int opt_level = fuse_opt_level == -1 ? pc->opt_level : fuse_opt_level;
-        auto max_fuse_depth = pc->GetConfig("relay.max_fuse_depth", Integer(kMaxFusedOps));
+        auto max_fuse_depth = pc->GetConfig("relay.FuseOps.max_fuse_depth", Integer(kMaxFusedOps));
         return Downcast<Function>(FuseOps(f, opt_level, max_fuse_depth.value(), m));
       };
   return CreateFunctionPass(pass_func, 1, "FuseOps", {"InferType"});

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -83,6 +83,8 @@ constexpr uint32_t kMaxFusedOps = 256;
 
 static const Op& stop_fusion_op = Op::Get("annotation.stop_fusion");
 
+TVM_REGISTER_PASS_CONFIG_OPTION("relay.approx_max_fuse_depth", Integer);
+
 /*!
  * \brief Indexed data flow graph in forward direction.
  *  This is a temporary data structure used for operator fusion analysis.
@@ -496,8 +498,8 @@ DominatorTree DominatorTree::PostDom(support::Arena* arena, const IndexedForward
  */
 class GraphPartitioner {
  public:
-  explicit GraphPartitioner(support::Arena* arena, int opt_level)
-      : arena_(arena), opt_level_(opt_level) {}
+  explicit GraphPartitioner(support::Arena* arena, int opt_level, int max_fuse_depth)
+      : arena_(arena), opt_level_(opt_level), max_fuse_depth_(max_fuse_depth) {}
   /*!
    * \brief Group as a union find data structure.
    */
@@ -549,6 +551,8 @@ class GraphPartitioner {
   support::Arena* arena_;
   /*! \brief optimization level for fuse operation. */
   int opt_level_;
+  /*! \brief The approximate maximum number of operations in one fused function */
+  size_t max_fuse_depth_;
   /*! \brief The internal groups. */
   std::vector<Group*> groups_;
   /*! \brief internal field used for deduplication */
@@ -605,6 +609,7 @@ class GraphPartitioner {
    */
   void MergeFromTo(Group* child, Group* parent) {
     // update the number of nodes of the parent group
+    LOG(INFO) << "parent->num_nodes, child->num_nodes " << parent->num_nodes << ", " << child->num_nodes;
     parent->num_nodes += child->num_nodes;
     child = child->FindRoot();
     parent = parent->FindRoot();
@@ -643,6 +648,26 @@ class GraphPartitioner {
     CommitFuse_(src, sink, target);
   }
 
+  size_t CountNodesUptoSink_(IndexedForwardGraph::Node* src, IndexedForwardGraph::Node* sink) {
+    if (src == sink || visited_.count(src)) return 0;
+    visited_.insert(src);
+    Group* gnode = groups_[src->index];
+    CHECK(gnode != nullptr);
+    auto sum = gnode->num_nodes;
+    for (auto link = src->outputs.head; link != nullptr; link = link->next) {
+      sum += CountNodesUptoSink_(link->value.node, sink);
+    }
+    return sum;
+  }
+
+  size_t CountNodesUptoDomParent(IndexedForwardGraph::Node* child,
+                                 IndexedForwardGraph::Node* dom_parent) {
+    Group* target = groups_[dom_parent->index];
+    visited_.clear();
+    CHECK(child != dom_parent);
+    return target->num_nodes + CountNodesUptoSink_(child, dom_parent);
+  }
+
   // Initialize the groups.
   void InitGroups(const IndexedForwardGraph& graph) {
     groups_.resize(graph.post_dfs_order.size());
@@ -675,7 +700,13 @@ class GraphPartitioner {
       size_t dom_parent_gindex = dom_node->parent->gnode->index;
 
       // refuse the fusion if too many ops are going to be fused together
-      if (groups_[dom_parent_gindex]->num_nodes + group_node->num_nodes > kMaxFusedOps) continue;
+      LOG(INFO) << "groups_[dom_parent_gindex]->num_nodes,  group_node->num_nodes " <<
+        groups_[dom_parent_gindex]->num_nodes << ", " <<  group_node->num_nodes;
+
+      if (CountNodesUptoDomParent(graph_node, dom_node->parent->gnode) > max_fuse_depth_) {
+        LOG(INFO) << "Skip fusion";
+        continue;
+      }
 
       if (phase == 2) {
         // Fuse injective ops into intermediate tuples, if any
@@ -763,22 +794,27 @@ std::vector<GraphPartitioner::Group*> GraphPartitioner::Partition(
   for (int phase = 0; phase < 3; ++phase) {
     this->RunFuse(graph, post_dom_tree, phase);
   }
+  for (auto g: groups_) {
+    if (g->FindRoot() == g) {
+      LOG(INFO) << "num nodes: " << g->num_nodes;
+    }
+  }
   return std::move(groups_);
 }
 
 class FuseMutator : private ExprMutator {
  public:
   // Run the transform
-  Expr Transform(const Expr& body, int fuse_opt_level) {
+  Expr Transform(const Expr& body, int fuse_opt_level, size_t max_fuse_depth) {
     // setup the group map.
     auto graph = IndexedForwardGraph::Create(&arena_, body);
-    auto groups = GraphPartitioner(&arena_, fuse_opt_level).Partition(graph);
+    auto groups = GraphPartitioner(&arena_, fuse_opt_level, max_fuse_depth).Partition(graph);
     for (size_t nid = 0; nid < graph.post_dfs_order.size(); ++nid) {
       CHECK(graph.post_dfs_order[nid]->ref != nullptr);
       gmap_[graph.post_dfs_order[nid]->ref] = groups[nid];
     }
     // The following line can be used for debug.
-    // this->DebugDumpGroup(body);
+    this->DebugDumpGroup(body);
     return this->Mutate(body);
   }
 
@@ -926,8 +962,8 @@ class FuseMutator : private ExprMutator {
   }
 };
 
-Expr FuseOps(const Expr& expr, int fuse_opt_level, const IRModule& module) {
-  return FuseMutator().Transform(expr, fuse_opt_level);
+Expr FuseOps(const Expr& expr, int fuse_opt_level, size_t max_fuse_depth, const IRModule& module) {
+  return FuseMutator().Transform(expr, fuse_opt_level, max_fuse_depth);
 }
 
 namespace transform {
@@ -936,7 +972,10 @@ Pass FuseOps(int fuse_opt_level) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
         int opt_level = fuse_opt_level == -1 ? pc->opt_level : fuse_opt_level;
-        return Downcast<Function>(FuseOps(f, opt_level, m));
+        auto max_fuse_depth = pc->GetConfig("relay.approx_max_fuse_depth", Integer(kMaxFusedOps));
+        auto ret = Downcast<Function>(FuseOps(f, opt_level, max_fuse_depth.value(), m));
+        LOG(INFO) << "After fuse pass: "  << AsText(ret, false);
+        return ret;
       };
   return CreateFunctionPass(pass_func, 1, "FuseOps", {"InferType"});
 }

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -498,7 +498,7 @@ DominatorTree DominatorTree::PostDom(support::Arena* arena, const IndexedForward
  */
 class GraphPartitioner {
  public:
-  explicit GraphPartitioner(support::Arena* arena, int opt_level, int max_fuse_depth)
+  explicit GraphPartitioner(support::Arena* arena, int opt_level, size_t max_fuse_depth)
       : arena_(arena), opt_level_(opt_level), max_fuse_depth_(max_fuse_depth) {}
   /*!
    * \brief Group as a union find data structure.

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -83,7 +83,7 @@ constexpr uint32_t kMaxFusedOps = 256;
 
 static const Op& stop_fusion_op = Op::Get("annotation.stop_fusion");
 
-TVM_REGISTER_PASS_CONFIG_OPTION("relay.FuseOps.max_fuse_depth", Integer);
+TVM_REGISTER_PASS_CONFIG_OPTION("relay.FuseOps.max_depth", Integer);
 
 /*!
  * \brief Indexed data flow graph in forward direction.
@@ -967,7 +967,7 @@ Pass FuseOps(int fuse_opt_level) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
         int opt_level = fuse_opt_level == -1 ? pc->opt_level : fuse_opt_level;
-        auto max_fuse_depth = pc->GetConfig("relay.FuseOps.max_fuse_depth", Integer(kMaxFusedOps));
+        auto max_fuse_depth = pc->GetConfig("relay.FuseOps.max_depth", Integer(kMaxFusedOps));
         return Downcast<Function>(FuseOps(f, opt_level, max_fuse_depth.value(), m));
       };
   return CreateFunctionPass(pass_func, 1, "FuseOps", {"InferType"});

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -916,7 +916,7 @@ class FuseMutator : private ExprMutator {
     // If the function has no call, it is not a primitive function.
     struct HasCallVisitor : ExprVisitor {
       bool has_call = false;
-      void VisitExpr_(const CallNode* op) final { has_call = true;}
+      void VisitExpr_(const CallNode* op) final { has_call = true; }
     } visitor;
     visitor(body);
     const GroupInfo& ginfo = ginfo_[group];

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -705,7 +705,8 @@ class GraphPartitioner {
       size_t dom_parent_gindex = dom_node->parent->gnode->index;
 
       // refuse the fusion if too many ops are going to be fused together
-      if (CountFusedNodesWithNewChild(graph_node, dom_node->parent->gnode) > max_fuse_depth_) continue;
+      if (CountFusedNodesWithNewChild(graph_node, dom_node->parent->gnode) > max_fuse_depth_)
+        continue;
 
       if (phase == 2) {
         // Fuse injective ops into intermediate tuples, if any

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -968,7 +968,7 @@ Pass FuseOps(int fuse_opt_level) {
       [=](Function f, IRModule m, PassContext pc) {
         int opt_level = fuse_opt_level == -1 ? pc->opt_level : fuse_opt_level;
         auto max_fuse_depth = pc->GetConfig("relay.max_fuse_depth", Integer(kMaxFusedOps));
-        return Downcast<Function>(FuseOps(f, opt_level, max_fuse_depth.value(), m));;
+        return Downcast<Function>(FuseOps(f, opt_level, max_fuse_depth.value(), m));
       };
   return CreateFunctionPass(pass_func, 1, "FuseOps", {"InferType"});
 }

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -626,7 +626,7 @@ def test_fuse_max():
     z = before(n)
     after = run_opt_pass(expected(n, max_fused_ops), transform.InferType())
 
-    with tvm.transform.PassContext(opt_level=3, config={"relay.max_fuse_depth": max_fused_ops}):
+    with tvm.transform.PassContext(config={"relay.max_fuse_depth": max_fused_ops}):
         zz = run_opt_pass(z, transform.FuseOps())
 
     assert tvm.ir.structural_equal(zz, after)
@@ -732,6 +732,47 @@ def test_fuse_bcast_reduce_scalar():
     assert tvm.ir.structural_equal(m["main"], after)
 
 
+def test_fuse_max_diamond():
+    def create_diamond(x, branch_len):
+        x1 = x
+        x2 = x
+        for _ in range(branch_len):
+            x1 = relay.exp(x1)
+            x2 = relay.exp(x2)
+        return relay.add(x1, x2)
+
+    def before(branch_len, num_diamond):
+        x = relay.var("x", shape=(10, 20))
+        out = x
+        for _ in range(num_diamond):
+            out = create_diamond(out, branch_len)
+        return relay.Function([x], out)
+
+    def after(branch_len, num_diamond):
+        def create_diamond_func(inp):
+            inp_var = relay.var("p", shape=(10, 20))
+            d = create_diamond(inp_var, branch_len)
+            f = relay.Function([inp_var], d)
+            f = f.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
+            return relay.Call(f, [inp])
+
+        inp = relay.var("x", shape=(10, 20))
+        out = inp
+        for _ in range(num_diamond):
+            out = create_diamond_func(out)
+        return relay.Function([inp], out)
+
+    branch_len = 5
+    max_fused_ops = branch_len * 2 + 1  # the number of ops in one diamond
+    num_diamond = 3
+
+    with tvm.transform.PassContext(config={"relay.max_fuse_depth": max_fused_ops}):
+        fused = run_opt_pass(before(branch_len, num_diamond), transform.FuseOps())
+
+    expected = run_opt_pass(after(branch_len, num_diamond), transform.InferType())
+    assert tvm.ir.structural_equal(fused, expected)
+
+
 if __name__ == "__main__":
     test_fuse_simple()
     test_conv2d_fuse()
@@ -751,3 +792,4 @@ if __name__ == "__main__":
     test_fuse_take()
     test_fuse_gather_nd()
     test_fuse_bcast_reduce_scalar()
+    test_fuse_max_diamond()

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -626,7 +626,7 @@ def test_fuse_max():
     z = before(n)
     after = run_opt_pass(expected(n, max_fused_ops), transform.InferType())
 
-    with tvm.transform.PassContext(config={"relay.FuseOps.max_fuse_depth": max_fused_ops}):
+    with tvm.transform.PassContext(config={"relay.FuseOps.max_depth": max_fused_ops}):
         zz = run_opt_pass(z, transform.FuseOps())
 
     assert tvm.ir.structural_equal(zz, after)
@@ -766,7 +766,7 @@ def test_fuse_max_diamond():
     max_fused_ops = branch_len * 2 + 1  # the number of ops in one diamond
     num_diamond = 3
 
-    with tvm.transform.PassContext(config={"relay.FuseOps.max_fuse_depth": max_fused_ops}):
+    with tvm.transform.PassContext(config={"relay.FuseOps.max_depth": max_fused_ops}):
         fused = run_opt_pass(before(branch_len, num_diamond), transform.FuseOps())
 
     expected = run_opt_pass(after(branch_len, num_diamond), transform.InferType())

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -626,7 +626,7 @@ def test_fuse_max():
     z = before(n)
     after = run_opt_pass(expected(n, max_fused_ops), transform.InferType())
 
-    with tvm.transform.PassContext(config={"relay.max_fuse_depth": max_fused_ops}):
+    with tvm.transform.PassContext(config={"relay.FuseOps.max_fuse_depth": max_fused_ops}):
         zz = run_opt_pass(z, transform.FuseOps())
 
     assert tvm.ir.structural_equal(zz, after)
@@ -766,7 +766,7 @@ def test_fuse_max_diamond():
     max_fused_ops = branch_len * 2 + 1  # the number of ops in one diamond
     num_diamond = 3
 
-    with tvm.transform.PassContext(config={"relay.max_fuse_depth": max_fused_ops}):
+    with tvm.transform.PassContext(config={"relay.FuseOps.max_fuse_depth": max_fused_ops}):
         fused = run_opt_pass(before(branch_len, num_diamond), transform.FuseOps())
 
     expected = run_opt_pass(after(branch_len, num_diamond), transform.InferType())


### PR DESCRIPTION
This adds support for configuring the number of ops in one fused function. The motivation is for a use case like 
[hummingbird ](https://github.com/microsoft/hummingbird) where there can be unbounded number of operations fused into one function, depending on the dataset. This leads to huge compilation time. 

More details explained in 
https://discuss.tvm.ai/t/aggressive-operator-fusion-and-its-consequence-of-huge-inlined-tir-expression/7687

There is already a hard coded constant kMaxFusedOps and the condition to check the number of fused ops:

https://github.com/apache/incubator-tvm/blob/a8e44710c6472a2ee5cb66283c7f5e77f4e4ca0d/src/relay/transforms/fuse_ops.cc#L82

https://github.com/apache/incubator-tvm/blob/a8e44710c6472a2ee5cb66283c7f5e77f4e4ca0d/src/relay/transforms/fuse_ops.cc#L678

But this condition is simply not correct, since for a diamond structure there are multiple paths connecting a child node (`group_node` above) and its dom parent. Correctly calculating the number of fused nodes requires more care, and I believe my implementation is correct.

Please review @tqchen @zhiics 