### PR TITLE
add -static-libgcc to target_link_libraries for tvm to fix arm64 nati…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,7 @@ if(USE_THREADS AND NOT BUILD_FOR_HEXAGON)
   target_link_libraries(tvm_runtime Threads::Threads)
 endif()
 
-target_link_libraries(tvm ${TVM_LINKER_LIBS} ${TVM_RUNTIME_LINKER_LIBS})
+target_link_libraries(tvm -static-libgcc ${TVM_LINKER_LIBS} ${TVM_RUNTIME_LINKER_LIBS})
 target_link_libraries(tvm_runtime ${TVM_RUNTIME_LINKER_LIBS})
 
 # Related headers


### PR DESCRIPTION
add -static-libgcc to target_link_libraries for tvm to fix arm64 native build.

The central issue /tvm/build/libtvm.so: undefined symbol: __extendhftf2 manifests itself
when first loading libtvm.so.

This is due to src/relay/transforms/pattern_util.h making use of
reinterpret_cast<__fp16*>(array->data)[i];

It could be argued this is a distro (debian)  gcc compiler bug and that avenue
is being looked into. In the meantime, this fixes the issue.

Fixes https://github.com/apache/incubator-tvm/issues/6415

Signed-off-by: Tom Gall <tom.gall@linaro.org>
