### PR TITLE
Add new target style to apply clang-format style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,3 +499,9 @@ if(MSVC)
   target_compile_definitions(tvm_objs PRIVATE -DTVM_EXPORTS)
   target_compile_definitions(tvm_runtime_objs PRIVATE -DTVM_EXPORTS)
 endif()
+
+add_custom_target(style
+  COMMENT "Applying clang-format style"
+  COMMAND tests/lint/git-clang-format.sh -i -f HEAD~1
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)


### PR DESCRIPTION
Add a new style target so style can be applied using the command `make style`

