### PR TITLE
[Topi][Cuda] Tiny bug fix for non-fp32 datatypes in conv2d_transpose.

### DIFF
--- a/python/tvm/topi/cuda/conv2d_transpose_nchw.py
+++ b/python/tvm/topi/cuda/conv2d_transpose_nchw.py
@@ -96,7 +96,7 @@ def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_
                 tvm.tir.indexdiv(y - pad_top, stride_height),
                 tvm.tir.indexdiv(x - pad_left, stride_width),
             ],
-            tvm.tir.const(0.0, "float32"),
+            tvm.tir.const(0.0, data.dtype),
         ),
         name="data_pad",
     )


### PR DESCRIPTION
The pad operator in the Cuda definition of conv2d_transpose assumed the input type was `float32`. This oneliner PR fixes that assumption.