### PR TITLE
[Doc][Fix] Fix a typo in hybrid script tutorial.

### DIFF
--- a/docs/langref/hybrid_script.rst
+++ b/docs/langref/hybrid_script.rst
@@ -38,7 +38,7 @@ you need to use ``tvm.te.hybrid.script`` decorator to indicate this is a hybrid 
 .. code-block:: python
 
     @tvm.te.hybrid.script
-    def outer_product(a, b, c):
+    def outer_product(a, b):
         c = output_tensor((100, 99), 'float32')
         for i in range(a.shape[0]):
             for j in range(b.shape[0]):

--- a/docs/langref/hybrid_script.rst
+++ b/docs/langref/hybrid_script.rst
@@ -43,7 +43,7 @@ you need to use ``tvm.te.hybrid.script`` decorator to indicate this is a hybrid 
         for i in range(a.shape[0]):
             for j in range(b.shape[0]):
                 c[i, j] = a[i] * b[j]
-          return c
+        return c
     a = numpy.random.randn(100)
     b = numpy.random.randn(99)
     c = outer_product(a, b)
@@ -76,7 +76,7 @@ or ``tvm.container.Array``, to this function, it returns a op node:
 
    a = tvm.te.placeholder((100, ), name='a')
    b = tvm.te.placeholder((99, ), name='b')
-   c = outer_product(a, b, c) # return the output tensor(s) of the operator
+   c = outer_product(a, b) # return the output tensor(s) of the operator
 
 You can use any methods that can be applied on a TVM ``OpNode``, like create_schedule, although
 so far, the functionality of schedule is as limited as ``ExternOpNode``. At least, it can be built

--- a/docs/langref/hybrid_script.rst
+++ b/docs/langref/hybrid_script.rst
@@ -230,5 +230,8 @@ Assert statement is supported, you can simply use it as it is in standard Python
 
 Keywords
 ~~~~~~~~
-- For keywords: ``serial``, ``range``, ``unroll``, ``parallel``, ``vectorize``, ``bind``, ``const_expr``
-- Math keywords: ``log``, ``exp``, ``sigmoid``, ``tanh``, ``power``, ``popcount``
+- For keywords: ``serial``, ``range``, ``unroll``, ``parallel``, ``vectorize``, ``bind``, ``const_range``
+- Math keywords: ``log``, ``exp``, ``sqrt``, ``rsqrt``, ``sigmoid``, ``tanh``, ``power``, ``popcount``, ``round``, ``ceil_div``
+- Allocate keywords: ``allocate``, ``output_tensor``
+- Data type keywords: ``uint8``, ``uint16``, ``uint32``, ``uint64``, ``int8``, ``int16``, ``int32``, ``int64``, ``float16``, ``float32``, ``float64``
+- Others: ``max_num_threads``


### PR DESCRIPTION
The `c` should not appear in the argument list of `outer_product`.
```python
@tvm.te.hybrid.script
def outer_product(a, b, c):
    c = output_tensor((100, 99), 'float32')
    for i in range(a.shape[0]):
        for j in range(b.shape[0]):
            c[i, j] = a[i] * b[j]
      return c
a = numpy.random.randn(100)
b = numpy.random.randn(99)
c = outer_product(a, b)
```

btw, the `tvm.hybrid.parse` API does not exist in master branch's codebase.