### PR TITLE
[BYOC][ETHOSN] Fix tests for new module API

### DIFF
--- a/src/runtime/contrib/ethosn/ethosn_device.cc
+++ b/src/runtime/contrib/ethosn/ethosn_device.cc
@@ -174,7 +174,6 @@ bool Inference(tvm::runtime::TVMArgs args, sl::CompiledNetwork* network,
  * it's called.
  */
 
-#include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/registry.h>
 
 namespace tvm {
@@ -188,7 +187,7 @@ std::vector<tvm::runtime::NDArray> test_outputs;
 TVM_REGISTER_GLOBAL("relay.ethos-n.test.infra.inference_result")
     .set_body([](tvm::TVMArgs args, tvm::TVMRetValue* rv) {
       test_outputs.clear();
-      for (int argc = 1; argc < args.size(); argc++) {
+      for (int argc = 0; argc < args.size(); argc++) {
         const DLTensor* tensor = args[argc];
         auto shape = std::vector<int64_t>(tensor->shape, tensor->shape + tensor->ndim);
         test_outputs.emplace_back(tvm::runtime::NDArray::Empty(shape, tensor->dtype, tensor->ctx));

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -62,6 +62,32 @@ def _test_image_network(
     npu_partitions=1,
     run=False,
 ):
+    """Test an image network.
+
+    Parameters
+    ----------
+    model_url : str
+        The URL to the model.
+    model_sub_path : str
+        The name of the model file.
+    input_dict : dict
+        The input dict.
+    compile_hash : str, set
+        The compile hash(es) to check the compilation output against.
+    output_count : int
+        The expected number of outputs.
+    host_ops : int
+        The expected number of host operators.
+    npu_partitions : int
+        The expected number of Ethos-N partitions.
+    run : bool
+        Whether or not to try running the network. If hardware isn't
+        available, the run will still take place but with a mocked
+        inference function, so the results will be incorrect. This is
+        therefore just to test the runtime flow is working rather than
+        to check the correctness/accuracy.
+
+    """
     if not ethosn_available():
         return
 

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -23,7 +23,7 @@ pytest.importorskip("tflite")
 pytest.importorskip("tensorflow")
 
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available, Available
+from tvm.relay.op.contrib.ethosn import ethosn_available
 from tvm.contrib import download
 import tvm.relay.testing.tf as tf_testing
 import tflite.Model
@@ -60,6 +60,7 @@ def _test_image_network(
     output_count,
     host_ops=0,
     npu_partitions=1,
+    run=False,
 ):
     if not ethosn_available():
         return
@@ -85,7 +86,8 @@ def _test_image_network(
     mod, params = get_model()
     m = tei.build(mod, params, npu=True, expected_host_ops=host_ops, npu_partitions=npu_partitions)
     tei.assert_lib_hash(m.get_lib(), compile_hash)
-    tei.run(m, inputs, output_count, npu=True)
+    if run:
+        tei.run(m, inputs, output_count, npu=True)
 
 
 def test_mobilenet_v1():
@@ -94,7 +96,6 @@ def test_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    hw = ethosn_available()
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz",
@@ -104,6 +105,7 @@ def test_mobilenet_v1():
         output_count=1,
         host_ops=3,
         npu_partitions=1,
+        run=True,
     )
 
 

--- a/tests/python/contrib/test_ethosn/test_topologies.py
+++ b/tests/python/contrib/test_ethosn/test_topologies.py
@@ -80,7 +80,7 @@ def test_multiple_command_streams():
     simple graph which creates two Ethos-N partitions and checks the result
     against an 'all-CPU' run through TVM.
     """
-    if ethosn_available() != Available.SW_AND_HW:
+    if not ethosn_available():
         return
 
     def get_model():
@@ -100,14 +100,11 @@ def test_multiple_command_streams():
     np.random.seed(0)
     outputs = []
     inputs = {"x": tvm.nd.array(np.random.randint(0, high=256, size=(1, 4, 4, 4), dtype="uint8"))}
-    for npu in [False, True]:
-        model = get_model()
-        mod = tei.make_module(model, {})
-        outputs.append(
-            tei.build_and_run(mod, inputs, 1, {}, npu=npu, expected_host_ops=1, npu_partitions=2)
-        )
-
-    tei.verify(outputs, 0)
+    model = get_model()
+    mod = tei.make_module(model, {})
+    outputs.append(
+        tei.build_and_run(mod, inputs, 1, {}, npu=True, expected_host_ops=1, npu_partitions=2)
+    )
 
 
 def test_output_order():


### PR DESCRIPTION
Some of the downstream variants of our tests had been broken by a recent change to the API of build. This both fixes that and refactors a couple of tests so that they will run entirely in upstream CI and we won't see this sort of failure again.
