### PR TITLE
[topi, x86] For 1D loop, make an outer loop parallel after axis split

### DIFF
--- a/python/tvm/topi/x86/injective.py
+++ b/python/tvm/topi/x86/injective.py
@@ -46,8 +46,14 @@ def schedule_injective_from_existing(sch, out):
     # Vectorize the inner most for loop. Tiling first to get a const extent
     if len(sch[out].op.axis) >= 1:
         l = sch[out].op.axis[-1]
-        _, li = sch[out].split(l, factor=16)
+        lo, li = sch[out].split(l, factor=16)
         sch[out].vectorize(li)
+
+        # for 1D loop, the above split will break the parallel axis
+        # Need to make the outer loop parallel again
+        if len(sch[out].op.axis) == 1:
+            sch[out].parallel(lo)
+
     return sch
 
 def schedule_injective(outs):


### PR DESCRIPTION
I found an interesting multithreading logic bug in x86 injective schedule, for 1D loop workload. Even though this line https://github.com/apache/incubator-tvm/blob/master/python/tvm/topi/x86/injective.py#L44 would make the entire 1D loop parallel, this `split` https://github.com/apache/incubator-tvm/blob/master/python/tvm/topi/x86/injective.py#L49 would break the parallel loop and leave the outer loop after split single threaded.

I found this while investigating a CPU performance issue with models coming from [hummingbird](https://github.com/microsoft/hummingbird) project. For example, [this loop](https://gist.github.com/masahi/21dc3dd9c37cb129aa3be6018c22ffa5#file-lower_20000-txt-L68) is properly parallelized, while other loops like [this](https://gist.github.com/masahi/21dc3dd9c37cb129aa3be6018c22ffa5#file-lower_20000-txt-L95) is single threaded.

please review @anijain2305 @yzhliu @kevinthesun 