### PR TITLE
[Rust] Allow convert Context to ArgValue

### DIFF
--- a/rust/tvm-sys/src/context.rs
+++ b/rust/tvm-sys/src/context.rs
@@ -248,6 +248,18 @@ impl Display for Context {
     }
 }
 
+impl<'a> From<&'a Context> for ArgValue<'a> {
+    fn from(ctx: &'a Context) -> Self {
+        DLContext::from(ctx).into()
+    }
+}
+
+impl<'a> From<Context> for ArgValue<'a> {
+    fn from(ctx: Context) -> Self {
+        DLContext::from(ctx).into()
+    }
+}
+
 impl From<Context> for RetValue {
     fn from(ret_value: Context) -> RetValue {
         RetValue::Context(ret_value.into())


### PR DESCRIPTION
This PR allow to use the new module interface:

```python
with tvm.transform.PassContext(opt_level=3):
    lib = relay.build(mod, target=target, target_host=target_host, params=params)

lib.export_library('deploy_lib.so')
```

```rust
use tvm::*;

let lib = Module::load(&Path::new("deploy_lib.so")).unwrap();
let default = lib.get_function("default", false).unwrap();
let ctx = Context::gpu(0);
let ret = default.invoke(vec![ctx.into()]);
let gmod: Module = ret.unwrap().try_into().unwrap();
```