### PR TITLE
[Torch] Support logsumexp, clean up unnecessary infer_shape usage

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -80,14 +80,6 @@ def _convert_to_tensor_array(adt_lst, prelude):
 
 def _should_construct_dynamic_list(list_construct_node):
     # if this list is element-accessed or modified at runtime, generate List ADT
-    def is_used_by_list_add(uses):
-        for use in uses:
-            op_name = use.user.kind()
-            output_type = _get_node_type(use.user)
-            if op_name in ["aten::add", "aten::add_"] and output_type == "ListType":
-                return True
-        return False
-
     def inplace_add_to_add(op_name):
         if op_name == "aten::add_":
             return "aten::add"
@@ -110,10 +102,18 @@ def _should_construct_dynamic_list(list_construct_node):
     if len(intersect) > 0 and intersect != set(["aten::add"]):
         return True
 
-    if is_used_by_list_add(filter(lambda use: use.user.kind() != "prim::Loop", uses)):
-        return True
+    # if add op outputs list, it is dynamic so we need to construct List ADT
+    for use in filter(lambda use: use.user.kind() in ["aten::add", "aten::add_"], uses):
+        output_type = _get_node_type(use.user)
+        if output_type == "ListType":
+            return True
 
     return False
+
+
+def _is_int_seq(seq):
+    # TODO (t-vi): handle non-int constants? (like numpy.intXX)
+    return len(seq) > 0 and all([isinstance(i, int) for i in seq])
 
 
 def _is_quantized_tensor(data, prelude):
@@ -335,7 +335,7 @@ def _split_with_sizes():
 
         split_index = 0
         indices = []
-        sections = _infer_shape(inputs[1])
+        sections = inputs[1]
         for i in range(len(sections) - 1):
             split_index += sections[i]
             indices.append(split_index)
@@ -497,7 +497,7 @@ def _zeros_like():
     return _impl
 
 
-def _full():
+def _full(default_dtype):
     def _impl(inputs, input_types):
         data = inputs[0]
 
@@ -516,7 +516,8 @@ def _full():
         if inputs[2] is not None: # dtype given
             dtype = _convert_dtype_value(inputs[2])
         else:
-            dtype = data.type_annotation.dtype
+            # if dtype is None, torch uses a global default set by torch.set_default_tensor_type()
+            dtype = default_dtype
 
         return _op.full(_expr.const(fill_value), shape, dtype=dtype)
     return _impl
@@ -637,7 +638,7 @@ def _log_sigmoid():
 def _adaptive_avg_pool_2d(prelude):
     def _impl(inputs, input_types):
         data = inputs[0]
-        output_size = _infer_shape(inputs[1])
+        output_size = inputs[1]
 
         def func(x):
             return _op.nn.adaptive_avg_pool2d(x, output_size=output_size)
@@ -652,7 +653,7 @@ def _adaptive_avg_pool_2d(prelude):
 def _adaptive_max_pool_2d():
     def _impl(inputs, input_types):
         data = inputs[0]
