### PR TITLE
[FIX,AUTOTVM] Print warning when all autotvm tasks fail with errors

### DIFF
--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -17,6 +17,7 @@
 # pylint: disable=unused-argument, no-self-use, invalid-name
 """Base class of tuner"""
 import logging
+import tempfile
 
 import numpy as np
 
@@ -177,11 +178,14 @@ class Tuner(object):
                 logger.setLevel(old_level)
 
         if error_ct == i:
+            _, f = tempfile.mkstemp(prefix="tvm_tuning_", suffix=".log", text=True)
+            with open(f, "w") as file:
+                file.write("\n".join(errors))
             logging.warning(
-                "Could not find a single schedule for task %s. A fallback config will be used. "
-                "The following errors occured:\n  %s",
+                "Could not find a single schedule for task %s. "
+                "A file containing the errors has been written to %s.",
                 self.task,
-                "\n  ".join(errors),
+                f,
             )
         GLOBAL_SCOPE.in_tuning = False
         del measure_batch

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -141,7 +141,7 @@ class Tuner(object):
                 else:
                     flops = 0
                     error_ct += 1
-                    errors.extend([r.costs[0] for r in results])
+                    errors.append(res.costs[0])
 
                 if flops > self.best_flops:
                     self.best_flops = flops

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -121,6 +121,7 @@ class Tuner(object):
 
         GLOBAL_SCOPE.in_tuning = True
         i = error_ct = 0
+        errors = []
         while i < n_trial:
             if not self.has_next():
                 break
@@ -139,6 +140,7 @@ class Tuner(object):
                 else:
                     flops = 0
                     error_ct += 1
+                    errors.extend([r.costs[0] for r in results])
 
                 if flops > self.best_flops:
                     self.best_flops = flops
@@ -174,6 +176,11 @@ class Tuner(object):
             else:
                 logger.setLevel(old_level)
 
+        if error_ct == i:
+            logging.warning(
+                "Could not find a single schedule for task %s. A fallback config will be used. The following errors occured:\n  %s"
+                % (self.task, "\n  ".join(errors))
+            )
         GLOBAL_SCOPE.in_tuning = False
         del measure_batch
 

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -178,8 +178,10 @@ class Tuner(object):
 
         if error_ct == i:
             logging.warning(
-                "Could not find a single schedule for task %s. A fallback config will be used. The following errors occured:\n  %s"
-                % (self.task, "\n  ".join(errors))
+                "Could not find a single schedule for task %s. A fallback config will be used. "
+                "The following errors occured:\n  %s",
+                self.task,
+                "\n  ".join(errors),
             )
         GLOBAL_SCOPE.in_tuning = False
         del measure_batch

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -182,7 +182,7 @@ class Tuner(object):
             with open(f, "w") as file:
                 file.write("\n".join(errors))
             logging.warning(
-                "Could not find a single schedule for task %s. "
+                "Could not find any valid schedule for task %s. "
                 "A file containing the errors has been written to %s.",
                 self.task,
                 f,

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -141,7 +141,11 @@ class Tuner(object):
                 else:
                     flops = 0
                     error_ct += 1
-                    errors.append(res.costs[0])
+                    error = res.costs[0]
+                    if isinstance(error, str):
+                        errors.append(error)
+                    else:
+                        errors.append(str(error))
 
                 if flops > self.best_flops:
                     self.best_flops = flops

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -178,7 +178,7 @@ class Tuner(object):
                 logger.setLevel(old_level)
 
         if error_ct == i:
-            _, f = tempfile.mkstemp(prefix="tvm_tuning_", suffix=".log", text=True)
+            _, f = tempfile.mkstemp(prefix="tvm_tuning_errors_", suffix=".log", text=True)
             with open(f, "w") as file:
                 file.write("\n".join(errors))
             logging.warning(


### PR DESCRIPTION
I recently encountered an issue where all my autotvm tasks failed. Unfortunately, I got no warnings, so I was very confused when I got a bunch of fallback config messages.

This PR fixes this situation by printing an error message is no config can be generated.