### PR TITLE
Add alternate cublaslt library name. CUDA 11.0 uses cublasLt.

### DIFF
--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -91,7 +91,8 @@ macro(find_cuda use_cuda)
       find_library(CUDA_CUBLAS_LIBRARY cublas
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)
-      find_library(CUDA_CUBLASLT_LIBRARY cublaslt
+      find_library(CUDA_CUBLASLT_LIBRARY
+        NAMES cublaslt cublasLt
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)
     endif(MSVC)


### PR DESCRIPTION
I installed cuda 11.0 and cublaslt was not found. The file is named with an upper-case L now, cublas`L`t so I added that as an optional name and the library is correctly found again.