### PR TITLE
Remove settings about SGX in config.cmake

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -87,17 +87,6 @@ set(USE_OPENGL OFF)
 # Whether enable MicroTVM runtime
 set(USE_MICRO OFF)
 
-# Whether to enable SGX runtime
-#
-# Possible values for USE_SGX:
-# - /path/to/sgxsdk: path to Intel SGX SDK
-# - OFF: disable SGX
-#
-# SGX_MODE := HW|SIM
-set(USE_SGX OFF)
-set(SGX_MODE "SIM")
-set(RUST_SGX_SDK "/path/to/rust-sgx-sdk")
-
 # Whether enable RPC runtime
 set(USE_RPC ON)
 


### PR DESCRIPTION
removed settings about SGX since SGX is removed from TVM core

@tqchen @nhynes 