### PR TITLE
fix libtvm build dependencies when USE_MICRO is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,13 @@ set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAGS}")
 add_library(tvm_runtime SHARED $<TARGET_OBJECTS:tvm_runtime_objs>)
 set_property(TARGET tvm_runtime APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAGS}")
 
+if(USE_MICRO)
+  # NOTE: cmake doesn't track dependencies at the file level across subdirectories. For the
+  # Unix Makefiles generator, need to add these explicit target-level dependency)
+  add_dependencies(tvm host_standalone_crt)
+  add_dependencies(tvm_runtime host_standalone_crt)
+endif()
+
 if(USE_CPP_RPC)
   add_subdirectory("apps/cpp_rpc")
 endif()


### PR DESCRIPTION
 * previously, building from scratch would fail with Unix Makefiles
   due to cmake limitation

thanks @hogepodge for reporting this bug: when USE_MICRO is on and cmake generator is Unix Makefiles, tvm builds fail with:
```
make[2]: *** No rule to make target `host_standalone_crt/libutvm_rpc_common.a', needed by `libtvm_runtime.dylib'.  Stop.`
```

This PR fixes that bug.

cc @tqchen 