### PR TITLE
Updated runtime to run under FreeBSD.

### DIFF
--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -70,7 +70,7 @@ def find_lib_path(name=None, search_path=None, optional=False):
     if os.environ.get("TVM_LIBRARY_PATH", None):
         dll_path.append(os.environ["TVM_LIBRARY_PATH"])
 
-    if sys.platform.startswith("linux"):
+    if sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         dll_path.extend(split_env_var("LD_LIBRARY_PATH", ":"))
         dll_path.extend(split_env_var("PATH", ":"))
     elif sys.platform.startswith("darwin"):

--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -17,6 +17,7 @@
 """Util to invoke C/C++ compilers in the system."""
 # pylint: disable=invalid-name
 import sys
+import os
 import subprocess
 
 from .._ffi.base import py_str
@@ -39,7 +40,8 @@ def create_shared(output, objects, options=None, cc="g++"):
     cc : Optional[str]
         The compiler command.
     """
-    if sys.platform == "darwin" or sys.platform.startswith("linux"):
+    if sys.platform == "darwin" or sys.platform.startswith("linux") \
+           or sys.platform.startswith("freebsd"):
         _linux_compile(output, objects, options, cc, compile_shared=True)
     elif sys.platform == "win32":
         _windows_shared(output, objects, options)
@@ -103,7 +105,8 @@ def get_target_by_dump_machine(compiler):
 # assign so as default output format
 create_shared.output_format = "so" if sys.platform != "win32" else "dll"
 create_shared.get_target_triple = get_target_by_dump_machine(
-    "g++" if sys.platform == "darwin" or sys.platform.startswith("linux") else None
+    os.environ["CXX"] if "CXX" in os.environ.keys() else \
+        "g++" if sys.platform == "darwin" or sys.platform.startswith("linux") else None
 )
 
 

--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -105,8 +105,7 @@ def get_target_by_dump_machine(compiler):
 # assign so as default output format
 create_shared.output_format = "so" if sys.platform != "win32" else "dll"
 create_shared.get_target_triple = get_target_by_dump_machine(
-    os.environ["CXX"] if "CXX" in os.environ.keys() else \
-        "g++" if sys.platform == "darwin" or sys.platform.startswith("linux") else None
+    os.environ.get("CXX", "g++" if sys.platform == "darwin" or sys.platform.startswith("linux") else None)
 )
 
 

--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -40,8 +40,11 @@ def create_shared(output, objects, options=None, cc="g++"):
     cc : Optional[str]
         The compiler command.
     """
-    if sys.platform == "darwin" or sys.platform.startswith("linux") \
-           or sys.platform.startswith("freebsd"):
+    if (
+        sys.platform == "darwin"
+        or sys.platform.startswith("linux")
+        or sys.platform.startswith("freebsd")
+    ):
         _linux_compile(output, objects, options, cc, compile_shared=True)
     elif sys.platform == "win32":
         _windows_shared(output, objects, options)

--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -105,7 +105,9 @@ def get_target_by_dump_machine(compiler):
 # assign so as default output format
 create_shared.output_format = "so" if sys.platform != "win32" else "dll"
 create_shared.get_target_triple = get_target_by_dump_machine(
-    os.environ.get("CXX", "g++" if sys.platform == "darwin" or sys.platform.startswith("linux") else None)
+    os.environ.get(
+        "CXX", "g++" if sys.platform == "darwin" or sys.platform.startswith("linux") else None
+    )
 )
 
 

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -74,7 +74,7 @@ def _server_env(load_library, work_path=None):
     def download_linked_module(file_name):
         """Load module from remote side."""
         # c++ compiler/linker
-        cc = os.environ['CXX'] if 'CXX' in os.environ.keys() else "g++"
+        cc = os.environ.get("CXX", "g++")
 
         # pylint: disable=import-outside-toplevel
         path = temp.relpath(file_name)

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -73,6 +73,9 @@ def _server_env(load_library, work_path=None):
     @tvm._ffi.register_func("tvm.rpc.server.download_linked_module", override=True)
     def download_linked_module(file_name):
         """Load module from remote side."""
+        # c++ compiler/linker
+        cc = os.environ['CXX'] if 'CXX' in os.environ.keys() else "g++"
+
         # pylint: disable=import-outside-toplevel
         path = temp.relpath(file_name)
 
@@ -80,7 +83,7 @@ def _server_env(load_library, work_path=None):
             # Extra dependencies during runtime.
             from tvm.contrib import cc as _cc
 
-            _cc.create_shared(path + ".so", path)
+            _cc.create_shared(path + ".so", path, cc=cc)
             path += ".so"
         elif path.endswith(".tar"):
             # Extra dependencies during runtime.
@@ -89,7 +92,7 @@ def _server_env(load_library, work_path=None):
             tar_temp = util.tempdir(custom_path=path.replace(".tar", ""))
             _tar.untar(path, tar_temp.temp_dir)
             files = [tar_temp.relpath(x) for x in tar_temp.listdir()]
-            _cc.create_shared(path + ".so", files)
+            _cc.create_shared(path + ".so", files, cc=cc)
             path += ".so"
         elif path.endswith(".dylib") or path.endswith(".so"):
             pass

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -396,7 +396,7 @@ def load_module(path, fmt=""):
     """
 
     # c++ compiler/linker
-    cc = os.environ["CXX"] if "CXX" in os.environ.keys() else "g++"
+    cc = os.environ.get("CXX", "g++")
 
     # High level handling for .o and .tar file.
     # We support this to be consistent with RPC module load.

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -17,6 +17,7 @@
 
 # pylint: disable=invalid-name, unused-import, import-outside-toplevel
 """Runtime Module namespace."""
+import os
 import ctypes
 import struct
 from collections import namedtuple
@@ -393,13 +394,17 @@ def load_module(path, fmt=""):
     This function will automatically call
     cc.create_shared if the path is in format .o or .tar
     """
+
+    # c++ compiler/linker
+    cc = os.environ["CXX"] if "CXX" in os.environ.keys() else "g++"
+
     # High level handling for .o and .tar file.
     # We support this to be consistent with RPC module load.
     if path.endswith(".o"):
         # Extra dependencies during runtime.
         from tvm.contrib import cc as _cc
 
-        _cc.create_shared(path + ".so", path)
+        _cc.create_shared(path + ".so", path, cc=cc)
         path += ".so"
     elif path.endswith(".tar"):
         # Extra dependencies during runtime.
@@ -408,7 +413,7 @@ def load_module(path, fmt=""):
         tar_temp = _util.tempdir(custom_path=path.replace(".tar", ""))
         _tar.untar(path, tar_temp.temp_dir)
         files = [tar_temp.relpath(x) for x in tar_temp.listdir()]
-        _cc.create_shared(path + ".so", files)
+        _cc.create_shared(path + ".so", files, cc=cc)
         path += ".so"
     # TODO(weberlo): we should probably use a more distinctive suffix for uTVM object files
     elif path.endswith(".obj"):


### PR DESCRIPTION
setenv CXX to proper binary - c++ or g++9 for FreeBSD 12.0.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
