### PR TITLE
[Parser] Fix parsing op string attributes

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -412,7 +412,7 @@ inline void SetIntValue(T* ptr, const TVMArgValue& val) {
 
 template <>
 inline void SetValue<std::string>(std::string* ptr, const TVMArgValue& val) {
-  if (val.type_code() == kTVMStr) {
+  if (String::CanConvertFrom(val)) {
     *ptr = val.operator std::string();
   } else {
     LOG(FATAL) << "Expect str";

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -488,9 +488,11 @@ class TVMArgValue : public TVMPODValue_ {
     } else if (type_code_ == kTVMBytes) {
       TVMByteArray* arr = static_cast<TVMByteArray*>(value_.v_handle);
       return std::string(arr->data, arr->size);
-    } else {
-      TVM_CHECK_TYPE_CODE(type_code_, kTVMStr);
+    } else if (type_code_ == kTVMStr) {
       return std::string(value_.v_str);
+    } else {
+      CHECK(IsObjectRef<tvm::runtime::String>());
+      return AsObjectRef<tvm::runtime::String>().operator std::string();
     }
   }
   operator PackedFunc() const {

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -837,6 +837,20 @@ def test_resnet_inlined_params():
     tvm.ir.assert_structural_equal(mod, parsed_mod)
 
 
+def test_op_string_attr():
+    call = parse_text(
+        """
+        free_var %x: Tensor[(1, 32, 32, 3), float32];
+        free_var %y: Tensor[(1, 1, 3, 3), float32];
+        nn.conv2d(%x, %y, data_layout="NHWC", kernel_layout="HWIO")
+        """
+    )
+    assert isinstance(call.op, tvm.ir.Op)
+    assert call.op.name == "nn.conv2d"
+    assert call.attrs.data_layout == "NHWC"
+    assert call.attrs.kernel_layout == "HWIO"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Attribute convertor failed to set string type field when a kTVMObjectHandle with underlying type of StringObj is passed in.  This causes relay parser error when creating conv2d op with customized data_layout string attribute.  @jroesch