### PR TITLE
[Relay/topi] Support scalar inputs in where op

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1663,6 +1663,7 @@ bool WhereRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     }
   }
   if (x_shape.size() == 0) {
+    // if x and y are scalar, the condition shape becomes the output shape
     reporter->Assign(types[3], TensorType(cond_shape, x->dtype));
   } else {
     reporter->Assign(types[3], TensorType(x_shape, x->dtype));
@@ -1698,6 +1699,9 @@ size is the same as x’s first dimension size. Each row of the output array
 is from x’s row if the corresponding element from condition is true, and
 from y’s row if false.
 
+When x and y are scalars, condition must be an 1D array. The output shape
+is the same as condition's shape.
+
 Note that all non-zero values are interpreted as True in condition.
 
 Examples::
@@ -1710,6 +1714,9 @@ Examples::
 
   cond = [1, 0]
   where(cond, x, y) = [[1, 2], [7, 8]]
+
+  cond = [0, 1]
+  where(cond, 1, -1) = [-1, 1]
 
 )code" TVM_ADD_FILELINE)
     .add_argument("condition", "Tensor", "Condition array")

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1662,7 +1662,11 @@ bool WhereRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
           << "condition and x must have the same shape: " << cond_shape << " vs " << x_shape;
     }
   }
-  reporter->Assign(types[3], TensorType(x_shape, x->dtype));
+  if (x_shape.size() == 0) {
+    reporter->Assign(types[3], TensorType(cond_shape, x->dtype));
+  } else {
+    reporter->Assign(types[3], TensorType(x_shape, x->dtype));
+  }
   return true;
 }
 


### PR DESCRIPTION
This adds support for relay/topi `where` op to take scalar values as input. This use case came up in hummingbird project. See https://github.com/microsoft/hummingbird/issues/232#issuecomment-682262544

I think this is a reasonable feature to add. The output shape is the same as condition's shape. Condition's shape has to be 1D. We could allow condition shape to be arbitrary when x and y are scalar, but I didn't make that change.

please review @zhiics @siju-samuel @junrushao1994 