### PR TITLE
[BYOC][JSON] Support input nodes with multiple entries

### DIFF
--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -150,7 +150,7 @@ class JSONRuntimeBase : public ModuleNode {
         << "Found mismatch in the number of provided data entryies and required.";
 
     for (size_t i = 0; i < static_cast<size_t>(args.size()); i++) {
-      auto eid = i < input_var_idx_.size() ? EntryID(input_var_idx_[i], 0)
+      auto eid = i < input_var_idx_.size() ? input_var_idx_[i]
                                            : EntryID(outputs_[i - input_var_idx_.size()]);
       CHECK(args[i].type_code() == kTVMNDArrayHandle || args[i].type_code() == kTVMDLTensorHandle)
           << "Expect NDArray or DLTensor as inputs";
@@ -183,7 +183,10 @@ class JSONRuntimeBase : public ModuleNode {
       uint32_t nid = input_nodes_[i];
       std::string name = nodes_[nid].name_;
       if (nodes_[nid].op_type_ == "input") {
-        input_var_idx_.push_back(nid);
+        CHECK_EQ(nodes_[nid].GetOpShape().size(), nodes_[nid].GetOpDataType().size());
+        for (size_t j = 0; j < nodes_[nid].GetOpShape().size(); ++j) {
+          input_var_idx_.push_back(EntryID(nid, j));
+        }
       } else {
         CHECK_EQ(nodes_[nid].op_type_, "const");
         auto pos = std::find(std::begin(const_names_), std::end(const_names_), name);

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -146,12 +146,12 @@ class JSONRuntimeBase : public ModuleNode {
    * \param args The packed args.
    */
   void SetInputOutputBuffers(const TVMArgs& args) {
-    CHECK_EQ(args.size(), input_var_idx_.size() + outputs_.size())
+    CHECK_EQ(args.size(), input_var_eid_.size() + outputs_.size())
         << "Found mismatch in the number of provided data entryies and required.";
 
     for (size_t i = 0; i < static_cast<size_t>(args.size()); i++) {
-      auto eid = i < input_var_idx_.size() ? input_var_idx_[i]
-                                           : EntryID(outputs_[i - input_var_idx_.size()]);
+      auto eid = i < input_var_eid_.size() ? input_var_eid_[i]
+                                           : EntryID(outputs_[i - input_var_eid_.size()]);
       CHECK(args[i].type_code() == kTVMNDArrayHandle || args[i].type_code() == kTVMDLTensorHandle)
           << "Expect NDArray or DLTensor as inputs";
 
@@ -185,7 +185,7 @@ class JSONRuntimeBase : public ModuleNode {
       if (nodes_[nid].op_type_ == "input") {
         CHECK_EQ(nodes_[nid].GetOpShape().size(), nodes_[nid].GetOpDataType().size());
         for (size_t j = 0; j < nodes_[nid].GetOpShape().size(); ++j) {
-          input_var_idx_.push_back(EntryID(nid, j));
+          input_var_eid_.push_back(EntryID(nid, j));
         }
       } else {
         CHECK_EQ(nodes_[nid].op_type_, "const");
@@ -264,8 +264,8 @@ class JSONRuntimeBase : public ModuleNode {
   std::vector<JSONGraphNodeEntry> outputs_;
   /*! \brief Data of that entry. */
   std::vector<const DLTensor*> data_entry_;
-  /*! \brief Map the input name to node index. */
-  std::vector<uint32_t> input_var_idx_;
+  /*! \brief Map the input name to entry id. */
+  std::vector<uint32_t> input_var_eid_;
   /*! \brief input const node index. */
   std::vector<uint32_t> const_idx_;
   /*! \brief Indicate if the engine has been initialized. */


### PR DESCRIPTION
Sometimes input nodes will have multiple data entries. The graph runtime will give a separate `arg` for each entry. The previous code assumed each input node would have 1 entry at index 0 which would correspond with a single arg.

Note that each custom runtime will also have the handle these types of inputs in a similar way.

Example JSON representation which would fail before but works with this PR. [This assert](https://github.com/apache/incubator-tvm/blob/master/src/runtime/contrib/json/json_runtime.h#L149-L150) would fail because the function has 3 args but 2 input + output nodes. See how op `input` has two entries for `dtype` and `shape`.

```
{
  "nodes": [
    {
      "op": "input", 
      "name": "tensorrt_0_i0", 
      "attrs": {
        "dtype": [
          [
            "float32", 
            "float32"
          ]
        ], 
        "shape": [
          [
            [1, 2, 6, 6], 
            [1, 3, 6, 6]
          ]
        ]
      }
    }, 
    {
      "op": "kernel", 
      "name": "concatenate", 
      "inputs": [[
          0, 
          0, 
          0], [
          0, 
          1, 
          0]], 
      "attrs": {
        "num_outputs": "1", 
        "num_inputs": "2", 
        "dtype": [
          [
            "float32"
          ]
        ], 
        "axis": [
          [
            "1"
          ]
        ], 
        "shape": [
          [
            [1, 5, 6, 6]
          ]
        ]
      }
    }
  ], 
  "arg_nodes": [0], 
  "heads": [[
      1, 
      0, 
      0]], 
  "node_row_ptr": [0, 2, 3]
}
```