### PR TITLE
[DOC] Fix missing te in the code example

### DIFF
--- a/docs/deploy/hls.rst
+++ b/docs/deploy/hls.rst
@@ -45,7 +45,7 @@ We use two python scripts for this tutorial.
       s = te.create_schedule(C.op)
       px, x = s[C].split(C.op.axis[0], nparts=1)
 
-      s[C].bind(px, tvm.thread_axis("pipeline"))
+      s[C].bind(px, tvm.te.thread_axis("pipeline"))
 
       fadd = tvm.build(s, [A, B, C], tgt, target_host=tgt_host, name="myadd")
 


### PR DESCRIPTION
This PR fixed the code example in this [page](https://tvm.apache.org/docs/deploy/hls.html).

- caused `AttributeError: module ‘tvm’ has no attribute ‘thread_axis’` error
- Fix based on [this thread](https://discuss.tvm.apache.org/t/attributeerror-module-tvm-has-no-attribute-thread-axis/6606)

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
