### PR TITLE
[AutoScheduler] Improve hyperlinks in the tutorial

### DIFF
--- a/docs/api/python/auto_scheduler.rst
+++ b/docs/api/python/auto_scheduler.rst
@@ -18,33 +18,7 @@
 tvm.auto_scheduler
 ------------------
 .. automodule:: tvm.auto_scheduler
+   :members:
+   :imported-members:
+   :autosummary:
 
-tvm.auto_scheduler.auto_schedule
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: tvm.auto_scheduler.auto_schedule
-
-.. autoclass:: tvm.auto_scheduler.auto_schedule.SearchTask
-
-.. autoclass:: tvm.auto_scheduler.auto_schedule.TuningOptions
-
-.. autofunction:: tvm.auto_scheduler.auto_schedule.create_task
-
-.. autofunction:: tvm.auto_scheduler.auto_schedule.auto_schedule
-
-tvm.auto_scheduler.workload_registry
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: tvm.auto_scheduler.workload_registry.register_workload
-
-
-tvm.auto_scheduler.measure
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: tvm.auto_scheduler.measure
-
-.. autoclass:: tvm.auto_scheduler.measure.LocalRPCMeasureContext
-
-.. autoclass:: tvm.auto_scheduler.measure.LocalRunner
-
-.. autoclass:: tvm.auto_scheduler.measure.LocalBuilder
-
-.. autoclass:: tvm.auto_scheduler.measure.RPCRunner

--- a/python/tvm/auto_scheduler/auto_schedule.py
+++ b/python/tvm/auto_scheduler/auto_schedule.py
@@ -199,7 +199,7 @@ def auto_schedule(task, search_policy=None, tuning_options=TuningOptions()):
 
     Returns
     -------
-        A `te.schedule` and the a list of `te.Tensor` to be used in `tvm.lower` or `tvm.build`.
+        A `te.Schedule` and the a list of `te.Tensor` to be used in `tvm.lower` or `tvm.build`.
     """
     if not isinstance(task, SearchTask):
         raise ValueError(

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -39,16 +39,16 @@ class ComputeDAG(Object):
     subgraph) to a ComputeDAG. It keeps the input/output tensors, all operations in the DAG, and
     some static analysis results for the DAG (e.g. the total float operation count,
     consumer/producer relations of operations, whether an operation stage should
-    be tiled/compute inlined ...).
+    be tiled/compute inlined).
     These analyses can help the search policy to make decisions during the search.
     ComputeDAG is also responsible for the interaction between auto-scheduler's `LoopState` and
     TVM schedule (e.g. applying the `LoopState` transform steps to a TVM schedule, providing
-    `LoopState` with extra information got from TVM schedule ...).
+    `LoopState` with extra information got from TVM schedule).
 
     Parameters
     ----------
     compute : Union[List[Tensor], str]
-        `Tensor`s or workload key for a compute declaration.
+        Input/output tensors or workload key for a compute declaration.
     """
 
     def __init__(self, compute):

--- a/python/tvm/auto_scheduler/cost_model/cost_model.py
+++ b/python/tvm/auto_scheduler/cost_model/cost_model.py
@@ -41,9 +41,9 @@ class RandomModel(CostModel):
 
         Parameters
         ----------
-        inputs : List[MeasureInput]
+        inputs : List[auto_scheduler.measure.MeasureInput]
             The measurement inputs
