### PR TITLE
[Ansor][AutoTVM v2.0] Phase 2: Update heavy operations with parallel_for

### DIFF
--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -245,7 +245,9 @@ class ComputeDAG : public ObjectRef {
    * This function calls TVM InferBound pass internally to get the bound.
    * The returned state of this function is guaranteed to have complete bound information.
    * \param states The input states.
-   * \return The States with complete bound information
+   * \return The States with complete bound information.
+   * \note The returned array will contains empty State, if there're infer bound failure on some
+   * states.
    */
   Array<State> InferBound(const Array<State>& states) const;
 

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -816,13 +816,13 @@ Array<State> ComputeDAG::InferBound(const Array<State>& states) const {
   out_states.reserve(states.size());
   std::mutex m;
 
-  tvm::support::parallel_for(0, states.size(), [this, &states, &out_states, &m](int index) {
+  support::parallel_for(0, states.size(), [this, &states, &out_states, &m](int i) {
     State out_state;
     try {
-      out_state = this->InferBound(states[index]);
+      out_state = this->InferBound(states[i]);
     } catch (dmlc::Error& e) {
       LOG(WARNING) << "InferBound fails on the state:\n"
-                   << states[index] << "\n"
+                   << states[i] << "\n"
                    << "with: " << e.what() << std::endl;
     }
     if (out_state.defined()) {

--- a/src/auto_scheduler/search_policy/search_policy.cc
+++ b/src/auto_scheduler/search_policy/search_policy.cc
@@ -58,6 +58,7 @@ void SearchPolicyNode::PreloadMeasuredStates(const String& log_file) {
             res.second[i]->error_no == 0 ? (1.0 / FloatArrayMean(res.second[i]->costs)) : 0.0);
       }
     }
+    // We can assume the recorded states will all be valid after infer bound
     measured_states = search_task->compute_dag.InferBound(measured_states);
     for (size_t i = 0; i < measured_states.size(); i++) {
       auto& state = measured_states[i];

--- a/src/auto_scheduler/search_policy/sketch_policy.cc
+++ b/src/auto_scheduler/search_policy/sketch_policy.cc
@@ -341,7 +341,8 @@ Array<State> SketchPolicyNode::SampleInitPopulation(const Array<State>& sketches
         // Derivation rule based enumeration
         bool valid = true;
         for (const auto& rule : init_rules) {
-          // Some rule needs use the random generator of SketchPolicyNode, which has to be protected
+          // Some rules use the random generator of SketchPolicyNode, so this part has to be
+          // protected
           std::unique_lock<std::mutex> l(m);
           if (rule->Apply(this, &tmp_s) == InitPopulationRule::ResultKind::kInvalid) {
             valid = false;

--- a/src/auto_scheduler/search_policy/sketch_policy.cc
+++ b/src/auto_scheduler/search_policy/sketch_policy.cc
@@ -179,7 +179,9 @@ State SketchPolicyNode::Search(int n_trials, int early_stopping, int num_measure
 
       // Infer bound. This is necessary for computing the correct ToStr() for redundancy check
       best_states = search_task->compute_dag.InferBound(best_states);
+      PruneInvalidState(search_task, &best_states);
       random_states = search_task->compute_dag.InferBound(random_states);
+      PruneInvalidState(search_task, &random_states);
 
       // Pick `num_measure_per_iter` states to measure, check hash to remove already measured state
       // Also pick some random states to do eps-greedy

--- a/src/support/parallel_for.cc
+++ b/src/support/parallel_for.cc
@@ -34,8 +34,8 @@ namespace support {
 
 std::vector<std::vector<int>> rr_partitioner(int begin, int end, int step, int num_threads) {
   int total_task_count = (end - begin) / step;
-  CHECK_GT(total_task_count, 0) << "Infinite loop condition, check the input value of "
-                                << "`begin`, `end`, `step`.";
+  CHECK_GE(total_task_count, 0) << "Infinite loop condition with begin: " << begin
+                                << " end: " << end << " step: " << step;
   std::vector<std::vector<int>> ret;
   ret.reserve(num_threads);
   for (size_t thread = 0; begin < end; begin += step, thread = (thread + 1) % num_threads) {

--- a/tests/cpp/parallel_for_test.cc
+++ b/tests/cpp/parallel_for_test.cc
@@ -89,6 +89,23 @@ TEST(ParallelFor, NestedWithNormalForLoop) {
   }
 }
 
+TEST(Parallelfor, NestedWithParallelFor) {
+  // Currently do not support using nested parallel_for
+  using tvm::support::parallel_for;
+
+  bool exception = false;
+  try {
+    parallel_for(0, 100, [](int i) {
+      parallel_for(0, 100, [](int j) {
+        // Blank loop
+      });
+    });
+  } catch (const std::exception& e) {
+    exception = true;
+  }
+  CHECK(exception);
+}
+
 TEST(ParallelFor, Exception) {
   using tvm::support::parallel_for;
 

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -48,7 +48,7 @@ def search_common(workload=matmul_auto_scheduler_test, target="llvm",
         if search_policy == 'empty':
             search_policy = auto_scheduler.EmptyPolicy(task)
         elif search_policy == 'sketch':
-            search_policy = auto_scheduler.SketchPolicy(task,
+            search_policy = auto_scheduler.SketchPolicy(task, schedule_cost_model=cost_model,
                     init_search_callbacks=init_search_callbacks)
 
         tuning_options = auto_scheduler.TuningOptions(num_measure_trials=num_measure_trials,
@@ -107,6 +107,18 @@ def test_sketch_search_policy_basic():
     t.join()
 
 
+def test_sketch_search_policy_xgbmodel():
+    if not tvm.runtime.enabled("llvm"):
+        return
+    # wrap the search in a new thread to avoid the conflict
+    # between python's multiprocessing and tvm's thread pool
+    t = PropagatingThread(target=search_common,
+                          kwargs={'seed': 944563397, 'search_policy': 'sketch',
+                                  'cost_model': auto_scheduler.XGBModel()})
+    t.start()
+    t.join()
+
+
 def test_sketch_search_policy_cuda_rpc_runner():
     if not tvm.runtime.enabled("cuda"):
         return
@@ -121,6 +133,7 @@ def test_sketch_search_policy_cuda_rpc_runner():
 
 
 if __name__ == "__main__":
-    test_workload_registry_search_basic()
+    # test_workload_registry_search_basic()
     test_sketch_search_policy_basic()
+    test_sketch_search_policy_xgbmodel()
     test_sketch_search_policy_cuda_rpc_runner()

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -133,7 +133,7 @@ def test_sketch_search_policy_cuda_rpc_runner():
 
 
 if __name__ == "__main__":
-    # test_workload_registry_search_basic()
+    test_workload_registry_search_basic()
     test_sketch_search_policy_basic()
     test_sketch_search_policy_xgbmodel()
     test_sketch_search_policy_cuda_rpc_runner()

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -132,8 +132,22 @@ def test_sketch_search_policy_cuda_rpc_runner():
     t.join()
 
 
+def test_sketch_search_policy_cuda_xgbmodel_rpc_runner():
+    if not tvm.runtime.enabled("cuda"):
+        return
+    measure_ctx = auto_scheduler.LocalRPCMeasureContext()
+    # wrap the search in a new thread to avoid the conflict
+    # between python's multiprocessing and tvm's thread pool
+    t = PropagatingThread(target=search_common,
+                          kwargs={'seed': 944563397, 'search_policy': 'sketch', 'target': 'cuda',
+                                  'runner': measure_ctx.runner, 'cost_model': auto_scheduler.XGBModel()})
+    t.start()
+    t.join()
+
+
 if __name__ == "__main__":
     test_workload_registry_search_basic()
     test_sketch_search_policy_basic()
     test_sketch_search_policy_xgbmodel()
     test_sketch_search_policy_cuda_rpc_runner()
+    test_sketch_search_policy_cuda_xgbmodel_rpc_runner()


### PR DESCRIPTION
For the full upstream plan, see [Ansor RFC](https://discuss.tvm.ai/t/rfc-ansor-an-auto-scheduler-for-tvm-autotvm-v2-0/7005/21).

This PR contains some small fix:
- Use parallel_for to speed up some heavy operations
  Currently add for:
  - ComputeDAG::InferBound
  - GetPerStoreFeaturesFromStates
  - ~~SketchPolicyNode::SampleInitPopulation(some rules used the SketchPolicyNode->rand_gen, so this part still has to be protected by a std::mutex)~~
  - ~~Do we need to add parallel_for for EvolutionarySearch after https://github.com/apache/incubator-tvm/pull/6310 has been merged?~~
- Add a SketchPolicy + XGBModel UT for a complete workflow test
- Add PruneInvalidState to the RandomModel branch

cc @merrymercy @comaniac 