### PR TITLE
[AutoTVM][Ansor] Enable random fill and CPU cache flush for AutoTVM and Ansor

### DIFF
--- a/include/tvm/auto_scheduler/measure.h
+++ b/include/tvm/auto_scheduler/measure.h
@@ -276,6 +276,8 @@ class ProgramRunnerNode : public Object {
   int min_repeat_ms;
   /*! \brief The cool down interval between two measurements. */
   double cooldown_interval;
+  /*! \brief Whether to flush cache on CPU between repeated measurements. */
+  bool enable_cpu_cache_flush;
 
   /*!
    * \brief Run measurement and return results.
@@ -358,8 +360,10 @@ class LocalRunner : public ProgramRunner {
    * \param repeat The number of times to repeat the measurement.
    * \param min_repeat_ms The minimum duration of one repeat in milliseconds.
    * \param cooldown_interval The cool down interval between two measurements.
+   * \param enable_cpu_cache_flush Whether to flush cache on CPU between repeated measurements.
    */
-  LocalRunner(int timeout, int number, int repeat, int min_repeat_ms, double cooldown_interval);
+  LocalRunner(int timeout, int number, int repeat, int min_repeat_ms, double cooldown_interval,
+              bool enable_cpu_cache_flush);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(LocalRunner, ProgramRunner, LocalRunnerNode);
 };
@@ -408,9 +412,11 @@ class RPCRunner : public ProgramRunner {
    * \param repeat The number of times to repeat the measurement.
    * \param min_repeat_ms The minimum duration of one repeat in milliseconds.
    * \param cooldown_interval The cool down interval between two measurements.
+   * \param enable_cpu_cache_flush Whether to flush cache on CPU between repeated measurements.
    */
   RPCRunner(const String& key, const String& host, int port, int priority, int n_parallel,
-            int timeout, int number, int repeat, int min_repeat_ms, double cooldown_interval);
+            int timeout, int number, int repeat, int min_repeat_ms, double cooldown_interval,
+            bool enable_cpu_cache_flush);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RPCRunner, ProgramRunner, RPCRunnerNode);
 };

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -594,9 +594,8 @@ def local_run(inputs, build_results,
             try:
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
-                assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
-                    "Do you enable USE_RANDOM in the config.cmake?"
-                random_fill = tvm.get_global_func("tvm.contrib.random.random_fill")
+                random_fill = tvm.get_global_func("tvm.contrib.random.random_fill", True)
+                assert random_fill, "Please make sure USE_RANDOM is ON in the config.cmake"
                 for arg in args:
                     random_fill(arg)
                 ctx.sync()
@@ -697,7 +696,7 @@ def rpc_run_worker(index):
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
                 assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
-                    "Do you enable USE_RANDOM in the config.cmake?"
+                    "Please make sure USE_RANDOM is ON in the config.cmake"
                 random_fill = remote.get_function("tvm.contrib.random.random_fill")
                 for arg in args:
                     random_fill(arg)

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -594,6 +594,8 @@ def local_run(inputs, build_results,
             try:
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
+                assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
+                    "Do you enable USE_RANDOM in the config.cmake?"
                 random_fill = tvm.get_global_func("tvm.contrib.random.random_fill")
                 for arg in args:
                     random_fill(arg)
@@ -694,6 +696,8 @@ def rpc_run_worker(index):
             try:
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
+                assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
+                    "Do you enable USE_RANDOM in the config.cmake?"
                 random_fill = remote.get_function("tvm.contrib.random.random_fill")
                 for arg in args:
                     random_fill(arg)

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -695,9 +695,11 @@ def rpc_run_worker(index):
             try:
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
-                assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
-                    "Please make sure USE_RANDOM is ON in the config.cmake"
-                random_fill = remote.get_function("tvm.contrib.random.random_fill")
+                try:
+                    random_fill = remote.get_function("tvm.contrib.random.random_fill")
+                except AttributeError:
+                    raise AttributeError("Please make sure USE_RANDOM is ON in the config.cmake "
+                                          "on the remote devices")
                 for arg in args:
                     random_fill(arg)
                 ctx.sync()

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -202,8 +202,6 @@ class LocalBuilder(ProgramBuilder):
 class LocalRunner(ProgramRunner):
     """ LocalRunner that uses local CPU/GPU to measures the time cost of programs.
 
-    TODO(FrozenGene): Add cpu cache flush to this runner.
-
     Parameters
     ----------
     timeout : int = 10
@@ -227,6 +225,12 @@ class LocalRunner(ProgramRunner):
         will be automatically increased.
     cooldown_interval : float = 0.0
         The cool down interval between two measurements.
+    enable_cpu_cache_flush: bool = False
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     """
 
     def __init__(self,
@@ -234,9 +238,11 @@ class LocalRunner(ProgramRunner):
                  number=3,
                  repeat=1,
                  min_repeat_ms=0,
-                 cooldown_interval=0.0):
+                 cooldown_interval=0.0,
+                 enable_cpu_cache_flush=False):
         self.__init_handle_by_constructor__(
-            _ffi_api.LocalRunner, timeout, number, repeat, min_repeat_ms, cooldown_interval)
+            _ffi_api.LocalRunner, timeout, number, repeat, min_repeat_ms, cooldown_interval,
+            enable_cpu_cache_flush)
 
 
 @tvm._ffi.register_object("auto_scheduler.RPCRunner")