-        results : List[MeasureResult]
+        results : List[auto_scheduler.measure.MeasureResult]
             The measurement results
         """
         _ffi_api.CostModelUpdate(self, inputs, results)
@@ -112,9 +112,9 @@ class PythonBasedModel(CostModel):
 
         Parameters
         ----------
-        inputs : List[MeasureInput]
+        inputs : List[auto_scheduler.measure.MeasureInput]
             The measurement inputs
-        results : List[MeasureResult]
+        results : List[auto_scheduler.measure.MeasureResult]
             The measurement results
         """
         raise NotImplementedError

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -197,22 +197,26 @@ class XGBModel(PythonBasedModel):
 
     def predict_stages(self, task, states):
         """Predict the scores of all stages in states. This is the breakdown version of `predict`.
+
         Parameters
         ----------
         search_task : SearchTask
             The search task of states
         statse : List[State]
             The input states
+
         Returns
         -------
         scores: List[float]
             The predicted scores for all stages in all states in the packed format
+
         Note
         ----
         For faster data copy between c++ and python, the python part returns scores in a
         single flatten array using a packed format. The c++ part then unpacks the flatten array.
         The packed format is:
         {
+
           float  scores[N];                 // scores[i] is the score for states[i].
           int    n_stage_0;                 // the number of stages in states[0]
           float  stage_scores_0[[n_stage_0] // the scores for all stages in states[0]
@@ -222,6 +226,7 @@ class XGBModel(PythonBasedModel):
           int    n_stage_i;                 // the number of stages in states[i]
           float  stage_scores_1[n_stage_i]; // the scores for all stages in states[i]
           ...  // untill i == N - 1
+
         }
         To implement this format, we also store int as float, so we can store all numbers
         into a single float array.

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-r"""
+"""
 Distributed measurement infrastructure to measure the runtime costs of tensor programs.
 
 These functions are responsible for building the tvm module, uploading it to

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -66,9 +66,9 @@ class RecordReader(Object):
 
         Returns
         -------
-        inputs : List[MeasureInput]
+        inputs : List[auto_scheduler.measure.MeasureInput]
             The MeasureInputs loaded from the log file.
-        results : List[MeasureResult]
+        results : List[auto_scheduler.measure.MeasureResult]
             The MeasureResults loaded from the log file.
         """
         inputs, results = _ffi_api.RecordReaderReadLines(
@@ -95,7 +95,7 @@ def load_records(filename):
 
     Returns
     -------
-    logs : List[MeasureInput, MeasureResult]
+    logs : List[auto_scheduler.measure.MeasureInput, auto_scheduler.measure.MeasureResult]
     """
     return zip(*RecordReader(filename).read_lines())
 
@@ -133,9 +133,9 @@ def load_best(filename, workload_key=None, target=None):
 
     Returns
     -------
-    input : MeasureInput
+    input : auto_scheduler.measure.MeasureInput
         The best State's MeasureInput from this log fine.
-    result : MeasureResult
+    result : auto_scheduler.measure.MeasureResult
         The best State's MeasureResult from this log fine.
     """
     log_reader = RecordReader(filename)

--- a/python/tvm/auto_scheduler/search_policy.py
+++ b/python/tvm/auto_scheduler/search_policy.py
@@ -105,9 +105,11 @@ class SketchPolicy(SearchPolicy):
         Callback functions called before the search process, usually used to do extra
         initializations.
         Possible callbacks:
-            - auto_scheduler.PreloadMeasuredStates
-            - auto_scheduler.PreloadCustomSketchRule
-            TODO(jcf94): Add these search callback implementations.
+
+          - auto_scheduler.PreloadMeasuredStates
+          - auto_scheduler.PreloadCustomSketchRule
+
+        TODO(jcf94): Add these search callback implementations.
     """
 
     DEFAULT_PARAMS = {

--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -57,7 +57,7 @@ def measure_str_key(inp, include_config=True):
 
     Parameters
     ----------
-    inp: MeasureInput
+    inp: autotvm.measure.MeasureInput
         input for the measure
     include_config: bool, optional
         whether includes config in the str key
@@ -78,8 +78,8 @@ def encode(inp, result, protocol="json"):
 
     Parameters
     ----------
-    inp: autotvm.tuner.MeasureInput
-    result: autotvm.tuner.MeasureResult
+    inp: autotvm.measure.MeasureInput
+    result: autotvm.measure.MeasureResult
         pair of input/result
     protocol: str
         log protocol, json or pickle
@@ -135,7 +135,7 @@ def decode(row, protocol="json"):
 
     Returns
     -------
-    ret : tuple(autotvm.tuner.MeasureInput, autotvm.tuner.MeasureResult), or None
+    ret : tuple(autotvm.measure.MeasureInput, autotvm.measure.MeasureResult), or None
         The tuple of input and result, or None if input uses old version log format.
     """
     # pylint: disable=unused-variable
@@ -204,8 +204,8 @@ def load_from_file(filename):
 
     Yields
     ------
-    input: autotvm.tuner.MeasureInput
-    result: autotvm.tuner.MeasureResult
+    input: autotvm.measure.MeasureInput
+    result: autotvm.measure.MeasureResult
     """
     for row in open(filename):
         if row and not row.startswith("#"):

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -184,7 +184,7 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str or iterator of (MeasureInput, MeasureResult)
+    records : str or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
         Each row of this file is an encoded record pair. Otherwise, it is an iterator.
@@ -205,7 +205,7 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str or iterator of (MeasureInput, MeasureResult)
+        records : str or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
             Each row of this file is an encoded record pair. Otherwise, it is an iterator.
@@ -382,7 +382,7 @@ class ApplyGraphBest(DispatchContext):
         """
         Parameters
         ----------
-        records : str or iterator of (MeasureInput, MeasureResult)
+        records : str or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
                    Each row of this file is an encoded record pair.

--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -1078,7 +1078,7 @@ class FallbackConfigEntity(ConfigSpace):
 
         Parameters
         ----------
-        ref_log: List of (MeasureInput, MeasureResult)
+        ref_log: List of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
             The reference log
         """
         knob_names = [x for x in self.space_map.keys() if isinstance(self.space_map[x], SplitSpace)]

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -188,7 +188,7 @@ class Tuner(object):
 
         Parameters
         ----------
-        data_set: Array of (MeasureInput, MeasureResult) pair
+        data_set: Array of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult) pair
             Previous tuning records
         """
         raise NotImplementedError()

--- a/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
+++ b/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
@@ -74,20 +74,20 @@ print(task.compute_dag)
 # Next, we set parameters for the auto-scheduler. These parameters
 # mainly specify how we do the measurement during the search and auto-tuning.
 #
-# * `measure_ctx` launches a different process for measurement. This
+# * :code:`measure_ctx` launches a different process for measurement. This
 #   provides an isolation. It can protect the master process from GPU crashes
 #   happended during measurement and avoid other runtime conflicts.
-# * `min_repeat_ms` defines the minimum duration of one "repeat" in every measurement.
+# * :code:`min_repeat_ms` defines the minimum duration of one "repeat" in every measurement.
 #   This can warmup the GPU, which is necessary to get accurate measurement results.
 #   Typically, we recommend a value > 300 ms.
-# * `num_measure_trials` is the number of measurement trials we can use during the search.
+# * :code:`num_measure_trials` is the number of measurement trials we can use during the search.
 #   We only make 10 trials in this tutorial for a fast demonstration. In practice, 1000 is a
 #   good value for the search to converge. You can do more trials according to your time budget.
-# * In addition, we use `RecordToFile` to dump measurement records into a file `conv2d.json`.
+# * In addition, we use :code:`RecordToFile` to dump measurement records into a file `conv2d.json`.
 #   The measurement records can be used to query the history best, resume the search,
 #   and do more analyses later.
-# * see :any:`auto_scheduler.auto_schedule.TuningOptions`:,
-#   :any:`auto_scheduler.measure.LocalRPCMeasureContext` for more parameters.
+# * see :any:`auto_scheduler.TuningOptions`,
+#   :any:`auto_scheduler.LocalRPCMeasureContext` for more parameters.
 
 measure_ctx = auto_scheduler.LocalRPCMeasureContext(min_repeat_ms=300)
 tune_option = auto_scheduler.TuningOptions(

--- a/tutorials/auto_scheduler/tune_matmul_x86.py
+++ b/tutorials/auto_scheduler/tune_matmul_x86.py
@@ -60,11 +60,12 @@ def matmul_add(N, L, M, dtype):
 # ^^^^^^^^^^^^^^^^^^^^^^
 # We then create a search task with N=L=M=128 and dtype="float32"
 # If your machine supports avx instructions, you can
-# - replace "llvm" below with "llvm -mcpu=core-avx2" to enable AVX2
-# - replace "llvm" below with "llvm -mcpu=skylake-avx512" to enable AVX-512
+#
+#   - replace "llvm" below with "llvm -mcpu=core-avx2" to enable AVX2
+#   - replace "llvm" below with "llvm -mcpu=skylake-avx512" to enable AVX-512
 
 target = tvm.target.Target("llvm")
-task = auto_scheduler.create_task(matmul_add, (128, 128, 128, "float32"), target)
+task = tvm.auto_scheduler.create_task(matmul_add, (128, 128, 128, "float32"), target)
 
 # Inspect the computational graph
 print(task.compute_dag)
@@ -72,13 +73,13 @@ print(task.compute_dag)
 ######################################################################
 # Next, we set parameters for the auto-scheduler.
 #
-# * `num_measure_trials` is the number of measurement trials we can use during the search.
+# * :code:`num_measure_trials` is the number of measurement trials we can use during the search.
 #   We only make 10 trials in this tutorial for a fast demonstration. In practice, 1000 is a
 #   good value for the search to converge. You can do more trials according to your time budget.
-# * In addition, we use `RecordToFile` to dump measurement records into a file `matmul.json`.
+# * In addition, we use :code:`RecordToFile` to dump measurement records into a file `matmul.json`.
 #   The measurement records can be used to query the history best, resume the search,
 #   and do more analyses later.
-# * see :any:`auto_scheduler.auto_schedule.TuningOptions`: for more parameters
+# * see :any:`auto_scheduler.TuningOptions` for more parameters
 
 tune_option = auto_scheduler.TuningOptions(
     num_measure_trials=10, measure_callbacks=[auto_scheduler.RecordToFile("matmul.json")]
@@ -189,5 +190,5 @@ def resume_search(task, log_file):
 #   For example, you can start a new thread/process (with the builtin python library
 #   threading or multiprocessing) and run the tvm binaries in the new thread/process.
 #   This provides an isolation and avoids the conflict in the main thread/process.
-#   You can also use :any:`auto_scheduler.measure.LocalRPCMeasureContext` for auto-scheduler,
+#   You can also use :any:`auto_scheduler.LocalRPCMeasureContext` for auto-scheduler,
 #   as shown in the GPU tutorial (:ref:`auto-scheduler-conv-gpu`).


### PR DESCRIPTION
Improve the hyperlinks in the tutorial, so the API calls in the code can be linked to its doc on the website.