### PR TITLE
[tvm4j] Fix android runtime error

### DIFF
--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -44,3 +44,7 @@ endif
 ifeq ($(USE_SORT), 1)
     APP_CPPFLAGS += -DUSE_SORT=1
 endif
+
+ifeq ($(USE_RANDOM), 1)
+    APP_CPPFLAGS += -DUSE_RANDOM=1
+endif

--- a/apps/android_rpc/app/src/main/jni/make/config.mk
+++ b/apps/android_rpc/app/src/main/jni/make/config.mk
@@ -42,6 +42,9 @@ USE_VULKAN = 0
 # whether to enable contrib sort functions during compile
 USE_SORT = 1
 
+# whether to eanble contrib random functions during compile
+USE_RANDOM = 1
+
 ifeq ($(USE_VULKAN), 1)
   # Statically linking vulkan requires API Level 24 or higher
   APP_PLATFORM = android-24

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -73,6 +73,10 @@
 #include "../src/runtime/contrib/sort/sort.cc"
 #endif
 
+#ifdef USE_RANDOM
+#include "../src/runtime/contrib/random/random.cc"
+#endif
+
 #include <android/log.h>
 
 void dmlc::CustomLogMessage::Log(const std::string& msg) {


### PR DESCRIPTION
codes for USE_RANDOM in tvm4j was missing.
