### PR TITLE
[tvmc] Introduce 'tune' subcommand (part 3/4)

### DIFF
--- a/python/tvm/driver/tvmc/__init__.py
+++ b/python/tvm/driver/tvmc/__init__.py
@@ -18,4 +18,5 @@
 TVMC - TVM driver command-line interface
 """
 
+from . import autotuner
 from . import compiler

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -106,6 +106,11 @@ def add_tune_parser(subparsers):
         help="compilation target as plain string, inline JSON or path to a JSON file",
         required=True,
     )
+    parser.add_argument(
+        "--target-host",
+        help="the host compilation target, defaults to 'llvm'",
+        default="llvm",
+    )
     parser.add_argument("--timeout", default=10, help="compilation timeout, in seconds")
     parser.add_argument(
         "--trials",
@@ -175,6 +180,7 @@ def drive_tune(args):
         mod=mod,
         params=params,
         target=target,
+        target_host=args.target_host,
         alter_layout=args.desired_layout,
     )
 
@@ -236,9 +242,6 @@ def get_tuning_tasks(mod, params, target, target_host=None, alter_layout=None):
     tasks : list of autotvm.Tasks
         list of tasks to be tuned
     """
-    if not target_host:
-        target_host = target
-
     if alter_layout:
         mod = common.convert_graph_layout(mod, alter_layout)
 

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -30,8 +30,12 @@ from tvm.autotvm.tuner import RandomTuner
 from tvm.autotvm.tuner import XGBTuner
 
 from . import common, frontends
-from .common import logger, TVMCException
+from .common import TVMCException
 from .main import register_parser
+
+
+# pylint: disable=invalid-name
+logger = logging.getLogger("TVMC")
 
 
 @register_parser

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -25,6 +25,10 @@ import tvm
 from tvm import relay
 from tvm import transform
 
+# TODO migrate compiler logger to the common logger (@leandron)
+# pylint: disable=invalid-name
+logger = logging.getLogger("TVMC")
+
 
 class TVMCException(Exception):
     """TVMC Exception"""
@@ -90,11 +94,11 @@ def target_from_cli(target):
 
     if os.path.exists(target):
         with open(target) as target_file:
-            logging.info("using target input from file: %s", target)
+            logger.info("using target input from file: %s", target)
             target = "".join(target_file.readlines())
 
     # TODO(@leandron) We don't have an API to collect a list of supported
     #       targets yet
-    logging.debug("creating target from input: %s", target)
+    logger.debug("creating target from input: %s", target)
 
     return tvm.target.Target(target)

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -25,7 +25,7 @@ import tvm
 from tvm import relay
 from tvm import transform
 
-# TODO migrate compiler logger to the common logger (@leandron)
+
 # pylint: disable=invalid-name
 logger = logging.getLogger("TVMC")
 

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -17,6 +17,11 @@
 """
 Common utility functions shared by TVMC modules.
 """
+import logging
+import os.path
+
+import tvm
+
 from tvm import relay
 from tvm import transform
 
@@ -63,3 +68,33 @@ def convert_graph_layout(mod, desired_layout):
             raise TVMCException(
                 "Error converting layout to {0}: {1}".format(desired_layout, str(err))
             )
+
+
+# TODO In a separate PR, eliminate the duplicated code here and in compiler.py (@leandron)
+def target_from_cli(target):
+    """
+    Create a tvm.target.Target instance from a
+    command line interface (CLI) string.
+
+    Parameters
+    ----------
+    target : str
+        compilation target as plain string,
+        inline JSON or path to a JSON file
+
+    Returns
+    -------
+    tvm.target.Target
+        an instance of target device information
+    """
+
+    if os.path.exists(target):
+        with open(target) as target_file:
+            logging.info("using target input from file: %s", target)
+            target = "".join(target_file.readlines())
+
+    # TODO(@leandron) We don't have an API to collect a list of supported
+    #       targets yet
+    logging.debug("creating target from input: %s", target)
+
+    return tvm.target.Target(target)

