### PR TITLE
[Fix] fix compilation error when setting USE_RELAY_DEBUG

### DIFF
--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -339,9 +339,6 @@ void VirtualMachine::RunLoop() {
   main_loop:
     auto const& instr = code_[this->pc_];
     DLOG(INFO) << "Executing(" << pc_ << "): " << instr;
-#if USE_RELAY_DEBUG
-    LOG(INFO) << instr;
-#endif  // USE_RELAY_DEBUG
 
     switch (instr.op) {
       case Opcode::Move: {

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -340,7 +340,7 @@ void VirtualMachine::RunLoop() {
     auto const& instr = code_[this->pc_];
     DLOG(INFO) << "Executing(" << pc_ << "): " << instr;
 #if USE_RELAY_DEBUG
-    InstructionPrint(std::cout, instr);
+    LOG(INFO) << instr;
 #endif  // USE_RELAY_DEBUG
 
     switch (instr.op) {


### PR DESCRIPTION
This pull request fixes a compilation error when setting  USE_RELAY_DEBUG.
`InstructionPrint` has been moved to [bytecode.cc](https://github.com/apache/incubator-tvm/blob/master/src/runtime/vm/bytecode.cc#L500)