### PR TITLE
[PY] GraphRuntime: Update the tutorials to the module-based interface

### DIFF
--- a/apps/benchmark/mobile_gpu_imagenet_bench.py
+++ b/apps/benchmark/mobile_gpu_imagenet_bench.py
@@ -40,7 +40,7 @@ def evaluate_network(network, target, target_host, dtype, repeat):
 
     print_progress("%-20s building..." % network)
     with tvm.transform.PassContext(opt_level=3):
-        graph, lib, params = relay.build(net, target=target, target_host=target_host, params=params)
+        lib = relay.build(net, target=target, target_host=target_host, params=params)
 
     tmp = tempdir()
     if "android" in str(target) or "android" in str(target_host):
@@ -58,10 +58,9 @@ def evaluate_network(network, target, target_host, dtype, repeat):
     remote.upload(tmp.relpath(filename))
 
     rlib = remote.load_module(filename)
-    module = runtime.create(graph, rlib, ctx)
+    module = runtime.GraphModule(rlib["default"](ctx))
     data_tvm = tvm.nd.array((np.random.uniform(size=input_shape)).astype(dtype))
     module.set_input("data", data_tvm)
-    module.set_input(**params)
 
     # evaluate
     print_progress("%-20s evaluating..." % network)

--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -47,6 +47,12 @@ def create(graph_json_str, libmod, ctx):
     -------
     graph_module : GraphModule
         Runtime graph module that can be used to execute the graph.
+
+    Note
+    ----
+    See also :py:class:`tvm.contrib.graph_runtime.GraphModule`
+    for examples to directly construct a GraphModule from an exported
+    relay compiled library.
     """
     assert isinstance(graph_json_str, string_types)
 
@@ -121,6 +127,27 @@ class GraphModule(object):
     ----------
     module : tvm.runtime.Module
         The internal tvm module that holds the actual graph functions.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        import tvm
+        from tvm import relay
+        from tvm.contrib import graph_runtime
+
+        # build the library using graph runtime
+        lib = relay.build(...)
+        lib.export_library("compiled_lib.so")
+        # load it back as a runtime
+        lib:tvm.runtime.Module = tvm.runtime.load_module("compiled_lib.so")
+        # Call the library factory function for default and create
+        # a new runtime.Module, wrap with graph module.
+        gmod = graph_runtime.GraphModule(lib["default"](ctx))
+        # use the gmod
+        gmod.set_input("x", data)
+        gmod.run()
     """
 
     def __init__(self, module):

--- a/python/tvm/relay/backend/graph_runtime_factory.py
+++ b/python/tvm/relay/backend/graph_runtime_factory.py
@@ -74,7 +74,9 @@ class GraphRuntimeFactoryModule(object):
     def __iter__(self):
         warnings.warn(
             "legacy graph runtime behaviour of producing json / lib / params will be "
-            "removed in the next release ",
+            " removed in the next release."
+            " Please see documents of tvm.contrib.graph_runtime.GraphModule for the "
+            " new recommended usage.",
             DeprecationWarning,
             2,
         )

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -522,10 +522,9 @@ def infer_value(input_val, params, mod=None):
 
         func = _function.Function(analysis.free_vars(input_val), input_val)
         with tvm.transform.PassContext(opt_level=0):
-            graph, lib, params = tvm.relay.build(func, target="llvm", params=params)
+            lib = tvm.relay.build(func, target="llvm", params=params)
         ctx = tvm.cpu(0)
-        m = graph_runtime.create(graph, lib, ctx)
-        m.set_input(**params)
+        m = graph_runtime.GraphModule(lib["default"](ctx))
         m.run()
         return m.get_output(0)
     except Exception:

--- a/python/tvm/relay/param_dict.py
+++ b/python/tvm/relay/param_dict.py
@@ -44,14 +44,13 @@ def save_param_dict(params):
     --------
     .. code-block:: python
 
-       # compile and save the modules to file.
-       graph, lib, params = tvm.relay.build(func, target=target, params=params)
-       module = graph_runtime.create(graph, lib, tvm.gpu(0))
+       # set up the parameter dict
+       params = {"param0": arr0, "param1": arr1}
        # save the parameters as byte array
        param_bytes = tvm.relay.save_param_dict(params)
        # We can serialize the param_bytes and load it back later.
        # Pass in byte array to module to directly set parameters
