### PR TITLE
[TVMC] fail gracefully in case no subcommand is provided

### DIFF
--- a/python/tvm/driver/tvmc/main.py
+++ b/python/tvm/driver/tvmc/main.py
@@ -79,7 +79,10 @@ def _main(argv):
         sys.stdout.write("%s\n" % version)
         return 0
 
-    assert hasattr(args, "func"), "Error: missing 'func' attribute for subcommand {0}".format(argv)
+    if not hasattr(args, "func"):
+        # In case no valid subcommand is provided, show usage and exit
+        parser.print_help(sys.stderr)
+        return 1
 
     try:
         return args.func(args)


### PR DESCRIPTION
This fixes an issue, when the user calls `tvmc` with no arguments at all. Rather than showing an `AssertError`, it now shows _usage_ and exit with code 1. @hogepodge reported it on Discuss.

cc @comaniac @hogepodge 