### PR TITLE
Add beagleboard ai, thunderx and stm32mp1 to the arm_cpu target.

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -272,6 +272,9 @@ def arm_cpu(model="unknown", options=None):
         "rk3399": ["-model=rk3399", "-mtriple=aarch64-linux-gnu", "-mattr=+neon"],
         "pynq": ["-model=pynq", "-mtriple=armv7a-linux-eabi", "-mattr=+neon"],
         "ultra96": ["-model=ultra96", "-mtriple=aarch64-linux-gnu", "-mattr=+neon"],
+        "beagleai": ["-model=beagleai", "-mtriple=armv7a-linux-gnueabihf", "-mattr=+neon,+vfp4,+thumb2", "-mcpu=cortex-a15"],
+        "stm32mp1": ["-model=stm32mp1", "-mtriple=armv7a-linux-gnueabihf", "-mattr=+neon,+vfp4,+thumb2"],
+        "thunderx": ["-model=thunderx", "-mtriple=aarch64-linux-gnu", "-mattr=+neon,+crc,+lse", "-mcpu=thunderxt88"],
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -219,6 +219,7 @@ def intel_graphics(model="unknown", options=None):
     opts = _merge_opts(opts, options)
     return Target(" ".join(["opencl"] + opts))
 
+
 def micro(hardware="unknown", options=None):
     """Returns a microTVM target.
 
@@ -230,14 +231,13 @@ def micro(hardware="unknown", options=None):
     options : str or list of str
         Additional options
     """
-    trans_table = {
-        "host": ["-mcpu=native"],
-    }
+    trans_table = {"host": ["-mcpu=native"]}
     opts = _merge_opts(trans_table[hardware] + ["-runtime=c", "--system-lib"], options)
 
     # NOTE: in the future, the default micro target will be LLVM except when
     # external dependencies are present.
     return Target(" ".join(["c"] + opts))
+
 
 def arm_cpu(model="unknown", options=None):
     """Returns a ARM CPU target.
@@ -272,9 +272,23 @@ def arm_cpu(model="unknown", options=None):
         "rk3399": ["-model=rk3399", "-mtriple=aarch64-linux-gnu", "-mattr=+neon"],
         "pynq": ["-model=pynq", "-mtriple=armv7a-linux-eabi", "-mattr=+neon"],
         "ultra96": ["-model=ultra96", "-mtriple=aarch64-linux-gnu", "-mattr=+neon"],
-        "beagleai": ["-model=beagleai", "-mtriple=armv7a-linux-gnueabihf", "-mattr=+neon,+vfp4,+thumb2", "-mcpu=cortex-a15"],
-        "stm32mp1": ["-model=stm32mp1", "-mtriple=armv7a-linux-gnueabihf", "-mattr=+neon,+vfp4,+thumb2"],
-        "thunderx": ["-model=thunderx", "-mtriple=aarch64-linux-gnu", "-mattr=+neon,+crc,+lse", "-mcpu=thunderxt88"],
+        "beagleai": [
+            "-model=beagleai",
+            "-mtriple=armv7a-linux-gnueabihf",
+            "-mattr=+neon,+vfp4,+thumb2",
+            "-mcpu=cortex-a15",
+        ],
+        "stm32mp1": [
+            "-model=stm32mp1",
+            "-mtriple=armv7a-linux-gnueabihf",
+            "-mattr=+neon,+vfp4,+thumb2",
+        ],
+        "thunderx": [
+            "-model=thunderx",
+            "-mtriple=aarch64-linux-gnu",
+            "-mattr=+neon,+crc,+lse",
+            "-mcpu=thunderxt88",
+        ],
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 


### PR DESCRIPTION
This adds three new models to the arm_cpu target. Two 32 bit devices, the beagle board-X15 and the STM32MP1, and a 64 bit device the ThunderX server.

Signed-off-by: Tom Gall <tom.gall@linaro.org>