-       module.load_params(param_bytes)
+       graph_runtime_mod.load_params(param_bytes)
     """
     args = []
     for k, v in params.items():

--- a/python/tvm/relay/quantize/_calibrate.py
+++ b/python/tvm/relay/quantize/_calibrate.py
@@ -45,9 +45,8 @@ def _get_profile_runtime(mod):
         ctx = tvm.context(target)
 
     with tvm.transform.PassContext(opt_level=3):
-        graph, lib, params = _build_module.build(func, target=target)
-    runtime = graph_runtime.create(graph, lib, ctx)
-    runtime.set_input(**params)
+        lib = _build_module.build(func, target=target)
+    runtime = graph_runtime.GraphModule(lib["default"](ctx))
 
     return runtime
 

--- a/tests/python/contrib/test_coreml_codegen.py
+++ b/tests/python/contrib/test_coreml_codegen.py
@@ -102,8 +102,8 @@ def test_compile_and_run():
     tol = 1e-3
 
     with relay.build_config(opt_level=3):
-        json, lib, params = relay.build(_create_graph_annotated(), target=target)
-    m = tvm.contrib.graph_runtime.create(json, lib, ctx)
+        lib = relay.build(_create_graph_annotated(), target=target)
+    m = tvm.contrib.graph_runtime.GraphModule(lib["default"](ctx))
 
     shape = (10, 10)
     x_data = np.random.rand(*shape).astype("float32")
@@ -111,7 +111,6 @@ def test_compile_and_run():
 
     m.set_input("x", x_data)
     m.set_input("y", y_data)
-    m.set_input(**params)
     m.run()
     out = tvm.nd.empty(shape, ctx=ctx)
     out = m.get_output(0, out)

--- a/tests/python/contrib/test_ethosn/infrastructure.py
+++ b/tests/python/contrib/test_ethosn/infrastructure.py
@@ -115,16 +115,15 @@ def build(mod, params, npu=True, expected_host_ops=0, npu_partitions=1):
             return relay.build(mod, params=params)
 
 
-def run(graph, lib, params, inputs, outputs, npu=True):
+def run(lib, inputs, outputs, npu=True):
     # Export and load lib to confirm this works
     lib_name = "mod.so"
     temp = util.tempdir()
     lib_path = temp.relpath(lib_name)
     lib.export_library(lib_path)
     lib = tvm.runtime.load_module(lib_path)
-    module = graph_runtime.create(graph, lib, tvm.cpu())
+    module = graph_runtime.GraphModule(lib["default"](tvm.cpu()))
     module.set_input(**inputs)
-    module.set_input(**params)
     module.run()
     out = [module.get_output(i) for i in range(outputs)]
     if not npu:
@@ -135,8 +134,8 @@ def run(graph, lib, params, inputs, outputs, npu=True):
 def build_and_run(
     mod, inputs, outputs, params, ctx=tvm.cpu(), npu=True, expected_host_ops=0, npu_partitions=1
 ):
-    graph, lib, params = build(mod, params, npu, expected_host_ops, npu_partitions)
-    return run(graph, lib, params, inputs, outputs, npu)
+    lib = build(mod, params, npu, expected_host_ops, npu_partitions)
+    return run(lib, inputs, outputs, npu)
 
 
 def verify(answers, atol, rtol=1e-07, verify_saturation=True):

--- a/tests/python/contrib/test_ethosn/test_topologies.py
+++ b/tests/python/contrib/test_ethosn/test_topologies.py
@@ -123,7 +123,7 @@ def test_input_tuples():
             mod = tei.make_module(model, {})
         else:
             mod = tei.make_ethosn_partition(model)
-        graph, lib, params = tei.build(mod, {}, npu=False)
-        outputs.append(tei.run(graph, lib, {}, inputs, 1, npu=npu))
+        lib = tei.build(mod, {}, npu=False)
+        outputs.append(tei.run(lib, inputs, 1, npu=npu))
 
     tei.verify(outputs, 0)

--- a/tests/python/frontend/caffe2/test_forward.py
+++ b/tests/python/frontend/caffe2/test_forward.py
@@ -40,13 +40,12 @@ def get_tvm_output(model, input_data, target, ctx, output_shape, output_dtype="f
         model.init_net, model.predict_net, shape_dict, dtype_dict
     )
     with tvm.transform.PassContext(opt_level=3):
-        graph, lib, params = relay.build(mod, target, params=params)
+        lib = relay.build(mod, target, params=params)
 
-    m = graph_runtime.create(graph, lib, ctx)
+    m = graph_runtime.GraphModule(lib["default"](ctx))
 
     # set inputs
     m.set_input(input_names, tvm.nd.array(input_data.astype(input_data.dtype)))
-    m.set_input(**params)
 
     # execute
     m.run()

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -77,11 +77,10 @@ def verify_mxnet_frontend_impl(
                 symbol, shape_dict, arg_params=args, aux_params=auxs
             )
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build(mod, target, params=params)
-        m = graph_runtime.create(graph, lib, ctx)
+            lib = relay.build(mod, target, params=params)
+        m = graph_runtime.GraphModule(lib["default"](ctx))
         # set inputs
         m.set_input("data", tvm.nd.array(x.astype(dtype)))
-        m.set_input(**params)
         m.run()
         # get outputs
         out = m.get_output(0, tvm.nd.empty(out_shape, dtype))

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -45,10 +45,9 @@ def get_tvm_runtime(script_module, input_name, ishape):
     with tvm.transform.PassContext(opt_level=3):
         # test on only cpu for now, torch cannot run quant models on cuda
         # also not to make CI too slow
-        json, lib, params = relay.build(mod, target="llvm", params=params)
+        lib = relay.build(mod, target="llvm", params=params)
 
-    runtime = tvm.contrib.graph_runtime.create(json, lib, tvm.cpu(0))
-    runtime.set_input(**params)
+    runtime = tvm.contrib.graph_runtime.GraphModule(lib["default"](tvm.cpu(0)))
     return runtime
 
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -199,17 +199,15 @@ def run_tvm_graph(
         return vmobj_to_list(result)
     else:
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build(mod, target, params=params)
+            lib = relay.build(mod, target, params=params)
 
         ctx = tvm.context(target, 0)
         from tvm.contrib import graph_runtime
 
-        m = graph_runtime.create(graph, lib, ctx)
+        m = graph_runtime.GraphModule(lib["default"](ctx))
         # set inputs
         for i, e in enumerate(input_node):
             m.set_input(e, tvm.nd.array(input_data[i].astype(input_data[i].dtype)))
-
-        m.set_input(**params)
         # execute
         m.run()
         # get outputs

--- a/tests/python/relay/benchmarking/benchmark_vm.py
+++ b/tests/python/relay/benchmarking/benchmark_vm.py
@@ -40,12 +40,11 @@ def benchmark_execution(
         mod, data, params, target, ctx, dtype="float32", number=2, repeat=20
     ):
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build(mod, target, params=params)
+            lib = relay.build(mod, target, params=params)
 
-        m = graph_runtime.create(graph, lib, ctx)
+        m = graph_runtime.GraphModule(lib["default"](ctx))
         # set inputs
         m.set_input("data", data)
-        m.set_input(**params)
         m.run()
         out = m.get_output(0, tvm.nd.empty(out_shape, dtype))
 

--- a/tests/python/relay/test_cpp_build_module.py
+++ b/tests/python/relay/test_cpp_build_module.py
@@ -44,13 +44,12 @@ def test_basic_build():
     func_in_mod = mod["main"]
     assert mod["main"] == func_in_mod, "cannot compare function to itself"
 
-    g_json, mmod, params = relay.build(mod, targets, "llvm", params=params)
+    lib = relay.build(mod, targets, "llvm", params=params)
     assert mod["main"] == func_in_mod, "relay.build changed module in-place"
 
     # test
-    rt = tvm.contrib.graph_runtime.create(g_json, mmod, ctx)
+    rt = tvm.contrib.graph_runtime.GraphModule(lib["default"](ctx))
     rt.set_input("a", A)
-    rt.load_params(relay.save_param_dict(params))
     rt.run()
     out = rt.get_output(0)
 

--- a/tests/python/relay/test_simplify_fc_transpose.py
+++ b/tests/python/relay/test_simplify_fc_transpose.py
@@ -29,16 +29,15 @@ from tvm.relay.data_dep_optimization import simplify_fc_transpose
 
 def run_func(func, params, x):
     with tvm.transform.PassContext(opt_level=3):
-        graph, lib, new_params = relay.build(func, "llvm", params=params)
+        lib = relay.build(func, "llvm", params=params)
 
     from tvm.contrib import graph_runtime
 
     ctx = tvm.cpu(0)
     dtype = "float32"
-    m = graph_runtime.create(graph, lib, ctx)
+    m = graph_runtime.GraphModule(lib["default"](ctx))
     # set inputs
     m.set_input("data", tvm.nd.array(x.astype(dtype)))
-    m.set_input(**new_params)
     # execute
     m.run()
     # get outputs

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -326,7 +326,7 @@ def tune_and_evaluate(tuning_opt):
     with autotvm.apply_history_best(log_file):
         print("Compile...")
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build_module.build(mod, target=target, params=params)
+            lib = relay.build_module.build(mod, target=target, params=params)
 
         # export library
         tmp = tempdir()
@@ -347,10 +347,9 @@ def tune_and_evaluate(tuning_opt):
 
         # upload parameters to device
         ctx = remote.context(str(target), 0)
-        module = runtime.create(graph, rlib, ctx)
+        module = runtime.GraphModule(rlib["default"](ctx))
         data_tvm = tvm.nd.array((np.random.uniform(size=input_shape)).astype(dtype))
         module.set_input("data", data_tvm)
-        module.set_input(**params)
 
         # evaluate
         print("Evaluate inference time cost...")

--- a/tutorials/autotvm/tune_relay_cuda.py
+++ b/tutorials/autotvm/tune_relay_cuda.py
@@ -233,7 +233,7 @@ def tune_and_evaluate(tuning_opt):
     with autotvm.apply_history_best(log_file):
         print("Compile...")
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build_module.build(mod, target=target, params=params)
+            lib = relay.build_module.build(mod, target=target, params=params)
 
         # export library
         tmp = tempdir()
@@ -242,10 +242,9 @@ def tune_and_evaluate(tuning_opt):
 
         # load parameters
         ctx = tvm.context(str(target), 0)
-        module = runtime.create(graph, lib, ctx)
+        module = runtime.GraphModule(lib["default"](ctx))
         data_tvm = tvm.nd.array((np.random.uniform(size=input_shape)).astype(dtype))
         module.set_input("data", data_tvm)
-        module.set_input(**params)
 
         # evaluate
         print("Evaluate inference time cost...")

--- a/tutorials/autotvm/tune_relay_mobile_gpu.py
+++ b/tutorials/autotvm/tune_relay_mobile_gpu.py
@@ -325,7 +325,7 @@ def tune_and_evaluate(tuning_opt):
     with autotvm.apply_history_best(log_file):
         print("Compile...")
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build_module.build(
+            lib = relay.build_module.build(
                 mod, target=target, params=params, target_host=target_host
             )
         # export library
@@ -347,10 +347,9 @@ def tune_and_evaluate(tuning_opt):
 
         # upload parameters to device
         ctx = remote.context(str(target), 0)
-        module = runtime.create(graph, rlib, ctx)
+        module = runtime.GraphModule(rlib["default"](ctx))
         data_tvm = tvm.nd.array((np.random.uniform(size=input_shape)).astype(dtype))
         module.set_input("data", data_tvm)
-        module.set_input(**params)
 
         # evaluate
         print("Evaluate inference time cost...")

--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -208,14 +208,13 @@ def tune_and_evaluate(tuning_opt):
     with autotvm.apply_graph_best(graph_opt_sch_file):
         print("Compile...")
         with tvm.transform.PassContext(opt_level=3):
-            graph, lib, params = relay.build_module.build(mod, target=target, params=params)
+            lib = relay.build_module.build(mod, target=target, params=params)
 
         # upload parameters to device
         ctx = tvm.cpu()
         data_tvm = tvm.nd.array((np.random.uniform(size=data_shape)).astype(dtype))
-        module = runtime.create(graph, lib, ctx)
+        module = runtime.GraphModule(lib["default"](ctx))
         module.set_input(input_name, data_tvm)
-        module.set_input(**params)
 
         # evaluate
         print("Evaluate inference time cost...")

--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -205,9 +205,9 @@ with autotvm.tophub.context(target):
 
     # Send the inference library over to the remote RPC server
     temp = util.tempdir()
-    lib.save(temp.relpath("graphlib.o"))
-    remote.upload(temp.relpath("graphlib.o"))
-    lib = remote.load_module("graphlib.o")
+    lib.export_library(temp.relpath("graphlib.tar"))
+    remote.upload(temp.relpath("graphlib.tar"))
+    lib = remote.load_module("graphlib.tar")
 
     # Graph runtime
     m = graph_runtime.GraphModule(lib["default"](ctx))

--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -197,9 +197,7 @@ with autotvm.tophub.context(target):
             )
     else:
         with vta.build_config(opt_level=3, disabled_pass={"AlterOpLayout"}):
-            graph, lib, params = relay.build(
-                relay_prog, target=target, params=params, target_host=env.target_host
-            )
+            lib = relay.build(relay_prog, target=target, params=params, target_host=env.target_host)
 
     # Measure Relay build time
     build_time = time.time() - build_start
@@ -212,7 +210,7 @@ with autotvm.tophub.context(target):
     lib = remote.load_module("graphlib.o")
 
     # Graph runtime
-    m = graph_runtime.create(graph, lib, ctx)
+    m = graph_runtime.GraphModule(lib["default"](ctx))
 
 ######################################################################
 # Perform image classification inference
@@ -243,7 +241,6 @@ image = image[np.newaxis, :]
 image = np.repeat(image, env.BATCH, axis=0)
 
 # Set the network parameters and inputs
-m.set_input(**params)
 m.set_input("data", image)
 
 # Perform inference and gather execution statistics

--- a/vta/tutorials/frontend/legacy/deploy_detection.py
+++ b/vta/tutorials/frontend/legacy/deploy_detection.py
@@ -242,9 +242,9 @@ with autotvm.tophub.context(target):
 
     # Send the inference library over to the remote RPC server
     temp = util.tempdir()
-    lib.save(temp.relpath("graphlib.o"))
-    remote.upload(temp.relpath("graphlib.o"))
-    lib = remote.load_module("graphlib.o")
+    lib.export_library(temp.relpath("graphlib.tar"))
+    remote.upload(temp.relpath("graphlib.tar"))
+    lib = remote.load_module("graphlib.tar")
 
     # Graph runtime
     m = graph_runtime.GraphModule(lib["default"](ctx))

--- a/vta/tutorials/frontend/legacy/deploy_detection.py
+++ b/vta/tutorials/frontend/legacy/deploy_detection.py
@@ -234,9 +234,7 @@ with autotvm.tophub.context(target):
 
     # Compile Relay program with AlterOpLayout disabled
     with vta.build_config(disabled_pass={"AlterOpLayout"}):
-        graph, lib, params = relay.build(
-            mod, target=target, params=params, target_host=env.target_host
-        )
+        lib = relay.build(mod, target=target, params=params, target_host=env.target_host)
 
     # Measure Relay build time
     build_time = time.time() - build_start
@@ -249,7 +247,7 @@ with autotvm.tophub.context(target):
     lib = remote.load_module("graphlib.o")
 
     # Graph runtime
-    m = graph_runtime.create(graph, lib, ctx)
+    m = graph_runtime.GraphModule(lib["default"](ctx))
 
 ####################################
 # Perform image detection inference.
@@ -271,7 +269,6 @@ data = np.repeat(data, env.BATCH, axis=0)
 
 # Set the network parameters and inputs
 m.set_input("data", data)
-m.set_input(**params)
 
 # Perform inference and gather execution statistics
 # More on: :py:method:`tvm.runtime.Module.time_evaluator`


### PR DESCRIPTION
Also added document about the encouraged usage.
In particular, we encourage the following usage.
```
lib = relay.build(...)
gmod = graph_runtime.GraphModule(lib["default"](ctx))
```
I have changed most of the tutorials and apps.
Some follow up PRs are needed to update some of the tests code.