### PR TITLE
[WIP][Windows] VS 2019 build fix

### DIFF
--- a/tests/azure-pipelines/main.yml
+++ b/tests/azure-pipelines/main.yml
@@ -42,9 +42,9 @@ jobs:
         solution: 'build.common/ALL_BUILD.vcxproj'
         maximumCpuCount: true
         configuration: 'Debug'
-  - job: Windows_VS2017_x64
+  - job: Windows_VS2019_x64
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     steps:
     - script: git submodule update --recursive --init
       displayName: Initialize submodules


### PR DESCRIPTION
This is a WIP PR.

Building TVM on VS2019 triggers an internal compiler error. Before issuing a fix, the goal is to be able to trigger the bug in CI first. 