### PR TITLE
[DOC] Fix mistyped word

### DIFF
--- a/python/tvm/te/hybrid/__init__.py
+++ b/python/tvm/te/hybrid/__init__.py
@@ -68,7 +68,7 @@ def script(pyfunc):
 
 
 def build(sch, inputs, outputs, name="hybrid_func"):
-    """Dump the corrent schedule to hybrid module
+    """Dump the current schedule to hybrid module
 
     Parameters
     ----------


### PR DESCRIPTION
* Fix the doc mistyped word in `tvm.te.hybrid.build` function

Could you help to check this pr, thanks! @merrymercy @icemelon9 @hlu1