### PR TITLE
 [CI] Update ci-cpu to the latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = "tlcpack/ci-lint:v0.62"
 ci_gpu = "tlcpack/ci-gpu:v0.64"
-ci_cpu = "tlcpack/ci-cpu:v0.65"
+ci_cpu = "tlcpack/ci-cpu:v0.66"
 ci_wasm = "tlcpack/ci-wasm:v0.60"
 ci_i386 = "tlcpack/ci-i386:v0.52"
 // <--- End of regex-scanned config.


### PR DESCRIPTION
Specifically, making sure that some of the latest changes to TVM dockerfile are taken into account:
* Ethos n driver update: https://github.com/apache/incubator-tvm/pull/6606
* Vitis AI CI support: https://github.com/apache/incubator-tvm/pull/6342

@u99127 @leandron @jornt-xilinx 