### PR TITLE
Make docs build again when not everything is enabled

### DIFF
--- a/tutorials/language/extern_op.py
+++ b/tutorials/language/extern_op.py
@@ -36,6 +36,9 @@ from tvm import te
 import numpy as np
 from tvm.contrib import cblas
 
+if not tvm.get_global_func("tvm.contrib.cblas.matmul", allow_missing=True):
+    raise Exception("Not compiled with cblas support; can't build this tutorial")
+
 ######################################################################
 # Use Extern Tensor Function
 # --------------------------

--- a/tutorials/optimize/opt_matmul_auto_tensorcore.py
+++ b/tutorials/optimize/opt_matmul_auto_tensorcore.py
@@ -237,13 +237,11 @@ def test_gemm(N, L, M, dtype, layout):
 
 # check whether the gpu has tensorcore
 if not tvm.gpu(0).exist or not tvm.runtime.enabled("cuda"):
-  print("skip because cuda is not enabled..")
-  sys.exit(0)
+  raise Exception("skip building this tutorial because cuda is not enabled..")
 
 ctx = tvm.gpu()
 if not nvcc.have_tensorcore(ctx.compute_version):
-  print('the gpu has no tensorcore, skipping...')
-  sys.exit(0)
+  raise Exception("the gpu has no tensorcore, skipping...")
 
 M, N, L = 512, 32, 512
 dtype = 'float16'


### PR DESCRIPTION
Currently at master, if you run `cd docs && make html` without I think at least BLAS and CUDA enabled, the whole process segfaults and aborts. It looks like the reason is due to relying on a function in the function registry that isn't always registered. This PR fixes that plus removes some sys.exit() calls which were not causing errors but preventing docs from being built when CUDA wasn't enabled (and you have no GPU).

Unsure how we should add a test to verify this behavior. I tried adding a script to run on ci-i386, but I'd need to expand the Python dependencies there to include sphinx + the doc building deps. Thoughts on doing that?