-        output_size = _infer_shape(inputs[1])
+        output_size = inputs[1]
 
         # returns dummy indices too
         return _op.nn.adaptive_max_pool2d(
@@ -663,7 +664,7 @@ def _adaptive_max_pool_2d():
 def _adaptive_max_pool_3d():
     def _impl(inputs, input_types):
         data = inputs[0]
-        output_size = _infer_shape(inputs[1])
+        output_size = inputs[1]
         # returns dummy indices too
         return _op.nn.adaptive_max_pool3d(data, output_size=output_size), None
 
@@ -672,7 +673,7 @@ def _adaptive_max_pool_3d():
 def _adaptive_avg_pool_3d():
     def _impl(inputs, input_types):
         data = inputs[0]
-        output_size = _infer_shape(inputs[1])
+        output_size = inputs[1]
         return _op.nn.adaptive_avg_pool3d(data, output_size=output_size)
 
     return _impl
@@ -681,13 +682,13 @@ def _maxpool_2d():
     def _impl(inputs, input_types):
         data = inputs[0]
 
-        pool_size = _infer_shape(inputs[1])
-        strides = _infer_shape(inputs[2])
-        padding = _infer_shape(inputs[3])
-        dilation = _infer_shape(inputs[4])
+        pool_size = inputs[1]
+        strides = inputs[2]
+        padding = inputs[3]
+        dilation = inputs[4]
         ceil_mode = int(inputs[5])
 
-        if dilation != (1, 1):
+        if dilation != [1, 1]:
             msg = "MaxPool2d with dilation %s is not implemented" % (str(dilation))
             raise NotImplementedError(msg)
 
@@ -704,13 +705,13 @@ def _maxpool_1d():
     def _impl(inputs, input_types):
         data = inputs[0]
 
-        pool_size = _infer_shape(inputs[1])
-        strides = _infer_shape(inputs[2])
-        padding = _infer_shape(inputs[3])
-        dilation = _infer_shape(inputs[4])
+        pool_size = inputs[1]
+        strides = inputs[2]
+        padding = inputs[3]
+        dilation = inputs[4]
         ceil_mode = int(inputs[5])
 
-        if dilation != (1,):
+        if dilation != [1]:
             msg = "MaxPool1d with dilation %s is not implemented" % (str(dilation))
             raise NotImplementedError(msg)
 
@@ -721,12 +722,12 @@ def _maxpool_3d():
     def _impl(inputs, input_types):
         data = inputs[0]
 
-        pool_size = _infer_shape(inputs[1])
-        strides = _infer_shape(inputs[2])
-        padding = _infer_shape(inputs[3])
-        dilation = _infer_shape(inputs[4])
+        pool_size = inputs[1]
+        strides = inputs[2]
+        padding = inputs[3]
+        dilation = inputs[4]
         ceil_mode = int(inputs[5])
-        if dilation != (1, 1, 1):
+        if dilation != [1, 1, 1]:
             msg = "MaxPool3d with dilation %s is not implemented" % (str(dilation))
             raise NotImplementedError(msg)
 
@@ -753,9 +754,9 @@ def _convolution():
         data = inputs[0]
         weight = inputs[1]
         bias = inputs[2]
-        strides = inputs[3]
-        padding = inputs[4]
-        dilation = inputs[5]
+        strides = tuple(inputs[3])
+        padding = tuple(inputs[4])
+        dilation = tuple(inputs[5])
 
         if isinstance(weight, _expr.Expr):
             inferred_shape = _infer_shape(weight)
@@ -786,20 +787,10 @@ def _convolution():
         kernel_size = weight_shape[2:]
         use_bias = isinstance(bias, _expr.Expr)
 
-        if isinstance(strides, _expr.Expr):
-            strides = _infer_shape(strides)
-            if len(kernel_size) == 1:
-                strides = (1, ) + strides
-
-        if isinstance(padding, _expr.Expr):
-            padding = _infer_shape(padding)
-            if len(kernel_size) == 1:
-                padding = (0, ) + padding
-
-        if isinstance(dilation, _expr.Expr):
-            dilation = _infer_shape(dilation)
-            if len(kernel_size) == 1:
-                dilation = (1, ) + dilation
+        if len(kernel_size) == 1:
+            strides = (1, ) + strides
+            padding = (0, ) + padding
+            dilation = (1, ) + dilation
 
         if use_transpose:
             if len(kernel_size) == 3:
@@ -1017,7 +1008,7 @@ def _transpose(prelude):
             axes[src] = dst
             axes[dst] = src
         else:
-            axes = _infer_shape(inputs[1], prelude.mod)
+            axes = inputs[1]
         return _op.transform.transpose(data, axes)
     return _impl
 
@@ -1178,12 +1169,14 @@ def _avg_pool2d(prelude):
     def _impl(inputs, input_types):
         data = inputs[0]
 
-        pool_size = _infer_shape(inputs[1])
+        pool_size = inputs[1]
+
         if inputs[2]:
-            strides = _infer_shape(inputs[2])
+            strides = inputs[2]
         else:
             strides = pool_size
-        padding = _infer_shape(inputs[3])
+
+        padding = inputs[3]
 
         ceil_mode = int(inputs[4])
         count_include_pad = int(inputs[5])
@@ -1207,12 +1200,14 @@ def _avg_pool3d():
     def _impl(inputs, input_types):
         data = inputs[0]
 
-        pool_size = _infer_shape(inputs[1])
+        pool_size = inputs[1]
+
         if inputs[2]:
-            strides = _infer_shape(inputs[2])
+            strides = inputs[2]
         else:
             strides = pool_size
-        padding = _infer_shape(inputs[3])
+
+        padding = inputs[3]
 
         ceil_mode = int(inputs[4])
         count_include_pad = int(inputs[5])
@@ -1242,6 +1237,8 @@ def _reduce(name):
         if len(inputs) > 2: # default, torch have only data, axis=None, keepdims=False
             if isinstance(inputs[1], int):
                 axis = int(inputs[1])
+            elif _is_int_seq(inputs[1]):
+                axis = inputs[1]
             else:
                 axis = list(_infer_shape(inputs[1]))
             keepdims = bool(inputs[2])
@@ -1257,7 +1254,7 @@ def _norm():
         axis = None
         keepdims = False
         if len(inputs) > 3:
-            axis = list(_infer_shape(inputs[2]))
+            axis = inputs[2]
             keepdims = bool(inputs[3])
 
         order = inputs[1]
@@ -1281,7 +1278,7 @@ def _frobenius_norm():
         axis = None
         keepdims = False
         if len(inputs) > 2:
-            axis = list(_infer_shape(inputs[1]))
+            axis = inputs[1]
             keepdims = bool(inputs[2])
 
         return _op.sqrt(_op.reduce.sum((data * data), axis=axis, keepdims=keepdims))
@@ -1297,7 +1294,7 @@ def _std():
             keepdims = False
             unbiased = bool(inputs[1])
         else:
-            axis = list(_infer_shape(inputs[1]))
+            axis = inputs[1]
             keepdims = bool(inputs[3])
             unbiased = bool(inputs[2])
 
@@ -1313,7 +1310,7 @@ def _variance():
             keepdims = False
             unbiased = bool(inputs[1])
         else:
-            axis = list(_infer_shape(inputs[1]))
+            axis = inputs[1]
             keepdims = bool(inputs[3])
             unbiased = bool(inputs[2])
 
@@ -1326,9 +1323,10 @@ def _mean(prelude):
         data = inputs[0]
 
         if inputs[1]:
-            axis = _infer_shape(inputs[1])
+            axis = inputs[1]
         else:
             axis = None
+
         if len(inputs) > 2 and inputs[2]:
             keepdims = int(inputs[2])
         else:
@@ -1454,7 +1452,7 @@ def _expand():
             shape = list(_infer_shape(data_in))
 
         ndims = len(shape)
-        sizes = _infer_shape(inputs[1])
+        sizes = inputs[1]
         out = inputs[0]
 
         out_dims = len(sizes)
@@ -1567,6 +1565,8 @@ def _upsample(method, prelude):
     def _impl(inputs, input_types):
         if isinstance(inputs[1], _expr.Var):
             out_size = _infer_shape(inputs[1])
+        elif _is_int_seq(inputs[1]):
+            out_size = inputs[1]
         elif isinstance(inputs[1], list):
             infer_res = [_infer_value(size, {}) for size in inputs[1]]
             out_size = [np.asscalar(res.asnumpy().astype(np.int))
@@ -1614,6 +1614,8 @@ def _upsample3d(method):
     def _impl(inputs, input_types):
         if isinstance(inputs[1], _expr.Var):
             out_size = _infer_shape(inputs[1])
+        elif _is_int_seq(inputs[1]):
+            out_size = inputs[1]
         elif isinstance(inputs[1], list):
             infer_res = [_infer_value(size, {}) for size in inputs[1]]
             out_size = [np.asscalar(res.asnumpy().astype(np.int))
@@ -1896,6 +1898,17 @@ def _nms(prelude):
     return _impl
 
 
+def _logsumexp():
+    def _impl(inputs, input_types):
+        data = _pytorch_promote_types(inputs[:1], input_types[:1])
+        dim_list = inputs[1]
+        keepdim = inputs[2] if len(inputs) > 2 else False
+        # dim is output of prim::ListConstruct, even if it is int in python code
+        assert isinstance(dim_list, list), "dim is expected to be a list"
+        return _op.logsumexp(data[0], axis=dim_list, keepdims=keepdim)
+    return _impl
+
+
 def _pytorch_result_type(dtypes, non_tensor_inputs):
     """This promotes TVM dtypes like PyTorch would"""
     import torch
@@ -2026,7 +2039,7 @@ def _wrap_const(c):
     return c
 
 # Operator mappings
-def _get_convert_map(prelude):
+def _get_convert_map(prelude, default_dtype):
     convert_map = {
         "aten::device"                          : _none(),
         "prim::device"                          : _none(),
@@ -2048,7 +2061,7 @@ def _get_convert_map(prelude):
         "aten::ones_like"                       : _ones_like(),
         "aten::zeros"                           : _zeros(),
         "aten::zeros_like"                      : _zeros_like(),
-        "aten::full"                            : _full(),
+        "aten::full"                            : _full(default_dtype),
         "aten::full_like"                       : _full_like(),
         "aten::linspace"                        : _linspace(),
         "aten::reciprocal"                      : _reciprocal(),
@@ -2198,6 +2211,7 @@ def _get_convert_map(prelude):
         "aten::index_select"                    : _select(),
         "aten::index"                           : _index(),
         "torchvision::nms"                      : _nms(prelude),
+        "aten::logsumexp"                       : _logsumexp()
     }
     return convert_map
 
@@ -2206,11 +2220,6 @@ def _run_jit_passes(graph):
     """ The inline pass is necessary to unwrap prim::CallMethod """
     import torch
     torch._C._jit_pass_inline(graph)
-
-
-def _is_int_seq(seq):
-    # TODO (t-vi): handle non-int constants? (like numpy.intXX)
-    return len(seq) > 0 and all([isinstance(i, int) for i in seq])
 
 
 def _get_tensor_and_var(torch_tensor, name):
@@ -2697,8 +2706,8 @@ def convert_operators(operators, outputs, ret_names, convert_map, prelude, defau
 
         if operator == "prim::Constant":
             outputs[node_name] = _get_constant(op_node)
-        elif operator == "prim::ListConstruct" and _is_int_seq(inputs):
-            outputs[node_name] = _expr.var(node_name, shape=inputs)
+        # elif operator == "prim::ListConstruct" and _is_int_seq(inputs):
+        #     outputs[node_name] = _expr.var(node_name, shape=inputs)
         elif operator == "prim::ListConstruct" and _should_construct_dynamic_list(op_node):
             outputs[node_name] = _convert_to_list_adt(inputs, prelude)
         elif operator == "prim::ListConstruct":
@@ -2783,7 +2792,7 @@ def from_pytorch(script_module, input_shapes, custom_convert_map=None, default_d
     mod = tvm.IRModule()
     prelude = Prelude(mod)
 
-    convert_map = _get_convert_map(prelude)
+    convert_map = _get_convert_map(prelude, default_dtype)
 
     graph = script_module.graph.copy()
     _run_jit_passes(graph)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2706,8 +2706,6 @@ def convert_operators(operators, outputs, ret_names, convert_map, prelude, defau
 
         if operator == "prim::Constant":
             outputs[node_name] = _get_constant(op_node)
-        # elif operator == "prim::ListConstruct" and _is_int_seq(inputs):
-        #     outputs[node_name] = _expr.var(node_name, shape=inputs)
         elif operator == "prim::ListConstruct" and _should_construct_dynamic_list(op_node):
             outputs[node_name] = _convert_to_list_adt(inputs, prelude)
         elif operator == "prim::ListConstruct":

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -471,9 +471,9 @@ def _quantized_conv2d(with_relu=False):
         input_zero_point = _expr.const(inputs[9])
 
         strides, padding, dilation = inputs[2], inputs[3], inputs[4]
-        strides = infer_shape(inputs[2])
-        padding = infer_shape(inputs[3])
-        dilation = infer_shape(inputs[4])
+        strides = inputs[2]
+        padding = inputs[3]
+        dilation = inputs[4]
         groups = inputs[5]
 
         weight_shape = infer_shape(weight)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2747,6 +2747,9 @@ def test_logsumexp():
     input_data = torch.rand(input_shape)
 
     verify_model(Logsumexp(0), input_data=input_data)
+    verify_model(Logsumexp(0, keepdim=True), input_data=input_data)
+    # Also test on double
+    verify_model(Logsumexp(1, keepdim=True), input_data=input_data.double())
 
 
 def test_forward_pretrained_bert_base_uncased():

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2733,6 +2733,22 @@ def test_forward_index():
     verify_model(Index1().eval(), input_data=input_data)
 
 
+def test_logsumexp():
+    class Logsumexp(Module):
+        def __init__(self, dim, keepdim=False):
+            super().__init__()
+            self.dim = dim
+            self.keepdim = keepdim
+
+        def forward(self, x):
+            return torch.logsumexp(x, self.dim, self.keepdim)
+
+    input_shape = (100, 100)
+    input_data = torch.rand(input_shape)
+
+    verify_model(Logsumexp(0), input_data=input_data)
+
+
 def test_forward_pretrained_bert_base_uncased():
     ######################################################################
     # This is an example how to run BERT models using TVM
@@ -2976,6 +2992,7 @@ if __name__ == "__main__":
     test_conv3d_transpose()
     test_forward_index()
     test_min_max()
+    test_logsumexp()
 
     # Model tests
     test_resnet18()


### PR DESCRIPTION
Add logsumexp support per https://github.com/microsoft/hummingbird/issues/232#issuecomment-684998759

I also fixed how we handle a list of integers during conversion. For some reason (probably a debt from the beginning) for each int list we are creating a Relay Var:

https://github.com/apache/incubator-tvm/blob/f56bb71df9c93ba8830c5ab632352b3b2569bec9/python/tvm/relay/frontend/pytorch.py#L2700-L2701

And inside each op converter we are using `infer_shape` to recover the int list. This doesn't make any sense, so I removed Relay Var creation and that allowed me to remove many _infer_shape usage in our frontend.

please review @siju-samuel @t-vi 

Also thanks to @siju-samuel for adding logsumexp to Relay!