### PR TITLE
[Formatting] Ignore deleted files when linting

### DIFF
--- a/tests/lint/git-black.sh
+++ b/tests/lint/git-black.sh
@@ -46,7 +46,7 @@ fi
 echo "Version Information: $(black --version)"
 
 # Compute Python files which changed to compare.
-IFS=$'\n' read -a FILES -d'\n' < <(git diff --name-only $1 -- "*.py" "*.pyi") || true
+IFS=$'\n' read -a FILES -d'\n' < <(git diff --name-only --diff-filter=ACMRTUX $1 -- "*.py" "*.pyi") || true
 echo "Read returned $?"
 if [ -z ${FILES+x} ]; then
     echo "No changes in Python files"


### PR DESCRIPTION
Ignore the deleted files in Python formatter. Per requested by #6483 
Suggestions to the filter combination are welcome.

Reference (https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203):
* Added (A)
* Copied (C)
* Deleted (D)
* Modified (M)
* Renamed (R)
* Changed (T)
* Unmerged (U)
* Unknown (X)
* Broken (B)

cc @tqchen @jroesch @areusch
