### PR TITLE
Switch Windows CI to build Release instead of Debug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,11 +58,11 @@ jobs:
       working-directory: build.common
       run: >-
         cmake
-        "-DUSE_SORT=ON"
-        "-DUSE_RPC=ON"
-        "-DUSE_GRAPH_RUNTIME=ON"
-        "-DCMAKE_BUILD_TYPE=Release"
-        "-DCMAKE_CONFIGURATION_TYPES=Release"
+        -DUSE_SORT=ON
+        -DUSE_RPC=ON
+        -DUSE_GRAPH_RUNTIME=ON
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_CONFIGURATION_TYPES="Release"
         ..
 
     # configuration for Mac

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
         "-DUSE_SORT=ON"
         "-DUSE_RPC=ON"
         "-DUSE_GRAPH_RUNTIME=ON"
+        "-DCMAKE_BUILD_TYPE=Release"
+        "-DCMAKE_CONFIGURATION_TYPES=Release"
         ..
 
     # configuration for Mac

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,4 +78,4 @@ jobs:
         ..
 
     - name: Build
-      run: cmake --build build.common -j3
+      run: cmake --build build.common --config Release -j3

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ tvm_t.*
 .local
 cmake-build-debug
 
+# Visual Studio
+.vs
+
 # Visual Studio Code
 .vscode
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -134,7 +134,13 @@ In order to generate the VS solution file using cmake, make sure you have a rece
   cd build
   cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release" ..
 
-This will generate the VS project using the MSVC 14 64 bit generator.
+Starting with Visual Studio 2019 the architecture is specified differently so use this command
+
+.. code:: bash
+
+  cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES="Release" ..
+
+This will generate the VS project using the MSVC 64 bit generator.
 Open the .sln file in the build directory and build with Visual Studio.
 In order to build with LLVM in windows, you will need to build LLVM from source.
 

--- a/src/arith/solve_linear_inequality.cc
+++ b/src/arith/solve_linear_inequality.cc
@@ -407,6 +407,9 @@ PartialSolvedInequalities SolveLinearInequalities(const IntConstraints& system_t
   return {res_bounds, other_conditions};
 }
 
+#ifdef _MSC_VER
+#pragma optimize("g", off)
+#endif
 IntConstraints SolveInequalitiesToRange(const IntConstraints& inequalities) {
   // Resulting ranges will contain ranges for the new variables and for the variables that are
   // not in the inequalities->variables but are in inequalities->ranges
@@ -439,6 +442,8 @@ IntConstraints SolveInequalitiesToRange(const IntConstraints& inequalities) {
       // There is an equation of the form `v == expr`, so this variable can be completely removed.
       // Note that we use the 0-th expression because they are ordered by complexity,
       // so it must be the simplest one.
+      // The MSVC compiler optimization must be disabled for the expression `bnd->equal[0]` which
+      // triggers an internal compiler error.
       Range best_range(bnd->equal[0],
                        analyzer.Simplify(bnd->equal[0] + 1, kSimplifyRewriteCanonicalRewrite));
       res_ranges.Set(var, best_range);
@@ -477,6 +482,9 @@ IntConstraints SolveInequalitiesToRange(const IntConstraints& inequalities) {
 
   return system;
 }
+#ifdef _MSC_VER
+#pragma optimize("g", on)
+#endif
 
 IntConstraintsTransform SolveInequalitiesDeskewRange(const IntConstraints& inequalities) {
   // Resulting ranges will contain ranges for the new variables and for the variables that are


### PR DESCRIPTION
This PR sets the Windows build to Release instead of Debug. ~This should fail CI, which is good because there is a bug that only shows with Release builds. If this fails CI then we can move forward with the fix.~

Success in failure. cmake is configured correctly to make a Release build which triggers the Internal compiler error in commit 3ca2d252062995978fb8c6aa5ec17dc961c4496a
`D:\a\incubator-tvm\incubator-tvm\src\arith\solve_linear_inequality.cc(410): fatal error C1001: Internal compiler error. `

Compiler optimization needed to be disabled for a single function in order to build Release using MSVC.

I updated the docs to include how to use visual studio 2019 for building.
