### PR TITLE
bugfix in BinaryBroadcastLayout + unit test

### DIFF
--- a/src/relay/transforms/infer_layout_util.h
+++ b/src/relay/transforms/infer_layout_util.h
@@ -142,7 +142,7 @@ inline Array<Array<Layout>> BinaryBroadcastLayout(const Attrs& attrs,
 
   if (!layouts[0].defined() && !layouts[1].defined()) {
     // both undefined, infer fails
-    return Array<Array<Layout>>{{Layout::Undef()}, {Layout::Undef()}};
+    return Array<Array<Layout>>{{Layout::Undef(), Layout::Undef()}, {Layout::Undef()}};
   } else if (!layouts[0].defined() || !layouts[1].defined()) {
     // only one is defined, use shape information to help infer
     int defined_idx = layouts[0].defined() ? 0 : 1;
@@ -157,7 +157,7 @@ inline Array<Array<Layout>> BinaryBroadcastLayout(const Attrs& attrs,
       // only know the tensor with smaller dimensions,
       // so we cannot infer the final broadcasted output.
       // fails in this case.
-      return Array<Array<Layout>>{{Layout::Undef()}, {Layout::Undef()}};
+      return Array<Array<Layout>>{{Layout::Undef(), Layout::Undef()}, {Layout::Undef()}};
     }
   } else if (layouts[0].defined() && layouts[1].defined() &&
              (layouts[0].ndim() == 0 || layouts[1].ndim() == 0)) {

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -52,6 +52,33 @@ def test_no_convert_layout():
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
 
 
+def test_qnn_binary_no_convert_layout():
+    def before():
+        x = relay.var("x", shape=(2, 2))
+        y = relay.var("y", shape=(1, 2))
+        return relay.Function(
+            [x, y],
+            relay.qnn.op.add(
+                x,
+                y,
+                lhs_scale=relay.const(0.0156863, "float32"),
+                lhs_zero_point=relay.const(127, "int32"),
+                rhs_scale=relay.const(0.0117647, "float32"),
+                rhs_zero_point=relay.const(85, "int32"),
+                output_scale=relay.const(0.0235294, "float32"),
+                output_zero_point=relay.const(128, "int32"),
+            ),
+        )
+
+    def expected():
+        return before()
+
+    a = before()
+    a = run_opt_pass(a, transform.ConvertLayout({}))
+    b = run_opt_pass(expected(), transform.InferType())
+    assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
+
+
 def test_conv_convert_layout():
     def before():
         x = relay.var("x", shape=(1, 56, 56, 64))
@@ -989,6 +1016,7 @@ def test_different_ops_convert_layout():
 
 
 if __name__ == "__main__":
+    test_qnn_binary_no_convert_layout()
     test_no_convert_layout()
     test_conv_convert_layout()
     test_conv_nhwc_convert_layout()


### PR DESCRIPTION
An attempt to fix an issue which appeared when ConverLayout pass
runs on quantized binary operations like qnn.add:
def before():
    x = relay.var("x", shape=(2, 2))
    y = relay.var("y", shape=(1, 2))
    return relay.Function(
        [x, y],
        relay.qnn.op.add(
            x,
            y,
            lhs_scale=relay.const(0.0156863, "float32"),
            lhs_zero_point=relay.const(127, "int32"),
            rhs_scale=relay.const(0.0117647, "float32"),
            rhs_zero_point=relay.const(85, "int32"),
            output_scale=relay.const(0.0235294, "float32"),
            output_zero_point=relay.const(128, "int32"),
        ),
    )

The issue manifested itself as
  [bt] (2) ./src/tvm/build/libtvm.so(tvm::relay::qnn::QnnBinaryBroadcastLayout(tvm::Attrs const&, tvm::runtime::Array<tvm::tir::Layout, void> const&, tvm::runtime::Array<tvm::tir::Layout, void> const&, tvm::runtime::Array<tvm::Type, void> const&)+0xa9) [0x7fadc080d949]
  [bt] (1) ./src/tvm/build/libtvm.so(tvm::runtime::Array<tvm::tir::Layout, void>::operator[](long) const+0xb6) [0x7fadc0382996]
  [bt] (0) ./src/tvm/build/libtvm.so(+0xb50c12) [0x7fadc037cc12]
  File "/workspace/include/tvm/runtime/container.h", line 681
IndexError: Check failed: 0 <= i && i < p->size_: indexing 1 on an array of size 1

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
