### PR TITLE
[ConvertLayout] Fix Strided Slice

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2183,6 +2183,11 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
       }
       auto factor = new_layout.FactorOf(axis);
       if (factor == -1) {
+        const LayoutAxis& new_axis = new_layout[i];
+        if (new_axis.name() != axis.name()) {
+          // original layout because the order of the axis has changed
+          return {{Layout::Undef()}, {Layout::Undef()}};
+        }
         new_begin.push_back(begin[i]);
         new_end.push_back(end[i]);
       } else {

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -1123,8 +1123,15 @@ def test_conv_strided_slice_convert_layout():
     def before():
         x = relay.var("x", shape=(1, 1200, 1200, 3))
         weight = relay.var("weight", shape=(3, 3, 3, 96))
-        y = relay.nn.conv2d(x, weight, channels=96, kernel_size=(3, 3), padding=(0, 0, 0, 0),
-                data_layout='NHWC', kernel_layout='HWIO')
+        y = relay.nn.conv2d(
+            x,
+            weight,
+            channels=96,
+            kernel_size=(3, 3),
+            padding=(0, 0, 0, 0),
+            data_layout="NHWC",
+            kernel_layout="HWIO",
+        )
         y = relay.nn.relu(y)
         y = relay.nn.pad(y, pad_width=((0, 0), (0, 1), (0, 1), (0, 0)))
         y = relay.strided_slice(y, begin=[0, 1, 1, 0], end=[1, 600, 600, 96], strides=[1, 1, 1, 1])
@@ -1136,7 +1143,13 @@ def test_conv_strided_slice_convert_layout():
         weight = relay.var("weight", shape=(3, 3, 3, 96))
         x = relay.layout_transform(x, "NHWC", "NCHW")
         weight = relay.layout_transform(weight, "HWIO", "OIHW")
-        y = relay.nn.conv2d(x, weight, channels=96, kernel_size=(3, 3), padding=(0, 0, 0, 0))
+        y = relay.nn.conv2d(
+            x,
+            weight,
+            channels=96,
+            kernel_size=(3, 3),
+            padding=(0, 0, 0, 0),
+        )
         y = relay.nn.relu(y)
         y = relay.nn.pad(y, pad_width=((0, 0), (0, 0), (0, 1), (0, 1)))
         y = relay.layout_transform(y, "NCHW", "NHWC")


### PR DESCRIPTION
While converting a network from NHWC to NCHW, we found that a conv2d was followed by strided_slice and it was erroring out. This PR ensures insertion of layout transform before the strided slice to correct the bug.

With careful handling of begin, end and strides, one can prevent the insertion of layout transform in future to get better performance.
@trevor-m 