### PR TITLE
[Relay] Remove unnecessary std::forward

### DIFF
--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -55,11 +55,11 @@ class ExprFunctor;
 
 // functions to be overriden.
 #define EXPR_FUNCTOR_DEFAULT \
-  { return VisitExprDefault_(op, std::forward<Args>(args)...); }
+  { return VisitExprDefault_(op, args...); }
 
-#define RELAY_EXPR_FUNCTOR_DISPATCH(OP)                                                    \
-  vtable.template set_dispatch<OP>([](const ObjectRef& n, TSelf* self, Args... args) {     \
-    return self->VisitExpr_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
+#define RELAY_EXPR_FUNCTOR_DISPATCH(OP)                                                \
+  vtable.template set_dispatch<OP>([](const ObjectRef& n, TSelf* self, Args... args) { \
+    return self->VisitExpr_(static_cast<const OP*>(n.get()), args...);                 \
   });
 
 template <typename R, typename... Args>
@@ -79,7 +79,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
    * \param args Additional arguments.
    * \return The result of the call
    */
-  R operator()(const Expr& n, Args... args) { return VisitExpr(n, std::forward<Args>(args)...); }
+  R operator()(const Expr& n, Args... args) { return VisitExpr(n, args...); }
   /*!
    * \brief The functor call.
    * \param n The expression node.
@@ -89,7 +89,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr(const Expr& n, Args... args) {
     CHECK(n.defined());
     static FType vtable = InitVTable();
-    return vtable(n, this, std::forward<Args>(args)...);
+    return vtable(n, this, args...);
   }
   // Functions that can be overriden by subclass
   virtual R VisitExpr_(const ConstantNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;

--- a/include/tvm/tir/expr_functor.h
+++ b/include/tvm/tir/expr_functor.h
@@ -76,11 +76,11 @@ class ExprFunctor;
 
 // functions to be overriden.
 #define EXPR_FUNCTOR_DEFAULT \
-  { return VisitExprDefault_(op, std::forward<Args>(args)...); }
+  { return VisitExprDefault_(op, args...); }
 
-#define IR_EXPR_FUNCTOR_DISPATCH(OP)                                                       \
-  vtable.template set_dispatch<OP>([](const ObjectRef& n, TSelf* self, Args... args) {     \
-    return self->VisitExpr_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
+#define IR_EXPR_FUNCTOR_DISPATCH(OP)                                                   \
+  vtable.template set_dispatch<OP>([](const ObjectRef& n, TSelf* self, Args... args) { \
+    return self->VisitExpr_(static_cast<const OP*>(n.get()), args...);                 \
   });
 
 template <typename R, typename... Args>
@@ -100,9 +100,7 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
    * \param args Additional arguments.
    * \return The result of the call
    */
-  R operator()(const PrimExpr& n, Args... args) {
-    return VisitExpr(n, std::forward<Args>(args)...);
-  }
+  R operator()(const PrimExpr& n, Args... args) { return VisitExpr(n, args...); }
   /*!
    * \brief The functor call.
    * \param n The expression node.
@@ -111,12 +109,12 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
    */
   virtual R VisitExpr(const PrimExpr& n, Args... args) {
     static FType vtable = InitVTable();
-    return vtable(n, this, std::forward<Args>(args)...);
+    return vtable(n, this, args...);
   }
   // Functions that can be overriden by subclass
   virtual R VisitExpr_(const VarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const SizeVarNode* op, Args... args) {
-    return VisitExpr_(static_cast<const VarNode*>(op), std::forward<Args>(args)...);
+    return VisitExpr_(static_cast<const VarNode*>(op), args...);
   }
   virtual R VisitExpr_(const BufferLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const ProducerLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;


### PR DESCRIPTION
In these places, the parameter `args` is lvalue. std::forward will
always give lvalue, so we don't need it anymore.
