### PR TITLE
[BUG_FIX] Fixes #6608: CHECK(data != nullptr) causes type checking to fail

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -767,7 +767,11 @@ bool ArgWhereRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                  const TypeReporter& reporter) {
   CHECK_EQ(num_inputs, 1);
   auto tt = types[0].as<TensorTypeNode>();
-  CHECK(tt != nullptr);
+
+  if (tt == nullptr) {
+    return false;
+  }
+
   const auto& input_shape = tt->shape;
   const auto& input_rank = input_shape.size();
   std::vector<IndexExpr> result_shape;
@@ -1643,7 +1647,10 @@ bool WhereRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   const auto* condition = types[0].as<TensorTypeNode>();
   const auto* x = types[1].as<TensorTypeNode>();
   const auto* y = types[2].as<TensorTypeNode>();
-  CHECK(condition != nullptr && x != nullptr && y != nullptr);
+
+  if (condition == nullptr || x == nullptr || y == nullptr) {
+    return false;
+  }
 
   const auto& cond_shape = condition->shape;
   const auto& x_shape = x->shape;
@@ -1979,7 +1986,11 @@ bool StridedSliceRel(const Array<Type>& types, int num_inputs, const Attrs& attr
   const StridedSliceAttrs* param = attrs.as<StridedSliceAttrs>();
   CHECK(param != nullptr);
   const auto* data = types[0].as<TensorTypeNode>();
-  CHECK(data != nullptr);
+
+  if (data != nullptr) {
+    return false;
+  }
+
   auto dshape = data->shape;
   int64_t num_axis = dshape.size();
 
@@ -3028,7 +3039,10 @@ bool SparseToDenseRel(const Array<Type>& types, int num_inputs, const Attrs& att
   auto sparse_indices = types[0].as<TensorTypeNode>();
   auto sparse_values = types[1].as<TensorTypeNode>();
   auto default_value = types[2].as<TensorTypeNode>();
-  CHECK(sparse_indices != nullptr && sparse_values != nullptr && default_value != nullptr);
+
+  if(sparse_indices == nullptr || sparse_values == nullptr || default_value == nullptr) {
+    return false;
+  }
 
   CHECK(sparse_indices->dtype.is_int()) << "sparse_indices must be tensor of integers";
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1986,7 +1986,7 @@ bool StridedSliceRel(const Array<Type>& types, int num_inputs, const Attrs& attr
   CHECK(param != nullptr);
   const auto* data = types[0].as<TensorTypeNode>();
 
-  if (data != nullptr) {
+  if (data == nullptr) {
     return false;
   }
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -890,7 +890,6 @@ RELAY_REGISTER_OP("scatter_add")
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
     .set_support_level(10);
 
-
 // Take
 TVM_REGISTER_NODE_TYPE(TakeAttrs);
 
@@ -3040,7 +3039,7 @@ bool SparseToDenseRel(const Array<Type>& types, int num_inputs, const Attrs& att
   auto sparse_values = types[1].as<TensorTypeNode>();
   auto default_value = types[2].as<TensorTypeNode>();
 
-  if(sparse_indices == nullptr || sparse_values == nullptr || default_value == nullptr) {
+  if (sparse_indices == nullptr || sparse_values == nullptr || default_value == nullptr) {
     return false;
   }
 

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -461,9 +461,9 @@ bool NdarraySizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   auto tt = types[0].as<TensorTypeNode>();
 
   if (tt == nullptr) {
-      return false;
+    return false;
   }
-  
+
   const auto* param = attrs.as<NdarraySizeAttrs>();
   CHECK(param != nullptr);
   reporter->Assign(types[1], TensorType({}, param->dtype));

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -459,7 +459,11 @@ bool NdarraySizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
                     const TypeReporter& reporter) {
   CHECK_EQ(num_inputs, 1);
   auto tt = types[0].as<TensorTypeNode>();
-  CHECK(tt != nullptr);
+
+  if (tt == nullptr) {
+      return false;
+  }
+  
   const auto* param = attrs.as<NdarraySizeAttrs>();
   CHECK(param != nullptr);
   reporter->Assign(types[1], TensorType({}, param->dtype));

--- a/src/relay/op/vision/multibox_op.cc
+++ b/src/relay/op/vision/multibox_op.cc
@@ -83,7 +83,10 @@ bool MultiBoxTransformLocRel(const Array<Type>& types, int num_inputs, const Att
   const auto* cls_prob = types[0].as<TensorTypeNode>();
   const auto* loc_pred = types[1].as<TensorTypeNode>();
   const auto* anchor = types[2].as<TensorTypeNode>();
-  CHECK(cls_prob != nullptr && loc_pred != nullptr && anchor != nullptr);
+
+  if (cls_prob == nullptr || loc_pred == nullptr || anchor == nullptr) {
+      return false;
+  }
 
   const auto& cls_shape = cls_prob->shape;
   const auto& loc_shape = loc_pred->shape;

--- a/src/relay/op/vision/multibox_op.cc
+++ b/src/relay/op/vision/multibox_op.cc
@@ -85,7 +85,7 @@ bool MultiBoxTransformLocRel(const Array<Type>& types, int num_inputs, const Att
   const auto* anchor = types[2].as<TensorTypeNode>();
 
   if (cls_prob == nullptr || loc_pred == nullptr || anchor == nullptr) {
-      return false;
+    return false;
   }
 
   const auto& cls_shape = cls_prob->shape;

--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -40,7 +40,11 @@ bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                    const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 4);
   const auto* data = types[0].as<TensorTypeNode>();
-  CHECK(data != nullptr);
+  
+  if (data == nullptr) {
+    return false;
+  }
+
   const auto input_dtype = data->dtype;
   CHECK(input_dtype == DataType::Int(8) || input_dtype == DataType::UInt(8) ||
         input_dtype == DataType::Int(32))

--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -40,7 +40,7 @@ bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                    const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 4);
   const auto* data = types[0].as<TensorTypeNode>();
-  
+
   if (data == nullptr) {
     return false;
   }

--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -44,7 +44,7 @@ bool QuantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   if (data == nullptr) {
     return false;
   }
-  
+
   const auto input_dtype = data->dtype;
   CHECK(input_dtype == DataType::Float(32))
       << "Input type should be one of float32 but was " << input_dtype;

--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -40,7 +40,11 @@ bool QuantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                  const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 4);
   const auto* data = types[0].as<TensorTypeNode>();
-  CHECK(data != nullptr);
+
+  if (data == nullptr) {
+    return false;
+  }
+  
   const auto input_dtype = data->dtype;
   CHECK(input_dtype == DataType::Float(32))
       << "Input type should be one of float32 but was " << input_dtype;

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -262,7 +262,7 @@ bool RequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   if (data == nullptr) {
     return false;
   }
-  
+
   const auto in_dtype = data->dtype;
   CHECK(in_dtype == DataType::Int(8) || in_dtype == DataType::UInt(8) ||
         in_dtype == DataType::Int(32))

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -258,7 +258,11 @@ bool RequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                    const TypeReporter& reporter) {
   CHECK_EQ(types.size(), 6);
   const auto* data = types[0].as<TensorTypeNode>();
-  CHECK(data != nullptr);
+
+  if (data == nullptr) {
+    return false;
+  }
+  
   const auto in_dtype = data->dtype;
   CHECK(in_dtype == DataType::Int(8) || in_dtype == DataType::UInt(8) ||
         in_dtype == DataType::Int(32))

--- a/src/relay/quantize/quantize.cc
+++ b/src/relay/quantize/quantize.cc
@@ -44,7 +44,11 @@ bool SimulatedQuantizeRel(const Array<Type>& types, int num_inputs, const Attrs&
   CHECK(param != nullptr);
 
   const auto* data = types[0].as<TensorTypeNode>();
-  CHECK(data != nullptr);
+
+  if (data == nullptr) {
+    return false;
+  }
+  
   CHECK_NE(data->shape.size(), 0) << "Input shape cannot be empty";
 
   reporter->Assign(types[1], TensorType({}, DataType::Float(32)));  // dom_scale

--- a/src/relay/quantize/quantize.cc
+++ b/src/relay/quantize/quantize.cc
@@ -48,7 +48,7 @@ bool SimulatedQuantizeRel(const Array<Type>& types, int num_inputs, const Attrs&
   if (data == nullptr) {
     return false;
   }
-  
+
   CHECK_NE(data->shape.size(), 0) << "Input shape cannot be empty";
 
   reporter->Assign(types[1], TensorType({}, DataType::Float(32)));  // dom_scale


### PR DESCRIPTION
Some type rels check that argument types are not null. In certain cases, this can cause the type inferencer to exit prematurely, and the model cannot be run.

Instead of checking that argument types are not null, type rels should just return false, and allow the type checker to determine if the type of arguments cannot be inferred. 

I believe this PR fixes all of the type rels with this issue, however I could have missed some. If you find another, please let me know. 

See issue #6608 for more details.

cc @jwfromm @vegaluisjose @areusch @mbrookhart 