@@ -244,8 +250,6 @@ class RPCRunner(ProgramRunner):
     """ RPCRunner that uses RPC call to measures the time cost of programs on remote devices.
     Or sometime we may need to use RPC even in local running to insulate the thread environment.
     (e.g. running CUDA programs)
-
-    TODO(FrozenGene): Add cpu cache flush to this runner.
 
     Parameters
     ----------
@@ -280,14 +284,20 @@ class RPCRunner(ProgramRunner):
         will be automatically increased.
     cooldown_interval : float = 0.0
         The cool down interval between two measurements.
+    enable_cpu_cache_flush: bool = False
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     """
 
     def __init__(self, key, host, port,
                  priority=1, n_parallel=1, timeout=10, number=3, repeat=1,
-                 min_repeat_ms=0, cooldown_interval=0.0):
+                 min_repeat_ms=0, cooldown_interval=0.0, enable_cpu_cache_flush=False):
         self.__init_handle_by_constructor__(
             _ffi_api.RPCRunner, key, host, port, priority, n_parallel, timeout,
-            number, repeat, min_repeat_ms, cooldown_interval)
+            number, repeat, min_repeat_ms, cooldown_interval, enable_cpu_cache_flush)
 
         if check_remote(key, host, port, priority, timeout):
             print("Get devices for measurement successfully!")
@@ -301,8 +311,6 @@ class RPCRunner(ProgramRunner):
 class LocalRPCMeasureContext:
     """ A context wrapper for running RPCRunner locally.
     This will launch a local RPC Tracker and local RPC Server.
-
-    TODO(FrozenGene): Add cpu cache flush to this RPC context.
 
     Parameters
     ----------
@@ -331,10 +339,16 @@ class LocalRPCMeasureContext:
         will be automatically increased.
     cooldown_interval : float = 0.0
         The cool down interval between two measurements.
+    enable_cpu_cache_flush: bool = False
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     """
 
     def __init__(self, priority=1, n_parallel=1, timeout=10, number=3, repeat=1,
-                 min_repeat_ms=0, cooldown_interval=0.0):
+                 min_repeat_ms=0, cooldown_interval=0.0, enable_cpu_cache_flush=False):
         ctx = tvm.context("cuda", 0)
         if ctx.exist:
             cuda_arch = "sm_" + "".join(ctx.compute_version.split('.'))
