### PR TITLE
[Torch] Fix aten::max and aten::min conversion

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -132,6 +132,32 @@ def _elemwise(name):
     return _impl
 
 
+def _min_max_common(name_elemwise, name_reduce):
+    def _impl(inputs, input_types):
+        if len(inputs) == 1:
+            data = _pytorch_promote_types(inputs[:1], input_types[:1])
+            return get_relay_op(name_reduce)(data[0])
+        elif len(inputs) >= 2 and isinstance(inputs[1], int):
+            data = _pytorch_promote_types(inputs[:1], input_types[:1])
+            dim = inputs[1]
+            keepdims = inputs[2] if len(inputs) > 2 else False
+            print(dim, keepdims)
+            # also return empty dummy indices
+            return get_relay_op(name_reduce)(data[0], axis=dim, keepdims=keepdims), None
+        else:
+            data0, data1 = _pytorch_promote_types(inputs[:2], input_types[:2])
+            return get_relay_op(name_elemwise)(data0, data1)
+    return _impl
+
+
+def _max():
+    return _min_max_common("maximum", "max")
+
+
+def _min():
+    return _min_max_common("minimum", "min")
+
+
 def _unary(name):
     def _impl(inputs, input_types):
         input_type = input_types[0]
@@ -2007,8 +2033,8 @@ def _get_convert_map(prelude):
         "prim::device"                          : _none(),
         "aten::sub"                             : _elemwise("subtract"),
         "aten::sub_"                            : _elemwise("subtract"),
-        "aten::max"                             : _elemwise("maximum"),
-        "aten::min"                             : _elemwise("minimum"),
+        "aten::max"                             : _max(),
+        "aten::min"                             : _min(),
         "aten::mul"                             : _elemwise("multiply"),
         "aten::mul_"                            : _elemwise("multiply"),
         "aten::pow"                             : _elemwise("power"),
@@ -2044,6 +2070,7 @@ def _get_convert_map(prelude):
         "aten::relu_"                           : _relu(prelude),
         "aten::prelu"                           : _prelu(),
         "aten::leaky_relu"                      : _leaky_relu(),
+        "aten::leaky_relu_"                     : _leaky_relu(),
         "aten::elu"                             : _elu(),
         "aten::elu_"                            : _elu(),
         "aten::celu"                            : _celu(),

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -141,8 +141,7 @@ def _min_max_common(name_elemwise, name_reduce):
             data = _pytorch_promote_types(inputs[:1], input_types[:1])
             dim = inputs[1]
             keepdims = inputs[2] if len(inputs) > 2 else False
-            print(dim, keepdims)
-            # also return empty dummy indices
+            # also return dummy indices
             return get_relay_op(name_reduce)(data[0], axis=dim, keepdims=keepdims), None
         else:
             data0, data1 = _pytorch_promote_types(inputs[:2], input_types[:2])

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -314,6 +314,44 @@ def test_forward_multiply():
     verify_model(Multiply3().float().eval(), input_data=input_data)
     verify_model(Multiply4().float().eval(), input_data=input_data)
 
+
+def test_min_max():
+    class Max(Module):
+        def forward(self, inp):
+            return torch.max(inp)
+
+    class Min(Module):
+        def forward(self, inp):
+            return torch.min(inp)
+
+    class Max2(Module):
+        def forward(self, inp):
+            out, _ = torch.max(inp, 1, keepdim=True)
+            return out
+
+    class Min2(Module):
+        def forward(self, inp):
+            out, _ = torch.min(inp, 0, keepdim=False)
+            return out
+
+    class Max3(Module):
+        def forward(self, lhs, rhs):
+            return torch.max(lhs, rhs)
+
+    class Min3(Module):
+        def forward(self, lhs, rhs):
+            return torch.min(lhs, rhs)
+
+    input_data = [torch.rand((10, 10)), torch.rand((10, 10))]
+
+    verify_model(Max(), input_data=input_data[0])
+    verify_model(Min(), input_data=input_data[0])
+    verify_model(Max2(), input_data=input_data[0])
+    verify_model(Min2(), input_data=input_data[0])
+    verify_model(Max3(), input_data=input_data)
+    verify_model(Min3(), input_data=input_data)
+
+
 def test_forward_reciprocal():
     torch.set_grad_enabled(False)
     input_shape = [2, 1, 10, 1, 10]
@@ -538,8 +576,8 @@ def test_forward_leakyrelu():
     input_data = torch.rand(input_shape).float()
     verify_model(torch.nn.LeakyReLU().eval(), input_data=input_data)
     verify_model(torch.nn.LeakyReLU(negative_slope=0.05).eval(), input_data=input_data)
-    verify_model(torch.nn.LeakyReLU(negative_slope=1.0).eval(), input_data=input_data)
-    verify_model(torch.nn.LeakyReLU(negative_slope=1.25).eval(), input_data=input_data)
+    verify_model(torch.nn.LeakyReLU(negative_slope=1.0, inplace=True).eval(), input_data=input_data)
+    verify_model(torch.nn.LeakyReLU(negative_slope=1.25, inplace=True).eval(), input_data=input_data)
 
 def test_forward_elu():
     torch.set_grad_enabled(False)
@@ -2937,6 +2975,7 @@ if __name__ == "__main__":
     test_conv3d()
     test_conv3d_transpose()
     test_forward_index()
+    test_min_max()
 
     # Model tests
     test_resnet18()


### PR DESCRIPTION
This is a fix for the issue found by hummingbird project
https://github.com/microsoft/hummingbird/issues/232#issuecomment-684142388

torch.max and min have 3 cases to handle, but we have conversion only for one of the cases. 
https://pytorch.org/docs/stable/generated/torch.max.html

Also added a conversion for `leaky_relu_` (seen problems from this op a few times)

please review @siju-samuel  