### PR TITLE
[RPC] Lazily import micro when starting an RPC server

### DIFF
--- a/python/tvm/exec/rpc_server.py
+++ b/python/tvm/exec/rpc_server.py
@@ -69,7 +69,7 @@ def init_utvm(args):
     args : argparse.Namespace
         parsed args from command-line invocation
     """
-    from tvm import micro
+    from tvm import micro  # pylint: disable=import-outside-toplevel
 
     if args.utvm_dev_config and args.utvm_dev_id:
         raise RuntimeError("only one of --utvm-dev-config and --utvm-dev-id allowed")

--- a/python/tvm/exec/rpc_server.py
+++ b/python/tvm/exec/rpc_server.py
@@ -25,7 +25,6 @@ import multiprocessing
 import sys
 import logging
 import tvm
-from tvm import micro
 from .. import rpc
 
 
@@ -70,6 +69,8 @@ def init_utvm(args):
     args : argparse.Namespace
         parsed args from command-line invocation
     """
+    from tvm import micro
+
     if args.utvm_dev_config and args.utvm_dev_id:
         raise RuntimeError("only one of --utvm-dev-config and --utvm-dev-id allowed")
 


### PR DESCRIPTION
Since #6334 the RPC server cannot be started unless USE_MICRO is enabled.

Without USE_MICRO enabled executing the command `python -m tvm.exec.rpc_server --host=0.0.0.0 --port=9090` will result in the following error:
```
ImportError: cannot import name '_rpc_connect'
```

I've tracked this down to an import in `python/tvn/exec/rpc_server.py`: `from tvm import micro` in the top level list of imports. This will mean that we try to import micro when it's not been built. Fix this by lazily importing micro when initializing an rpc server with micro enabled.

cc @areusch, @liangfu, @tqchen 
