### PR TITLE
[CI] add python environment setup as part of cpp unittest runner script

### DIFF
--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -19,6 +19,9 @@
 set -e
 set -u
 
+# Python is required by apps/bundle_deploy
+source tests/scripts/setup-pytest-env.sh
+
 export LD_LIBRARY_PATH="lib:${LD_LIBRARY_PATH:-}"
 # NOTE: important to use abspath, when VTA is enabled.
 export VTA_HW_PATH=`pwd`/3rdparty/vta-hw


### PR DESCRIPTION
In #6334, `task_cpp_unittest.sh` script started also running `apps/bundle_deploy`'s `test_dynamic` and `test_static`. If now we try to run `task_cpp_unittest.sh` as a standalone script, we'll see an error complaining it can't find `tvm` python module.

The error message is:
```
(...)
[==========] Running 0 tests from 0 test cases.
[==========] 0 tests from 0 test cases ran. (0 ms total)
[  PASSED  ] 0 tests.
python3 build_model.py -o build --test
Traceback (most recent call last):
  File "build_model.py", line 21, in <module>
    from tvm import relay
ModuleNotFoundError: No module named 'tvm'
Makefile:123: recipe for target 'build/test_graph_c.json' failed
make: *** [build/test_graph_c.json] Error 1

```

This PR adds the python environment setup script to have TVM's python environment setup available, to make `task_cpp_unittest.sh`  runs as a standalone script.

We don't see this error in the current upstream CI, because we always run the build script before cpp tests, and in this case we'll be in the right directory when this test runs.

cc @areusch @tqchen 