### PR TITLE
[Ansor] Support multiple output ops and fix Python API printing

### DIFF
--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -997,8 +997,6 @@ std::pair<te::Schedule, Array<te::Tensor>> ComputeDAG::ApplySteps(
   }
 
   // Create the initial schedule
-  // TODO(jcf94): Currently we only checked single output dag for TVM Auto-scheduler,
-  // update this after testing with multiple outputs.
   te::Schedule schedule = te::create_schedule(ops);
 
   // init axes
@@ -1027,8 +1025,6 @@ String ComputeDAG::PrintStepsAsPython(const Array<Step>& transform_steps) const 
     }
   }
   // Create the initial schedule
-  // TODO(jcf94): Currently we only checked single output dag for TVM Auto-scheduler,
-  // update this after testing with multiple outputs.
   te::Schedule schedule = te::create_schedule(ops);
 
   // init axes

--- a/src/auto_scheduler/search_policy/sketch_policy_rules.h
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.h
@@ -28,6 +28,7 @@
 #include <tvm/auto_scheduler/loop_state.h>
 #include <tvm/auto_scheduler/search_task.h>
 
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/auto_scheduler/search_policy/sketch_policy_rules.h
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.h
@@ -76,6 +76,10 @@ class SketchGenerationRule {
   virtual std::vector<std::pair<State, int>> Apply(const SketchPolicyNode& policy,
                                                    const State& state, int stage_id) const = 0;
 
+  /*!
+   * \brief Get the name of this rule.
+   * \return A string of the rule name.
+   */
   virtual std::string GetRuleName() const = 0;
 };
 

--- a/src/auto_scheduler/search_policy/sketch_policy_rules.h
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.h
@@ -85,7 +85,7 @@ class SketchGenerationRule {
                                 int stage_id) const final;                                       \
     std::vector<std::pair<State, int>> Apply(const SketchPolicyNode& policy, const State& state, \
                                              int stage_id) const final;                          \
-    std::string GetRuleName() const final { return #rule_name; }                                \
+    std::string GetRuleName() const final { return #rule_name; }                                 \
   };
 
 /*! \brief The rule that simply skips the current stage. It returns an unchanged state and move to

--- a/src/auto_scheduler/search_policy/sketch_policy_rules.h
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.h
@@ -74,6 +74,8 @@ class SketchGenerationRule {
    */
   virtual std::vector<std::pair<State, int>> Apply(const SketchPolicyNode& policy,
                                                    const State& state, int stage_id) const = 0;
+
+  virtual std::string GetRuleName() const = 0;
 };
 
 #define DEFINE_SKETCH_GENERATION_RULE(rule_name)                                                 \
@@ -83,6 +85,7 @@ class SketchGenerationRule {
                                 int stage_id) const final;                                       \
     std::vector<std::pair<State, int>> Apply(const SketchPolicyNode& policy, const State& state, \
                                              int stage_id) const final;                          \
+    std::string GetRuleName() const final { return #rule_name; }                                \
   };
 
 /*! \brief The rule that simply skips the current stage. It returns an unchanged state and move to

--- a/src/auto_scheduler/utils.h
+++ b/src/auto_scheduler/utils.h
@@ -209,16 +209,20 @@ inline int64_t AxisLengthProd(const Array<tir::IterVar>& axes) {
 }
 
 /*!
- * \brief Clean the name of an iterator to make it valid in python code.
+ * \brief Clean the name of an iterator or an op to make it valid in python code.
  * \param str The original name.
+ * \param prefix The name prefix to differentiate the same name (e.g., the same iterator names).
  * \return The cleaned name.
  */
-inline std::string CleanName(const std::string& str) {
+inline std::string CleanName(const std::string& str, const std::string& prefix = "") {
   std::string ret = str;
   StrReplace(&ret, ".", "_");
   StrReplace(&ret, "@", "_");
   StrReplace(&ret, "outer", "o");
   StrReplace(&ret, "inner", "i");
+  if (prefix != "") {
+    return prefix + "_" + ret;
+  }
   return ret;
 }
 


### PR DESCRIPTION
As I'm trying to use Ansor to tune the operators generated from `te.gradient`, I fixed some issues in this PR so that now Ansor can tune the backward ops (regardless the performance). Detail change list:

- [Multiple Output] Create a schedule with all outputs instead of the first output.
- [Python API Printing] Change `tvm.thread_axis` to `te.thread_axis`.
- [Python API Printing] Add prefix to all iterators to avoid name conflict; otherwise we may refer to the wrong iterator with the same name hint (e.g., `ax0`). For example:

```python
ax0, ... = tuple(pad_temp_data_grad.op.axis) + ...
...
ax0, ... = tuple(pad_temp_shared.op.axis) + ...
s[pad_temp_data_grad].split(ax0, factor=4)
```
where `ax0` in `split` should refer to the `ax0` from `pad_temp_data_grad`, but it has been overridden by `pad_temp_shared` after `cache_read`. This PR improves `CleanName` by providing an optional prefix so that we can differentiate those iterators by their stages.

cc @merrymercy @jcf94 