### PR TITLE
Fix type code error in rust resnet example #6528

### DIFF
--- a/rust/tvm/examples/resnet/src/main.rs
+++ b/rust/tvm/examples/resnet/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
         graph.into(),
         (&lib).into(),
         (&ctx.device_type).into(),
-        (&ctx.device_id).into(),
+        (&(ctx.device_id as i32)).into(),
     ]);
 
     // get graph runtime module


### PR DESCRIPTION
The error occurred because the type of device_id in rust is u32, but in c++ is int. temporally convert the type of device_id to i32 to make this demo pass.

@tqchen @nhynes 
