### PR TITLE
[MSVC] Make able to compile with MSVC

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -636,7 +636,10 @@ bool UsesExportABI(const PrimFunc& f) {
   return false;
 }
 
-__attribute__((unused)) std::ostream& operator<<(std::ostream& os, const llvm::Module& m) {
+#ifdef __GNUC__
+__attribute__((unused))
+#endif
+std::ostream& operator<<(std::ostream& os, const llvm::Module& m) {
   std::string ms;
   llvm::raw_string_ostream sos(ms);
   sos << m;

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -636,11 +636,7 @@ bool UsesExportABI(const PrimFunc& f) {
   return false;
 }
 
-#ifdef __GNUC__
-__attribute__((unused))
-#endif
-std::ostream&
-operator<<(std::ostream& os, const llvm::Module& m) {
+DMLC_ATTRIBUTE_UNUSED std::ostream& operator<<(std::ostream& os, const llvm::Module& m) {
   std::string ms;
   llvm::raw_string_ostream sos(ms);
   sos << m;

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -639,7 +639,8 @@ bool UsesExportABI(const PrimFunc& f) {
 #ifdef __GNUC__
 __attribute__((unused))
 #endif
-std::ostream& operator<<(std::ostream& os, const llvm::Module& m) {
+std::ostream&
+operator<<(std::ostream& os, const llvm::Module& m) {
   std::string ms;
   llvm::raw_string_ostream sos(ms);
   sos << m;

--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -54,6 +54,7 @@
 
 #include <memory>
 #include <utility>
+#include <iterator>
 
 #include "ad_util.h"
 

--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -52,9 +52,9 @@
 #include <tvm/tir/analysis.h>
 #include <tvm/tir/stmt_functor.h>
 
+#include <iterator>
 #include <memory>
 #include <utility>
-#include <iterator>
 
 #include "ad_util.h"
 


### PR DESCRIPTION
HEAD ( 1a26a2e9e073e7fb579390edba8baf826743909c ) cannot be compiled with msvc.  
So, I added some `#include` and `#ifdef` to make it compilable.