### PR TITLE
[Frontend][Tensorflow] Fix TF 1.15 conv2d_transpose parsing

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -302,7 +302,11 @@ def _conv(opname):
             )
             attr["data_format"] = "NCHW"
 
-            if opname == "conv_transpose" and len(attr["_output_shapes"]) > 0:
+            if (
+                opname == "conv_transpose"
+                and len(attr["_output_shapes"]) > 0
+                and attr["_output_shapes"][0]
+            ):
                 tmp_shape = attr["_output_shapes"][0]
                 tmp_shape = [tmp_shape[ii] for ii in (0, 3, 1, 2)]
                 attr["_output_shapes"][0] = tmp_shape
@@ -385,7 +389,11 @@ def _conv(opname):
             kernel_h, kernel_w = attr["kernel_shape"]
 
             pdata_shape = input_shape
-            if opname == "conv_transpose" and len(attr["_output_shapes"]) > 0:
+            if (
+                opname == "conv_transpose"
+                and len(attr["_output_shapes"]) > 0
+                and attr["_output_shapes"][0]
+            ):
                 pdata_shape = attr["_output_shapes"][0]
 
             if attr["data_format"] == "NHWC":

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -302,6 +302,7 @@ def _conv(opname):
             )
             attr["data_format"] = "NCHW"
 