--- a/tests/python/driver/tvmc/test_autotuner.py
+++ b/tests/python/driver/tvmc/test_autotuner.py
@@ -1,0 +1,150 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import pytest
+import os
+import tarfile
+
+from os import path
+
+from tvm import autotvm
+from tvm.driver import tvmc
+
+
+def _get_tasks(model):
+    mod, params = tvmc.frontends.load_model(model)
+    return tvmc.autotuner.get_tuning_tasks(mod, params, "llvm")
+
+
+def _get_measure_options():
+    return autotvm.measure_option(
+        builder=autotvm.LocalBuilder(build_func="default"), runner="local"
+    )
+
+
+def _tuner_test_helper(
+    model, tuner_name, tmpdir_name, tasks=None, early_stopping=1, tuning_records=None
+):
+    tasks = tasks if tasks else _get_tasks(model)
+    log_file = os.path.join(tmpdir_name, "log_{}.txt".format(tuner_name))
+
+    tvmc.autotuner.tune_tasks(
+        tasks=[tasks[0]],
+        log_file=log_file,
+        measure_option=_get_measure_options(),
+        tuner=tuner_name,
+        trials=1,
+        early_stopping=early_stopping,
+        tuning_records=tuning_records,
+    )
+
+    # testing whether the log file was produced
+    assert path.exists(log_file), "tuning log file should exist"
+
+    with autotvm.apply_history_best(log_file) as best:
+        assert isinstance(
+            best, autotvm.task.dispatcher.ApplyHistoryBest
+        ), "unable to load the best results of tuning"
+
+    return log_file
+
+
+def test_get_tuning_tasks(onnx_resnet50):
+    pytest.importorskip("onnx")
+
+    sut = _get_tasks(onnx_resnet50)
+    expected_task_type = autotvm.task.Task
+
+    assert type(sut) is list
+    assert len(sut) > 0
+    assert all([type(x) is expected_task_type for x in sut]) is True
+
+
+def test_tune_tasks__tuner__xgb(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "xgb", tmpdir_name)
+
+
+def test_tune_tasks__tuner__xgb_knob(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "xgb_knob", tmpdir_name)
+
+
+def test_tune_tasks__tuner__ga(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "ga", tmpdir_name)
+
+
+def test_tune_tasks__tuner__random(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "random", tmpdir_name)
+
+
+def test_tune_tasks__tuner__gridsearch(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "gridsearch", tmpdir_name)
+
+
+def test_tune_tasks__tuner__gridsearch__tuning_records(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    output_log_phase_1 = _tuner_test_helper(onnx_resnet50, "gridsearch", tmpdir_name)
+
+    # Exercises transfer learning by making sure a previous log exists
+    _tuner_test_helper(onnx_resnet50, "gridsearch", tmpdir_name, tuning_records=output_log_phase_1)
+
+
+def test_tune_tasks__tuner__ga__empty_tasks(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "ga", tmpdir_name, tasks=[])
+
+
+def test_tune_tasks__tuner__xgb__no_early_stopping(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "xgb", tmpdir_name, tasks=None, early_stopping=None)
+
+
+def test_tune_tasks__tuner__xgb__no_tuning_records(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_resnet50, "xgb", tmpdir_name, tasks=None, tuning_records=None)
+
+
+def test_tune_tasks__invalid_tuner(onnx_resnet50, tmpdir_factory):
+    pytest.importorskip("onnx")
+
+    tasks = _get_tasks(onnx_resnet50)
+    log_file = os.path.join(tmpdir_factory.mktemp("data"), "log2.txt")
+
+    with pytest.raises(tvmc.common.TVMCException):
+        tvmc.autotuner.tune_tasks(tasks, log_file, _get_measure_options(), "invalid_tuner", 1, 1)


### PR DESCRIPTION
Introduce a sub-command to drive auto-tuning via command line, using AutoTVM, to produce the tuning records that can be used at compile time, or to further improve other tuning sessions. It follow good practices present on the auto-tuning tutorials.

In case you want to try it out (supposing you have your tvm built and working with this PR), you can have a look on the example below:
```
$ wget https://github.com/onnx/models/raw/master/vision/classification/resnet/model/resnet50-v2-7.onnx
$ python -m tvm.driver.tvmc --verbose tune --trials 1 --output log1.txt --target="llvm" resnet50-v2-7.onnx
(...messages...)
WARNING:root:Attribute spatial is ignored in relay.sym.batch_norm
[Task  1/23]  Current/Best:    0.00/   0.00 GFLOPS | Progress: (1/1) | 1.32 s Done.
[Task  2/23]  Current/Best:    0.00/   0.00 GFLOPS | Progress: (1/1) | 1.23 s Done.
[Task  3/23]  Current/Best:    0.00/   0.00 GFLOPS | Progress: (1/1) | 1.07 s Done.
...
```

cc @comaniac @masahi @FrozenGene for reviews if possible
 