### PR TITLE
[docs] Missing documentation dependency 'autodocsumm' on docs/README.txt

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -3,7 +3,7 @@ TVM Documentations
 This folder contains the source of TVM documents
 
 - A hosted version of doc is at https://tvm.apache.org/docs
-- pip install sphinx>=1.5.5 sphinx-gallery sphinx_rtd_theme matplotlib Image recommonmark "Pillow<7"
+- pip install sphinx>=1.5.5 sphinx-gallery sphinx_rtd_theme matplotlib Image recommonmark "Pillow<7" autodocsumm
 - Build tvm first in the root folder.
 - Run the following command
 ```bash


### PR DESCRIPTION
When testing a new tutorial I'm writing about TVMC, I noticed that the guidance to generate docs is missing one plugin: `autodocsumm`.

If this is not present you'll see an error like this:
```
$ ./tests/scripts/task_sphinx_precheck.sh
cd python; python3 setup.py build_ext --inplace
WARNING: Cython is not installed, will compile without cython module
running build_ext
PreCheck sphinx doc generation WARNINGS..
rm -rf _build/*
rm -rf gen_modules
rm -rf tutorials
rm -rf vta/tutorials
python3 -m sphinx -b html -d _build/doctrees   . _build/html
Running Sphinx v3.2.1

Extension error:
Could not import extension autodocsumm (exception: No module named 'autodocsumm')
Makefile:70: recipe for target 'html' failed
make: *** [html] Error 2
```