### PR TITLE
Add proper cmake PATHS when multiple NAMES.

### DIFF
--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -93,6 +93,7 @@ macro(find_cuda use_cuda)
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)
       find_library(CUDA_CUBLASLT_LIBRARY
         NAMES cublaslt cublasLt
+        PATHS
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)
     endif(MSVC)


### PR DESCRIPTION
Further fix for #6541 introduced by @rkimball .

* For ```cmake``` with **multiple** ```NAMES``` entries a ```PATHS``` (separator) entry must follow otherwise it cannot make difference what are ```NAMES``` and what are ```PATHS```.
* Not the case for **single** entries.

-----

On my machine:

Before:
```
-- Found CUDA_CUBLASLT_LIBRARY=CUDA_CUBLASLT_LIBRARY-NOTFOUND
```
After:
```
-- Found CUDA_CUBLASLT_LIBRARY=/usr/local/cuda/lib64/libcublasLt.so
```

@rkimball , @tqchen , @junrushao1994 please help me with the review.

Thank you !

