### PR TITLE
[CI][docker] remove old pylint 1.9.4 from docker installation script

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -21,4 +21,4 @@ set -u
 set -o pipefail
 
 # install libraries for python package on ubuntu
-pip3 install pylint==1.9.4 six numpy pytest cython decorator scipy tornado typed_ast pytest mypy orderedset attrs requests Pillow packaging
+pip3 install six numpy pytest cython decorator scipy tornado typed_ast pytest mypy orderedset attrs requests Pillow packaging


### PR DESCRIPTION
It seems that despite we having standard `pylint==2.4.4` being installed in the context of `ci_lint`, we have this mention to `pylint==1.9.4` left in `ubuntu_install_python_package.sh`, so I think we can remove the old one.

cc @tqchen @jroesch 

