### PR TITLE
[ROCM] Support rocblas_sgemm_strided_batched

### DIFF
--- a/python/tvm/contrib/rocblas.py
+++ b/python/tvm/contrib/rocblas.py
@@ -48,3 +48,36 @@ def matmul(lhs, rhs, transa=False, transb=False):
         ),
         name="C",
     )
+
+
+def batch_matmul(lhs, rhs, transa=False, transb=False):
+    """Create an extern op that compute matrix mult of A and rhs with rocBLAS
+
+    Parameters
+    ----------
+    lhs : Tensor
+        The left batched matrix operand
+    rhs : Tensor
+        The right batched matrix operand
+    transa : bool
+        Whether transpose lhs
+    transb : bool
+        Whether transpose rhs
+
+    Returns
+    -------
+    C : Tensor
+        The result tensor.
+    """
+    batch_size = lhs.shape[0]
+    assert batch_size == rhs.shape[0]
+    n = lhs.shape[2] if transa else lhs.shape[1]
+    m = rhs.shape[1] if transb else rhs.shape[2]
+    return te.extern(
+        (batch_size, n, m),
+        [lhs, rhs],
+        lambda ins, outs: tvm.tir.call_packed(
+            "tvm.contrib.rocblas.batch_matmul", ins[0], ins[1], outs[0], transa, transb
+        ),
+        name="C",
+    )

--- a/python/tvm/topi/rocm/__init__.py
+++ b/python/tvm/topi/rocm/__init__.py
@@ -19,6 +19,7 @@
 """rocm specific declaration and schedules."""
 from __future__ import absolute_import as _abs
 
+from .batch_matmul import *
 from .conv2d import *
 from .dense import *
 from .nn import *

--- a/python/tvm/topi/rocm/batch_matmul.py
+++ b/python/tvm/topi/rocm/batch_matmul.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-variable, unused-argument
+"""Schedule for batch_matmul operator"""
+from tvm import autotvm
+from tvm.contrib import rocblas
+from .. import generic
+from ..util import get_const_tuple
+
+
+@autotvm.register_topi_compute("batch_matmul_rocblas.rocm")
+def batch_matmul_rocblas(cfg, x, y, out_shape=None):
+    """Computes matrix multiplication of `x` and `y` via rocblas when
+    `x` and `y` are batched matrices.
+
+    Parameters
+    ----------
+    cfg : ConfigSpace
+        Autotvm tuning space config file
+    x : tvm.te.Tensor
+        3-D with shape [batch, M, K]
+    y : tvm.te.Tensor
+        3-D with shape [batch, N, K]
+    Returns
+    -------
+    output : tvm.te.Tensor
+        3-D with shape [batch, M, N]
+    """
+    batch, M, K = get_const_tuple(x.shape)
+    _, N, _ = get_const_tuple(y.shape)
+    if out_shape is not None:
+        assert out_shape[0] == batch, "Input and output batch sizes must match"
+        assert out_shape[1] == M and out_shape[2] == N, "Invalid output shape"
+    result = rocblas.batch_matmul(x, y, False, True)
+    cfg.add_flop(batch * M * N * K * 2)
+    return result
+
+
+@autotvm.register_topi_schedule("batch_matmul_rocblas.rocm")
+def schedule_batch_matmul_rocblas(_, outs):
+    """Schedule for batch_matmul operator with rocm cblas"""
+    return generic.schedule_extern(outs)

--- a/tests/python/contrib/test_rocblas.py
+++ b/tests/python/contrib/test_rocblas.py
@@ -18,11 +18,13 @@ import tvm
 import tvm.testing
 from tvm import te
 import numpy as np
+import tvm.topi.testing
+import tvm.testing
 from tvm.contrib import rocblas
 
 
 @tvm.testing.requires_rocm
-def test_matmul_add():
+def test_matmul():
     n = 1024
     l = 128
     m = 235
@@ -46,5 +48,65 @@ def test_matmul_add():
     verify()
 
 
