### PR TITLE
[TFLite] Support for 'SAME' Padding option for TRANSPOSE_CONV operator of TFLite.

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -2696,11 +2696,11 @@ class OperatorConverter(object):
 
         # Input (data) Tensor. NHWC layout
         input_tensor = input_tensors[2]
-        input_shape = input_tensor.tensor.ShapeAsNumpy()
+        _, input_h, input_w, input_c = input_tensor.tensor.ShapeAsNumpy()
         # Weights tensor. TFLite uses OHWI layout
         weights_tensor = input_tensors[1]
         out_channels, kernel_h, kernel_w, in_channels = weights_tensor.tensor.ShapeAsNumpy()
-        assert input_shape[3] == in_channels, \
+        assert input_c == in_channels, \
             "Input channel in the filter should match to channel in the input"
         # output_shape Tensor. NHWC layout
         output_shape_tensor = input_tensors[0]
@@ -2743,15 +2743,15 @@ class OperatorConverter(object):
             "Output channel in the filter should match to channel in the output_shape"
 
         if padding == Padding.SAME:
-            pad_top, pad_bottom = get_pad_value(input_shape[1], kernel_h, stride_h)
-            pad_left, pad_right = get_pad_value(input_shape[2], kernel_w, stride_w)
-            pads = (pad_top, pad_left, pad_bottom, pad_right)
+            pad_top, pad_bottom = get_pad_value(input_h, kernel_h, stride_h)
+            pad_left, pad_right = get_pad_value(input_w, kernel_w, stride_w)
+            padding = (pad_top, pad_left, pad_bottom, pad_right)
         else:
-            pads = (0, 0, 0, 0)
+            padding = (0, 0, 0, 0)
 
         out = _op.nn.conv2d_transpose(in_expr, weight_expr_iohw,
                                       strides=(stride_h, stride_w),
-                                      padding=pads,
+                                      padding=padding,
                                       channels=int(out_channels),
                                       kernel_size=(int(kernel_h), int(kernel_w)),
                                       data_layout="NHWC",

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -983,10 +983,20 @@ def test_forward_transpose_conv():
     _test_transpose_conv([1, 32, 32, 16], [3, 3, 5, 16], [1, 65, 65, 5], [2, 2], 'VALID')
     _test_transpose_conv([1, 32, 32, 16], [3, 3, 5, 16], [1, 65, 34, 5], [2, 1], 'VALID')
 
+    # kernel 3x3, padding SAME
+    _test_transpose_conv([4, 32, 32, 16], [3, 3, 5, 16], [4, 32, 32, 5], [1, 1], 'SAME')
+    _test_transpose_conv([1, 32, 32, 16], [3, 3, 5, 16], [1, 64, 64, 5], [2, 2], 'SAME')
+    _test_transpose_conv([1, 32, 32, 16], [3, 3, 5, 16], [1, 64, 32, 5], [2, 1], 'SAME')
+
     # kernel 2x2, padding VALID
     _test_transpose_conv([4, 32, 32, 16], [2, 2, 5, 16], [4, 33, 33, 5], [1, 1], 'VALID')
     _test_transpose_conv([1, 32, 32, 16], [2, 2, 5, 16], [1, 64, 64, 5], [2, 2], 'VALID')
     _test_transpose_conv([1, 32, 32, 16], [2, 2, 5, 16], [1, 64, 33, 5], [2, 1], 'VALID')
+
+    # kernel 2x2, padding SAME
+    _test_transpose_conv([4, 32, 32, 16], [2, 2, 5, 16], [4, 32, 32, 5], [1, 1], 'SAME')
+    _test_transpose_conv([1, 32, 32, 16], [2, 2, 5, 16], [1, 64, 64, 5], [2, 2], 'SAME')
+    _test_transpose_conv([1, 32, 32, 16], [2, 2, 5, 16], [1, 64, 32, 5], [2, 1], 'SAME')
 
     # kernel 1x1, padding VALID
     _test_transpose_conv([4, 32, 32, 16], [1, 1, 5, 16], [4, 32, 32, 5], [1, 1], 'VALID')


### PR DESCRIPTION
* Added support for 'SAME' Padding option for TRANSPOSE_CONV operator for all
  valid kernel sizes.
* Added tests for 'SAME' Padding option for TRANSPOSE_CONV operator.