### PR TITLE
[CODEGEN][CUDA]: fix cuda half math function is undefined: herf

### DIFF
--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -308,6 +308,10 @@ static inline __device__ __host__ half htanh(half x) {
   float result = tanhf(tmp_x);
   return __float2half(result);
 }
+
+static inline __device__ __host__ half herf(half x) {
+  return __float2half(erf(__half2float(x)));
+}
 #endif
 )";
 


### PR DESCRIPTION
I got an "identifier herf undefined" error when converting a model into TVM, which can be reproduced by the following code
```
import torch
import numpy as np
import tvm
from tvm import relay

class ErfTest(torch.nn.Module):
    def forward(self, data):
        return torch.erf(data)

def run(data):
    # convert pytorch to tvm
    traced = torch.jit.trace(ErfTest(), torch.from_numpy(data).cuda())
    mod, params = relay.frontend.from_pytorch(traced, [('data', data.shape)])

    # compile
    with tvm.transform.PassContext(opt_level=3):
        relay_graph, relay_lib, relay_params = tvm.relay.build(mod, target='cuda', params=params)
        relay_model = tvm.contrib.graph_runtime.create(relay_graph, relay_lib, tvm.context('gpu', 0))

    # run
    relay_model.set_input('data', data)
    relay_model.run()
    return relay_model.get_output(0)

data = np.random.rand(3, 4).astype(np.float32)
print(torch.erf(torch.Tensor(data)))
print(run(data))
print(run(data.astype(np.float16)))
```
![image](https://user-images.githubusercontent.com/16698151/91425664-04197a00-e88e-11ea-8212-5e08ec9b4650.png)

I fixed this in the same way as #6225 and the results seem ok

<img src="https://user-images.githubusercontent.com/16698151/91427276-3deb8000-e890-11ea-8fa0-2fb0c3585cae.png" width="300">

cc @vinx13 Could you help to review this?