### PR TITLE
[FIX,TESTING] Add tvm.testing to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ os.environ["TVM_BUILD_DOC"] = "1"
 import tvm
 from tvm import topi
 from tvm import te
+from tvm import testing
 
 version = tvm.__version__
 release = tvm.__version__

--- a/docs/contribute/code_guide.rst
+++ b/docs/contribute/code_guide.rst
@@ -94,7 +94,7 @@ If you want your test to run over a variety of targets, use the :py:func:`tvm.te
   def test_mytest(target, ctx):
     ...
 
-will run `test_mytest` with `target="llvm"`, `target="cuda"`, and few others. This also ensures that your test is run on the correct hardware by the CI. If you only want to test against a couple targets use `@tvm.testing.parametrize_targets("target_1", "target_2")`. If you want to test on a single target, use the associated decorator from :py:func:`tvm.testing`. For example, CUDA tests use the `@tvm.testing.requires_cuda` decorator.
+will run ``test_mytest`` with ``target="llvm"``, ``target="cuda"``, and few others. This also ensures that your test is run on the correct hardware by the CI. If you only want to test against a couple targets use ``@tvm.testing.parametrize_targets("target_1", "target_2")``. If you want to test on a single target, use the associated decorator from :py:func:`tvm.testing`. For example, CUDA tests use the ``@tvm.testing.requires_cuda`` decorator.
 
 Handle Integer Constant Expression
 ----------------------------------


### PR DESCRIPTION
`tvm.testing` was not previously included in the docs. This PR should add it. (I don't actually know if this works because I can't build the docs locally).
