### PR TITLE
[RPC][REFACTOR] Update RPC module to enable remote linking.

### DIFF
--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -66,6 +66,26 @@ std::string GenerateUntarCommand(const std::string& tar_file, const std::string&
 
 namespace tvm {
 namespace runtime {
+
+/*!
+ * \brief CleanDir Removes the files from the directory
+ * \param dirname THe name of the directory
+ */
+void CleanDir(const std::string& dirname);
+
+/*!
+ * \brief buld a shared library if necessary
+ *
+ *        This function will automatically call
+ *        cc.create_shared if the path is in format .o or .tar
+ *        High level handling for .o and .tar file.
+ *        We support this to be consistent with RPC module load.
+ * \param file_in The input file path.
+ *
+ * \return The name of the shared library.
+ */
+std::string BuildSharedLibrary(std::string file_in);
+
 RPCEnv::RPCEnv() {
 #ifndef _WIN32
   char cwd[PATH_MAX];
@@ -79,17 +99,29 @@ RPCEnv::RPCEnv() {
 #endif
 
   mkdir(base_.c_str(), 0777);
-  TVM_REGISTER_GLOBAL("tvm.rpc.server.workpath").set_body([](TVMArgs args, TVMRetValue* rv) {
-    static RPCEnv env;
-    *rv = env.GetPath(args[0]);
+  TVM_REGISTER_GLOBAL("tvm.rpc.server.workpath").set_body([this](TVMArgs args, TVMRetValue* rv) {
+    *rv = this->GetPath(args[0]);
   });
 
-  TVM_REGISTER_GLOBAL("tvm.rpc.server.load_module").set_body([](TVMArgs args, TVMRetValue* rv) {
-    static RPCEnv env;
-    std::string file_name = env.GetPath(args[0]);
-    *rv = Load(&file_name, "");
+  TVM_REGISTER_GLOBAL("tvm.rpc.server.load_module").set_body([this](TVMArgs args, TVMRetValue* rv) {
+    std::string file_name = this->GetPath(args[0]);
+    file_name = BuildSharedLibrary(file_name);
+    *rv = Module::LoadFromFile(file_name, "");
     LOG(INFO) << "Load module from " << file_name << " ...";
   });
+
+  TVM_REGISTER_GLOBAL("tvm.rpc.server.download_linked_module")
+      .set_body([this](TVMArgs args, TVMRetValue* rv) {
+        std::string file_name = this->GetPath(args[0]);
+        file_name = BuildSharedLibrary(file_name);
+        std::string bin;
+        LoadBinaryFromFile(file_name, &bin);
+        TVMByteArray binarr;
+        binarr.data = bin.data();
+        binarr.size = bin.length();
+        *rv = binarr;
+        LOG(INFO) << "Send linked module " << file_name << " to client";
+      });
 }
 /*!
  * \brief GetPath To get the work path from packed function
@@ -229,27 +261,14 @@ void CreateShared(const std::string& output, const std::vector<std::string>& fil
 #endif
 }
 
-/*!
- * \brief Load Load module from file
-          This function will automatically call
-          cc.create_shared if the path is in format .o or .tar
-          High level handling for .o and .tar file.
-          We support this to be consistent with RPC module load.
- * \param fileIn The input file, file name will be updated
- * \param fmt The format of file
- * \return Module The loaded module
- */
-Module Load(std::string* fileIn, const std::string& fmt) {
-  const std::string& file = *fileIn;
+std::string BuildSharedLibrary(std::string file) {
   if (support::EndsWith(file, ".so") || support::EndsWith(file, ".dll")) {
-    return Module::LoadFromFile(file, fmt);
+    return file;
   }
 
   std::string file_name = file + ".so";
   if (support::EndsWith(file, ".o")) {
-    std::vector<std::string> files;
-    files.push_back(file);
-    CreateShared(file_name, files);
+    CreateShared(file_name, {file});
   } else if (support::EndsWith(file, ".tar")) {
     const std::string tmp_dir = "./rpc/tmp/";
     mkdir(tmp_dir.c_str(), 0777);
@@ -267,8 +286,7 @@ Module Load(std::string* fileIn, const std::string& fmt) {
   } else {
     file_name = file;
   }
-  *fileIn = file_name;
-  return Module::LoadFromFile(file_name, fmt);
+  return file_name;
 }
 
 /*!

--- a/apps/cpp_rpc/rpc_env.h
+++ b/apps/cpp_rpc/rpc_env.h
@@ -32,24 +32,6 @@ namespace tvm {
 namespace runtime {
 
 /*!
- * \brief Load Load module from file
-          This function will automatically call
-          cc.create_shared if the path is in format .o or .tar
-          High level handling for .o and .tar file.
-          We support this to be consistent with RPC module load.
- * \param file The input file
- * \param file The format of file
- * \return Module The loaded module
- */
-Module Load(std::string* path, const std::string& fmt = "");
-
-/*!
- * \brief CleanDir Removes the files from the directory
- * \param dirname THe name of the directory
- */
-void CleanDir(const std::string& dirname);
-
-/*!
  * \brief RPCEnv The RPC Environment parameters for c++ rpc server
  */
 struct RPCEnv {

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -160,6 +160,42 @@ class RPCSession(object):
         """
         return _ffi_api.LoadRemoteModule(self._sess, path)
 
+    def download_linked_module(self, path):
+        """Link a module in the remote and download it.
+
+        Parameters
+        ----------
+        path : str
+            The relative location to remote temp folder.
+
+        Returns
+        -------
+        blob : bytearray
+            The result blob from the file.
+
+        Note
+        ----
+        This function can be helpful when a linker
+        is not available on the local client.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            mod = build_module_with_cross_compilation()
+            # export the module as tar because a local linker is not available
+            mod.export_library("lib.tar")
+            remote.upload("lib.tar")
+            # invoke the linker on the remote to link the module as a library
+            # note that the library can only run on the same env as the remote
+            with open("lib.so", "wb") as file:
+                file.write(remote.download_linked_module("lib.tar"))
+        """
+        if "download_linked_module" not in self._remote_funcs:
+            self._remote_funcs["download_linked_module"] = self.get_function(
+                "tvm.rpc.server.download_linked_module")
+        return self._remote_funcs["download_linked_module"](path)
+
     def cpu(self, dev_id=0):
         """Construct CPU device."""
         return self.context(1, dev_id)

--- a/tests/python/unittest/test_runtime_rpc.py
+++ b/tests/python/unittest/test_runtime_rpc.py
@@ -220,6 +220,19 @@ def test_rpc_remote_module():
         print("%g secs/op" % cost)
         np.testing.assert_equal(b.asnumpy(), a.asnumpy() + 1)
 
+        # Download the file from the remote
+        path_tar = temp.relpath("dev_lib.tar")
+        f.export_library(path_tar)
+        remote.upload(path_tar)
+        local_download_path = temp.relpath("dev_lib.download.so")
+        with open(local_download_path, "wb") as fo:
+            fo.write(remote.download_linked_module("dev_lib.tar"))
+        fupdated = tvm.runtime.load_module(local_download_path)
+        a = tvm.nd.array(np.random.uniform(size=102).astype(A.dtype), tvm.cpu(0))
+        b = tvm.nd.array(np.zeros(102, dtype=A.dtype), tvm.cpu(0))
+        fupdated(a, b)
+        np.testing.assert_equal(b.asnumpy(), a.asnumpy() + 1)
+
     def check_minrpc():
         if tvm.get_global_func("rpc.PopenSession", allow_missing=True) is None:
             return


### PR DESCRIPTION
Remote linking is useful when the linker is not available
on the host environment.