@@ -347,7 +361,7 @@ class LocalRPCMeasureContext:
                              tracker_addr=(self.tracker.host, self.tracker.port))
         self.runner = RPCRunner(device_key, host, self.tracker.port, priority,
                                 n_parallel, timeout, number, repeat,
-                                min_repeat_ms, cooldown_interval)
+                                min_repeat_ms, cooldown_interval, enable_cpu_cache_flush)
         # Wait for the processes to start
         time.sleep(0.5)
 
@@ -507,7 +521,7 @@ def local_builder_build(inputs, timeout, n_parallel, build_func='default', verbo
 @tvm._ffi.register_func("auto_scheduler.local_runner.run")
 def local_run(inputs, build_results,
               timeout=10, number=3, repeat=1, min_repeat_ms=0, cooldown_interval=0,
-              verbose=1):
+              enable_cpu_cache_flush=False, verbose=1):
     """
     Run function of LocalRunner to test the performance of the input BuildResults.
 
@@ -538,6 +552,12 @@ def local_run(inputs, build_results,
         will be automatically increased.
     cooldown_interval : float = 0.0
         The cool down interval between two measurements.
+    enable_cpu_cache_flush: bool = False
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     verbose: int = 1
         Verbosity level. 0 for silent, 1 to output information during program measuring.
 
@@ -555,9 +575,15 @@ def local_run(inputs, build_results,
         try:
             func = module.load_module(build_res.filename)
             ctx = ndarray.context(str(inp.task.target), 0)
-            # TODO(FrozenGene): Add cpu cache flush to this function.
+            # Limitation:
+            # We can not get PackFunction directly in the remote mode as it is wrapped
+            # under the std::function. We could lift the restriction later once we fold
+            # the PackedFunc as an object. Currently, we pass function name to work
+            # around it.
+            f_prepare = 'cache_flush_cpu_non_first_arg' if enable_cpu_cache_flush else ''
             time_f = func.time_evaluator(
-                func.entry_name, ctx, number=number, repeat=repeat, min_repeat_ms=min_repeat_ms)
+                func.entry_name, ctx, number=number, repeat=repeat, min_repeat_ms=min_repeat_ms,
+                f_preproc=f_prepare)
         # pylint: disable=broad-except
         except Exception:
             costs = (max_float,)
@@ -566,9 +592,11 @@ def local_run(inputs, build_results,
 
         if error_no == 0:
             try:
-                # TODO(FrozenGene): Update to ndarray.non-empty.
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
+                random_fill = tvm.get_global_func("tvm.contrib.random.random_fill")
+                for arg in args:
+                    random_fill(arg)
                 ctx.sync()
                 costs = time_f(*args).results
             # pylint: disable=broad-except
@@ -626,7 +654,8 @@ def rpc_run_worker(index):
     """
     global GLOBAL_RUN_ARGUMENTS
     inputs, build_results, key, host, port, priority, timeout, number, \
-        repeat, min_repeat_ms, cooldown_interval, verbose = GLOBAL_RUN_ARGUMENTS
+        repeat, min_repeat_ms, cooldown_interval, enable_cpu_cache_flush, \
+        verbose = GLOBAL_RUN_ARGUMENTS
 
     max_float = 1e10  # We use 1e10 instead of sys.float_info.max for better readability in log
     inp = inputs[index]
@@ -646,9 +675,15 @@ def rpc_run_worker(index):
             remote.upload(build_res.filename)
             func = remote.load_module(os.path.split(build_res.filename)[1])
             ctx = remote.context(str(inp.task.target), 0)
-            # TODO(FrozenGene): Add cpu cache flush to this function.
+            # Limitation:
+            # We can not get PackFunction directly in the remote mode as it is wrapped
+            # under the std::function. We could lift the restriction later once we fold
+            # the PackedFunc as an object. Currently, we pass function name to work
+            # around it.
+            f_prepare = 'cache_flush_cpu_non_first_arg' if enable_cpu_cache_flush else ''
             time_f = func.time_evaluator(
-                func.entry_name, ctx, number=number, repeat=repeat, min_repeat_ms=min_repeat_ms)
+                func.entry_name, ctx, number=number, repeat=repeat, min_repeat_ms=min_repeat_ms,
+                f_preproc=f_prepare)
         # pylint: disable=broad-except
         except Exception:
             costs = (max_float,)
