### PR TITLE
[Bugfix] Simplify reduce expression in te.gradient

### DIFF
--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -1172,8 +1172,10 @@ PrimExpr RemoveJacobianAndLiftNonzeroCondImpl(const PrimExpr& expr_orig, const A
 
       new_red = Reduce(red->combiner, source, red->axis, cond, red->value_index, red->init);
       new_red = SimplifyReductionDomain(new_red, combined_vranges);
+      // Update original red pointer for later use.
+      red = new_red.as<ReduceNode>();
       // If the reduction disappears completely then transform the result as a non-reduction
-      if (!new_red.as<ReduceNode>()) {
+      if (!red) {
         return RemoveJacobianAndLiftNonzeroCondImpl(new_red, axis, vranges);
       }
 


### PR DESCRIPTION
Update the pointer with simplified reduction for later use.
The bug doesn't affect functionality but does harm to performance.

@ArmageddonKnight @comaniac 
better to be included in the release. @zhiics @ZihengJiang 
