### PR TITLE
[tvmc] linting error on onnx command line driver frontend

### DIFF
--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -154,6 +154,7 @@ class OnnxFrontend(Frontend):
         # pylint: disable=C0415
         import onnx
 
+        # pylint: disable=E1101
         model = onnx.load(path)
 
         # pylint: disable=E1101


### PR DESCRIPTION
Two minor changes on `tvmc`:
 * Updates onnx load function from "load" (a compatibility attribute) to "load_model" (the actual function)
 * Add a pylint comment, that we don't see currently on upstream CI, but it reproduces when linting it locally.

cc @manupa-arm @comaniac @d-smirnov 