### PR TITLE
[TEST] Remove unintentional pytest dependency

### DIFF
--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -51,9 +51,6 @@ from . import target
 # tvm.te
 from . import te
 
-# tvm.testing
-from . import testing
-
 # tvm.driver
 from .driver import build, lower
 


### PR DESCRIPTION
This removes an unintentional dependency on `pytest`, that exists on `python/tvm/__init__.py`.

Fix #6398

cc @tqchen @tkonolige @d-smirnov 