+            # Check whether output shapes attribute is set and not None
             if (
                 opname == "conv_transpose"
                 and len(attr["_output_shapes"]) > 0
@@ -389,6 +390,7 @@ def _conv(opname):
             kernel_h, kernel_w = attr["kernel_shape"]
 
             pdata_shape = input_shape
+            # Check whether output shapes attribute is set and not None
             if (
                 opname == "conv_transpose"
                 and len(attr["_output_shapes"]) > 0

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -204,6 +204,7 @@ def compare_tf_with_tvm(
     opt_level=3,
     mode="graph_runtime",
     cuda_layout="NCHW",
+    add_shapes_to_graph_def=True,
 ):
     """Generic function to generate and compare tensorflow and TVM output"""
 
@@ -219,7 +220,11 @@ def compare_tf_with_tvm(
     with tf.Session() as sess:
         if init_global_variables:
             sess.run(variables.global_variables_initializer())
-        final_graph_def = tf_testing.AddShapesToGraphDef(sess, out_node)
+        final_graph_def = (
+            tf_testing.AddShapesToGraphDef(sess, out_node)
+            if add_shapes_to_graph_def
+            else tf.get_default_graph().as_graph_def()
+        )
 
         tf_output = run_tf_graph(sess, in_data, in_name, out_name)
 
@@ -420,6 +425,7 @@ def _test_convolution(
     padding,
     data_format,
     deconv_output_shape=[],
+    add_shapes_to_graph_def=True,
 ):
     """ One iteration of convolution with given shapes and attributes """
 
@@ -454,6 +460,7 @@ def _test_convolution(
                 np.reshape(data_array, tensor_in_sizes).astype("float32"),
                 "Placeholder:0",
                 "Conv2D:0",
+                add_shapes_to_graph_def=add_shapes_to_graph_def,
             )
         elif opname == "conv_transpose":
             nn_ops.conv2d_transpose(
@@ -469,6 +476,7 @@ def _test_convolution(
                 np.reshape(data_array, tensor_in_sizes).astype("float32"),
                 "Placeholder:0",
                 "conv2d_transpose:0",
+                add_shapes_to_graph_def=add_shapes_to_graph_def,
             )
         else:
             nn_ops.depthwise_conv2d_native(
@@ -484,6 +492,7 @@ def _test_convolution(
                 np.reshape(data_array, tensor_in_sizes).astype("float32"),
                 "Placeholder:0",
                 "DepthwiseConv2dNative:0",
+                add_shapes_to_graph_def=add_shapes_to_graph_def,
             )
 
 
@@ -646,11 +655,32 @@ def test_forward_convolution():
     _test_convolution("conv", [4, 17, 17, 19], [3, 3, 19, 19], [1, 1], [2, 2], "VALID", "NHWC")
     _test_convolution("conv", [4, 17, 17, 124], [1, 1, 124, 19], [1, 1], [1, 1], "SAME", "NHWC")
     _test_convolution("conv", [4, 17, 17, 12], [3, 3, 12, 32], [1, 1], [2, 2], "VALID", "NHWC")
+    _test_convolution(
+        "conv",
+        [4, 17, 17, 12],
+        [3, 3, 12, 32],
+        [1, 1],
+        [2, 2],
+        "VALID",
+        "NHWC",
+        add_shapes_to_graph_def=False,
+    )
     _test_convolution("depthwise", [4, 8, 8, 176], [1, 1, 176, 1], [1, 1], [1, 1], "SAME", "NHWC")
     _test_convolution("depthwise", [4, 17, 17, 19], [3, 3, 19, 1], [1, 1], [2, 2], "VALID", "NHWC")
     _test_convolution("depthwise", [4, 17, 17, 124], [1, 1, 124, 1], [1, 1], [1, 1], "SAME", "NHWC")
     _test_convolution("depthwise", [4, 17, 17, 12], [3, 3, 12, 1], [1, 1], [2, 2], "VALID", "NHWC")
     _test_convolution("depthwise", [4, 17, 17, 12], [3, 3, 12, 2], [1, 1], [2, 2], "VALID", "NHWC")
+    _test_convolution(
+        "depthwise",
+        [4, 17, 17, 12],
+        [3, 3, 12, 2],
+        [1, 1],
+        [2, 2],
+        "VALID",
+        "NHWC",
+        add_shapes_to_graph_def=False,
+    )
+
     _test_convolution(
         "conv_transpose",
         [4, 8, 8, 32],
@@ -783,6 +813,18 @@ def test_forward_convolution():
         "NHWC",
         [1, 8, 8, 1],
     )
+    # Test without adding shapes to graph def
+    _test_convolution(
+        "conv_transpose",
+        [4, 8, 8, 32],
+        [1, 1, 176, 32],
+        [1, 1],
+        [1, 1],
+        "SAME",
+        "NHWC",
+        [4, 8, 8, 176],
+        add_shapes_to_graph_def=False,
+    )
 
 
 #######################################################################
@@ -799,6 +841,7 @@ def _test_convolution3d(
     padding,
     data_format,
     deconv_output_shape=[],
+    add_shapes_to_graph_def=True,
 ):
     """ One iteration of 3D convolution with given shapes and attributes """
 
@@ -834,6 +877,7 @@ def _test_convolution3d(
                 "Placeholder:0",
                 "Conv3D:0",
                 cuda_layout="NCDHW",
+                add_shapes_to_graph_def=add_shapes_to_graph_def,
             )
 
 
@@ -864,6 +908,17 @@ def test_forward_convolution3d():
     _test_convolution3d(
         "conv", [4, 17, 17, 17, 12], [3, 3, 3, 12, 32], [1, 1, 1], [2, 2, 2], "VALID", "NDHWC"
     )
+    # Test without adding shapes to graph def
+    _test_convolution3d(
+        "conv",
+        [4, 17, 17, 17, 12],
+        [3, 3, 3, 12, 32],
+        [1, 1, 1],
+        [2, 2, 2],
+        "VALID",
+        "NDHWC",
+        add_shapes_to_graph_def=False,
+    )
 
 
 #######################################################################
@@ -872,7 +927,13 @@ def test_forward_convolution3d():
 
 
 def _test_convolution3d_transpose(
-    data_shape, filter_shape, strides, padding, output_shape, data_format="NCDHW"
+    data_shape,
+    filter_shape,
+    strides,
+    padding,
+    output_shape,
+    data_format="NCDHW",
+    add_shapes_to_graph_def=True,
 ):
     """ One iteration of 3D convolution transpose with given shapes and attributes """
 
@@ -897,7 +958,13 @@ def _test_convolution3d_transpose(
             data_format=data_format,
         )
 
-        compare_tf_with_tvm(data_array, "Placeholder:0", "conv3d_transpose:0", cuda_layout="NDHWC")
+        compare_tf_with_tvm(
+            data_array,
+            "Placeholder:0",
+            "conv3d_transpose:0",
+            cuda_layout="NDHWC",
+            add_shapes_to_graph_def=add_shapes_to_graph_def,
+        )
 
 
 @tvm.testing.uses_gpu
@@ -969,6 +1036,17 @@ def test_forward_convolution3d_transpose():
         padding="VALID",
         output_shape=[1, 24, 24, 24, 6],
         data_format="NDHWC",
+    )
+
+    # Test without adding shapes to graph def
+    _test_convolution3d_transpose(
+        data_shape=[1, 8, 8, 8, 16],
+        filter_shape=[3, 3, 3, 6, 16],
+        strides=[3, 3, 3],
+        padding="VALID",
+        output_shape=[1, 24, 24, 24, 6],
+        data_format="NDHWC",
+        add_shapes_to_graph_def=False,
     )
 
 


### PR DESCRIPTION
Fix for Tensorflow 1.15.0 conv2d_transpose parsing. Specifically, attr["_output_shapes"][0] can be None.

Following snippet can be used to create a model for reproducing the bug (run with TF 1.15.0):
```
import tensorflow as tf

output_shape = [1, 8, 8, 128]
strides = [1, 2, 2, 1]

x = tf.compat.v1.placeholder(tf.float32, shape=[1, 32, 32, 4])
w = tf.constant(0.1, shape=[7, 7, 128, 4])
ct = tf.nn.conv2d_transpose(x, w, output_shape=output_shape, strides=strides, padding='SAME')

graph_def = tf.compat.v1.get_default_graph().as_graph_def()
with tf.io.gfile.GFile('conv2d_transpose_tf1_15.pb', "wb") as f:
    f.write(graph_def.SerializeToString())
```

In general, I think it might be useful to adjust the CI to run the frontend tests with multiple versions of the the external frameworks to verify compatibility with the versions we want to support?

@siju-samuel @masahi, could you have a look?