@@ -657,9 +692,11 @@ def rpc_run_worker(index):
 
         if error_no == 0:
             try:
-                # TODO(FrozenGene): Update to ndarray.non-empty.
                 args = [ndarray.empty(get_const_tuple(x.shape), x.dtype, ctx) for x in
                         build_res.args]
+                random_fill = remote.get_function("tvm.contrib.random.random_fill")
+                for arg in args:
+                    random_fill(arg)
                 ctx.sync()
 
                 costs = time_f(*args).results
@@ -698,7 +735,7 @@ def rpc_run_worker(index):
 @tvm._ffi.register_func("auto_scheduler.rpc_runner.run")
 def rpc_runner_run(inputs, build_results, key, host, port,
                    priority=1, n_parallel=1, timeout=10, number=3, repeat=1, min_repeat_ms=0,
-                   cooldown_interval=0.0, verbose=1):
+                   cooldown_interval=0.0, enable_cpu_cache_flush=False, verbose=1):
     """ Run function of RPCRunner to test the performance of the input BuildResults.
 
     Parameters
@@ -738,6 +775,12 @@ def rpc_runner_run(inputs, build_results, key, host, port,
         will be automatically increased.
     cooldown_interval : float = 0.0
         The cool down interval between two measurements.
+    enable_cpu_cache_flush: bool = False
+        Whether to flush cache on CPU between repeated measurements.
+        Flushing cache can make the measured latency of one operator closer to
+        its actual latency during end-to-end inference.
+        To make this option effective, the argument `number` should also be set to 1.
+        This is only has effect on CPU task.
     verbose: int = 1
         Verbosity level. 0 for silent, 1 to output information during program measuring.
 
@@ -748,7 +791,8 @@ def rpc_runner_run(inputs, build_results, key, host, port,
     """
     global GLOBAL_RUN_ARGUMENTS
     GLOBAL_RUN_ARGUMENTS = (inputs, build_results, key, host, port, priority, timeout, number,
-                            repeat, min_repeat_ms, cooldown_interval, verbose)
+                            repeat, min_repeat_ms, cooldown_interval, enable_cpu_cache_flush,
+                            verbose)
 
     assert len(inputs) == len(build_results), \
         "Measure input size should be equal to build results"

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -699,7 +699,7 @@ def rpc_run_worker(index):
                     random_fill = remote.get_function("tvm.contrib.random.random_fill")
                 except AttributeError:
                     raise AttributeError("Please make sure USE_RANDOM is ON in the config.cmake "
-                                          "on the remote devices")
+                                         "on the remote devices")
                 for arg in args:
                     random_fill(arg)
                 ctx.sync()

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -511,6 +511,8 @@ def run_through_rpc(measure_input, build_result,
         if ref_input:
             args = [nd.array(x, ctx=ctx) for x in ref_input]
         else:
+            assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
+                "Do you enable USE_RANDOM in the config.cmake?"
             random_fill = remote.get_function("tvm.contrib.random.random_fill")
             args = [nd.empty(x[0], dtype=x[1], ctx=ctx) for x in build_result.arg_info]
             for arg in args:

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -511,10 +511,10 @@ def run_through_rpc(measure_input, build_result,
         if ref_input:
             args = [nd.array(x, ctx=ctx) for x in ref_input]
         else:
-            # create empty arrays on the remote device and copy them once.
-            # This can avoid some memory issues that make the measurement results unreliable.
+            random_fill = remote.get_function("tvm.contrib.random.random_fill")
             args = [nd.empty(x[0], dtype=x[1], ctx=ctx) for x in build_result.arg_info]
-            args = [nd.array(x, ctx=ctx) for x in args]
+            for arg in args:
+                random_fill(arg)
             ctx.sync()
 
         costs = time_f(*args).results

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -511,9 +511,11 @@ def run_through_rpc(measure_input, build_result,
         if ref_input:
             args = [nd.array(x, ctx=ctx) for x in ref_input]
         else:
-            assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
-                "Please make sure USE_RANDOM is ON in the config.cmake"
-            random_fill = remote.get_function("tvm.contrib.random.random_fill")
+            try:
+                random_fill = remote.get_function("tvm.contrib.random.random_fill")
+            except AttributeError:
+                raise AttributeError("Please make sure USE_RANDOM is ON in the config.cmake "
+                                     "on the remote devices")
             args = [nd.empty(x[0], dtype=x[1], ctx=ctx) for x in build_result.arg_info]
             for arg in args:
                 random_fill(arg)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -512,7 +512,7 @@ def run_through_rpc(measure_input, build_result,
             args = [nd.array(x, ctx=ctx) for x in ref_input]
         else:
             assert tvm.get_global_func("tvm.contrib.random.random_fill", True), \
-                "Do you enable USE_RANDOM in the config.cmake?"
+                "Please make sure USE_RANDOM is ON in the config.cmake"
             random_fill = remote.get_function("tvm.contrib.random.random_fill")
             args = [nd.empty(x[0], dtype=x[1], ctx=ctx) for x in build_result.arg_info]
             for arg in args:

--- a/tests/python/unittest/test_auto_scheduler_measure.py
+++ b/tests/python/unittest/test_auto_scheduler_measure.py
@@ -165,7 +165,7 @@ def test_record_pragma_storage_align_rfactor():
     record_common(dag, s)
 
 
-def test_measure_local_builder_runner():
+def test_measure_local_builder_runner(enable_cpu_cache_flush=False):
     if not tvm.testing.device_enabled("llvm"):
         return
 
@@ -175,7 +175,8 @@ def test_measure_local_builder_runner():
 
     minp = auto_scheduler.MeasureInput(task, s0)
     local_builder = auto_scheduler.LocalBuilder()
-    local_runner = auto_scheduler.LocalRunner(timeout=60)
+    local_runner = auto_scheduler.LocalRunner(timeout=60,
+                                              enable_cpu_cache_flush=enable_cpu_cache_flush)
 
     bress = local_builder.build([minp])
     assert bress[0].error_no == 0
@@ -183,7 +184,7 @@ def test_measure_local_builder_runner():
     assert mress[0].error_no == 0
 
 
-def test_measure_local_builder_rpc_runner():
+def test_measure_local_builder_rpc_runner(enable_cpu_cache_flush=False):
     if not tvm.testing.device_enabled("llvm"):
         return
 
@@ -193,7 +194,8 @@ def test_measure_local_builder_rpc_runner():
 
     minp = auto_scheduler.MeasureInput(task, s0)
     local_builder = auto_scheduler.LocalBuilder()
-    measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=60)
+    measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=60,
+                                                        enable_cpu_cache_flush=enable_cpu_cache_flush)
     rpc_runner = measure_ctx.runner
 
     bress = local_builder.build([minp])
@@ -207,5 +209,8 @@ if __name__ == "__main__":
     test_record_compute_at_root_inline_cache_read_write()
     test_record_follow_split_follow_fused_split()
     test_record_pragma_storage_align_rfactor()
-    test_measure_local_builder_runner()
-    test_measure_local_builder_rpc_runner()
+    test_measure_local_builder_runner(enable_cpu_cache_flush=True)
+    test_measure_local_builder_runner(enable_cpu_cache_flush=False)
+    test_measure_local_builder_rpc_runner(enable_cpu_cache_flush=True)
+    test_measure_local_builder_rpc_runner(enable_cpu_cache_flush=False)
+


### PR DESCRIPTION
Follow up #5913 and #5914 , enable AutoTVM / Ansor support random fill and CPU cache flush to get preciser measurement.

@merrymercy @jcf94 
