### PR TITLE
[METAL] set MTLBuffer purgeable state (#6376)

### DIFF
--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -255,7 +255,7 @@ void MetalWorkspace::FreeWorkspace(TVMContext ctx, void* data) {
 
 MetalThreadEntry::~MetalThreadEntry() {
   for (auto x : temp_buffer_) {
-    if (x != nil){
+    if (x != nil) {
       [(id<MTLBuffer>)x setPurgeableState:MTLPurgeableStateEmpty];
       [x release];
     }

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -164,6 +164,9 @@ void* MetalWorkspace::AllocDataSpace(TVMContext ctx, size_t nbytes, size_t align
 }
 
 void MetalWorkspace::FreeDataSpace(TVMContext ctx, void* ptr) {
+  // MTLBuffer PurgeableState should be set to empty before manual
+  // release in order to prevent memory leak
+  [(id<MTLBuffer>)ptr setPurgeableState:MTLPurgeableStateEmpty];
   // release the ptr.
   CFRelease(ptr);
 }
@@ -252,7 +255,10 @@ void MetalWorkspace::FreeWorkspace(TVMContext ctx, void* data) {
 
 MetalThreadEntry::~MetalThreadEntry() {
   for (auto x : temp_buffer_) {
-    if (x != nil) [x release];
+    if (x != nil){
+      [(id<MTLBuffer>)x setPurgeableState:MTLPurgeableStateEmpty];
+      [x release];
+    }
   }
 }
 


### PR DESCRIPTION
When using manual reference counting, MTLBuffer purgeable state should be set before releasing.

cc @tqchen 

Resolves most of the issue reported in issue (#6376) .
Approx ~800KB memory leak still occurs when loading a new or reloading a model.