+def verify_batch_matmul(batch, m, k, n, lib, transa=False, transb=False, dtype="float32"):
+    ashape = (batch, k, m) if transa else (batch, m, k)
+    bshape = (batch, n, k) if transb else (batch, k, n)
+    A = te.placeholder(ashape, name="A", dtype=dtype)
+    B = te.placeholder(bshape, name="B", dtype=dtype)
+    C = lib.batch_matmul(A, B, transa, transb)
+    s = te.create_schedule(C.op)
+
+    def get_numpy(a, b, transa, transb):
+        if transa:
+            a = a.transpose(0, 2, 1)
+        if not transb:
+            b = b.transpose(0, 2, 1)
+        return tvm.topi.testing.batch_matmul(a, b)
+
+    def verify(target="rocm"):
+        if not tvm.testing.device_enabled(target):
+            print("skip because %s is not enabled..." % target)
+            return
+        if not tvm.get_global_func(lib.__name__ + ".batch_matmul", True):
+            print("skip because extern function is not available")
+            return
+        ctx = tvm.rocm(0)
+        f = tvm.build(s, [A, B, C], target)
+        a = tvm.nd.array(np.random.uniform(size=ashape).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.random.uniform(size=bshape).astype(B.dtype), ctx)
+        c = tvm.nd.array(np.zeros((batch, m, n), dtype=C.dtype), ctx)
+        f(a, b, c)
+        tvm.testing.assert_allclose(
+            c.asnumpy(), get_numpy(a.asnumpy(), b.asnumpy(), transa, transb), rtol=1e-5
+        )
+
+    verify()
+
+
+@tvm.testing.requires_rocm
+def test_batch_matmul():
+    verify_batch_matmul(128, 64, 512, 512, rocblas, transa=False, transb=False)
+    verify_batch_matmul(128, 64, 512, 512, rocblas, transa=False, transb=True)
+    verify_batch_matmul(128, 64, 512, 512, rocblas, transa=True, transb=False)
+    verify_batch_matmul(128, 64, 512, 512, rocblas, transa=True, transb=True)
+    verify_batch_matmul(128, 512, 512, 64, rocblas, transa=False, transb=False)
+    verify_batch_matmul(128, 512, 512, 64, rocblas, transa=False, transb=True)
+    verify_batch_matmul(128, 512, 512, 64, rocblas, transa=True, transb=False)
+    verify_batch_matmul(128, 512, 512, 64, rocblas, transa=True, transb=True)
+    verify_batch_matmul(128, 512, 64, 512, rocblas, transa=False, transb=False)
+    verify_batch_matmul(128, 512, 64, 512, rocblas, transa=False, transb=True)
+    verify_batch_matmul(128, 512, 64, 512, rocblas, transa=True, transb=False)
+    verify_batch_matmul(128, 512, 64, 512, rocblas, transa=True, transb=True)
+    verify_batch_matmul(128, 64, 128, 128, rocblas, transa=False, transb=False)
+    verify_batch_matmul(128, 64, 128, 128, rocblas, transa=False, transb=True)
+    verify_batch_matmul(128, 64, 128, 128, rocblas, transa=True, transb=False)
+    verify_batch_matmul(128, 64, 128, 128, rocblas, transa=True, transb=True)
+    verify_batch_matmul(128, 128, 128, 64, rocblas, transa=False, transb=False)
+    verify_batch_matmul(128, 128, 128, 64, rocblas, transa=False, transb=True)
+    verify_batch_matmul(128, 128, 128, 64, rocblas, transa=True, transb=False)
+    verify_batch_matmul(128, 128, 128, 64, rocblas, transa=True, transb=True)
+
+
 if __name__ == "__main__":
-    test_matmul_add()
+    test_matmul()
+    test_batch_matmul()


### PR DESCRIPTION
Support rocBLAS batched GEMM and prioritize rocBLAS strategy over codegen when no costs are provided via a tuning config. Also canonicalize invocation of column major rocBLAS APIs for matmul and batched_matmul.