### PR TITLE
[ConvertLayout] Use a packed function to decide layout based on operator attributes

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -321,9 +321,14 @@ TVM_DLL Pass AlterOpLayout();
  * \param desired_layouts Specify mapping of op_name to array of desired layouts for each input.
  *                        For example: Map("nn.conv2d", Array("NHWC", "OHWI")),
  *                        this specifies the desired layout for data then kernel for nn.conv2d.
+ * \param custom_layout Specify a function which will take in: the name of the operator, the call
+ *                      attributes and the call arguments, which then returns a list of layouts. Use
+ *                      this option when you need to check the characteristics of an operator
+ *                      before deciding the layout to use.
  * \return The pass.
  */
-TVM_DLL Pass ConvertLayout(const Map<String, Array<String>>& desired_layouts);
+TVM_DLL Pass ConvertLayout(const Map<String, Array<String>>& desired_layouts,
+                           const PackedFunc& custom_layout = PackedFunc());
 
 /*!
  * \brief Legalizes an expr with another expression.

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -383,7 +383,7 @@ def AlterOpLayout():
     return _ffi_api.AlterOpLayout()
 
 
-def ConvertLayout(desired_layouts):
+def ConvertLayout(desired_layouts, custom_layout=None):
     """ Given a dest layout, this pass transforms the expr such that most of the ops input data
     layout is changed to the dest layout. In ideal situation, there are only 2 layout transforms,
     one at the start and one at the end.
@@ -405,13 +405,17 @@ def ConvertLayout(desired_layouts):
         defined by the operator. An example for nn.conv2d could be: {"nn.conv2d", ["NHWC", "OHWI]},
         where the first item in the list specifies the data layout and the second specifies the
         kernel layout.
+    custom_layout : Callable[[str, tvm.relay.op.op_attrs, tvm.ir.container.Array], List[str]]
+        Specify a function which will take in: the name of the operator, the call attributes
+        and the call arguments, which then returns a list of layouts. Use this option when you
+        need to check the characteristics of an operator before deciding the layout to use.
 
     Returns
     -------
     pass: FunctionPass
       The pass.
     """
-    return _ffi_api.ConvertLayout(desired_layouts)
+    return _ffi_api.ConvertLayout(desired_layouts, custom_layout)
 
 
 def Legalize(legalize_map_attr_name="FTVMLegalize"):


### PR DESCRIPTION
Allows the user to specify a 'custom' label on the operators they wish to use a separate function to determine the layout, rather than relying on purely the operator name. One use-case example of this is were one might require a different layout for depth-wise convolution and other types of convolution. e.g. IHWO for depthwise, else OHWI.

See convert_layout.rst for a more detailed explanation.

cc @anijain2305 @manupa-arm @mbaret
