### PR TITLE
Add a make style target for linux and hopefully macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,3 +485,11 @@ if(MSVC)
   target_compile_definitions(tvm_objs PRIVATE -DTVM_EXPORTS)
   target_compile_definitions(tvm_runtime_objs PRIVATE -DTVM_EXPORTS)
 endif()
+
+if(UNIX)
+  add_custom_target(style
+    COMMENT "Applying clang-format style"
+    COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/cmake/util/Style.cmake
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
+endif(UNIX)

--- a/cmake/util/Style.cmake
+++ b/cmake/util/Style.cmake
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(DIRS
+  src
+  include
+  golang
+  nnvm
+  tests
+)
+foreach(DIR ${DIRS})
+  message(STATUS "Applying style to ${DIR}")
+  execute_process(
+    COMMAND find ${DIR} -name *.cc -exec clang-format-10 -i {} +
+    COMMAND find ${DIR} -name *.h -exec clang-format-10 -i {} +
+  )
+endforeach()


### PR DESCRIPTION
Add a new target `make style` which applies clang-format to all *.cc and *.h file in the following directories. You will need to have clang-format-10 installed.
The directory list processed is
* src
* include
* golang
* nnvm
* tests
I did not test if this works in macos but it does work on ubuntu