### PR TITLE
[tvmc] fix command line argument variable name in 'compile'

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -107,7 +107,7 @@ def drive_compile(args):
         None,
         args.model_format,
         args.tuning_records,
-        args.tensor_layout,
+        args.desired_layout,
     )
 
     if dumps:


### PR DESCRIPTION
This is a variable that we changed names during code review, and it was incorrectly left behind with the previous name.

