### PR TITLE
[BYOC] Support control flow in annotate_target

### DIFF
--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -138,8 +138,8 @@ class AnnotateTargetRewriter : public ExprRewriter {
     }
 
     if (pre->args.size()) {
-        // Peek the first argument. If it is compiler begin then this node had annotated by
-        // another target before, so we also consider that target as a supported target.
+      // Peek the first argument. If it is compiler begin then this node had annotated by
+      // another target before, so we also consider that target as a supported target.
       const CallNode* first_arg_call = pre->args[0].as<CallNode>();
       if (first_arg_call && first_arg_call->op == CompilerBeginOp()) {
         std::string arg_target = first_arg_call->attrs.as<CompilerAttrs>()->compiler;
@@ -244,8 +244,8 @@ class AnnotateTargetRewriter : public ExprRewriter {
     Expr new_expr;
     std::pair<std::string, Array<Expr>> target_n_args;
     Expr new_body = InsertCompilerEndAndPropogateTarget(let->body);
-    bool is_functional_literal = let->value.as<FunctionNode>() != nullptr;
-    if (is_functional_literal) {
+    // Do not annotate function literal with let binding.
+    if (let->value->IsInstance<FunctionNode>()) {
       new_expr = Let(let->var, let->value, new_body);
     } else {
       target_n_args = AnnotateArgs({let->value});

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -35,9 +35,9 @@ namespace tvm {
 namespace relay {
 namespace annotate_target {
 
-const PackedFunc* make_begin_op =
+static const PackedFunc* make_begin_op =
     runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
-const PackedFunc* make_end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
+static const PackedFunc* make_end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
 
 // A helper class to insert annotation boundaries for a program region that will
 // be handled by a specific compiler.

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -128,9 +128,9 @@ class AnnotateTargetRewriter : public ExprRewriter {
       return InsertAnnotation(input_expr, op_expr_to_target_[input_expr], make_end_op);
     }
 
-    // Peek the first argument. If it is compiler begin then this node had annotated by
-    // another target before, so we also consider that target as a supported target.
     if (pre->args.size()) {
+        // Peek the first argument. If it is compiler begin then this node had annotated by
+        // another target before, so we also consider that target as a supported target.
       const CallNode* first_arg_call = pre->args[0].as<CallNode>();
       if (first_arg_call && first_arg_call->op == CompilerBeginOp()) {
         std::string arg_target = first_arg_call->attrs.as<CompilerAttrs>()->compiler;

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -77,7 +77,7 @@ class AnnotateTargetRewriter : public ExprRewriter {
         compiler_ends.push_back(call->args[0]);
       } else if (op_expr_to_target_.find(arg) != op_expr_to_target_.end()) {
         arg_target = op_expr_to_target_[arg];
-        compiler_ends.push_back(InsertAnnotation(arg, arg_target, make_end_op));
+        compiler_ends.push_back(InsertCompilerEndAndPropogateTarget(arg));
       } else {
         // Input vars.
         compiler_ends.push_back(arg);
@@ -136,7 +136,7 @@ class AnnotateTargetRewriter : public ExprRewriter {
       CHECK(op_expr_to_target_.find(input_expr) != op_expr_to_target_.end());
       return InsertAnnotation(input_expr, op_expr_to_target_[input_expr], make_end_op);
     }
-
+    // Check prior to peeking first argument
     if (pre->args.size()) {
       // Peek the first argument. If it is compiler begin then this node had annotated by
       // another target before, so we also consider that target as a supported target.

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file src/relay/transforms/annotate_target.cc
+ * \file src/relay/transforms/.cc
  * \brief Wraps an expr with compiler_begin and compiler_end to indicate that
  * this expr should be handled by the external compiler.
  */
@@ -33,7 +33,7 @@
 
 namespace tvm {
 namespace relay {
-namespace annotate_target {
+namespace  {
 
 const PackedFunc* make_begin_op =
     runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
@@ -307,14 +307,14 @@ Expr AnnotateTarget(const Expr& expr, const Array<runtime::String>& targets) {
   return PostOrderRewrite(expr, &rewriter);
 }
 
-}  // namespace annotate_target
+}  // namespace 
 
 namespace transform {
 
 Pass AnnotateTarget(const Array<runtime::String>& targets) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(relay::annotate_target::AnnotateTarget(f, targets));
+        return Downcast<Function>(relay::AnnotateTarget(f, targets));
       };
   auto func_pass = CreateFunctionPass(pass_func, 0, "AnnotateTargetFunc", {"InferType"});
   return transform::Sequential({func_pass, InferType()}, "AnnotateTarget");

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -37,7 +37,8 @@ namespace annotate_target {
 
 static const PackedFunc* make_begin_op =
     runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
-static const PackedFunc* make_end_op = runtime::Registry::Get("relay.op.annotation._make.compiler_end");
+static const PackedFunc* make_end_op =
+    runtime::Registry::Get("relay.op.annotation._make.compiler_end");
 
 // A helper class to insert annotation boundaries for a program region that will
 // be handled by a specific compiler.

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file src/relay/transforms/.cc
+ * \file src/relay/transforms/annotate_target.cc
  * \brief Wraps an expr with compiler_begin and compiler_end to indicate that
  * this expr should be handled by the external compiler.
  */
@@ -33,7 +33,7 @@
 
 namespace tvm {
 namespace relay {
-namespace  {
+namespace annotate_target {
 
 const PackedFunc* make_begin_op =
     runtime::Registry::Get("relay.op.annotation._make.compiler_begin");
@@ -307,14 +307,14 @@ Expr AnnotateTarget(const Expr& expr, const Array<runtime::String>& targets) {
   return PostOrderRewrite(expr, &rewriter);
 }
 
-}  // namespace 
+}  // namespace annotate_target
 
 namespace transform {
 
 Pass AnnotateTarget(const Array<runtime::String>& targets) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(relay::AnnotateTarget(f, targets));
+        return Downcast<Function>(relay::annotate_target::AnnotateTarget(f, targets));
       };
   auto func_pass = CreateFunctionPass(pass_func, 0, "AnnotateTargetFunc", {"InferType"});
   return transform::Sequential({func_pass, InferType()}, "AnnotateTarget");

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -77,7 +77,7 @@ class AnnotateTargetRewriter : public ExprRewriter {
         compiler_ends.push_back(call->args[0]);
       } else if (op_expr_to_target_.find(arg) != op_expr_to_target_.end()) {
         arg_target = op_expr_to_target_[arg];
-        compiler_ends.push_back(InsertCompilerEndAndPropogateTarget(arg));
+        compiler_ends.push_back(InsertAnnotation(arg, arg_target, make_end_op));
       } else {
         // Input vars.
         compiler_ends.push_back(arg);

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -109,6 +109,16 @@ class AnnotateTargetRewriter : public ExprRewriter {
   }
 
   Expr InsertCompilerEndAndPropogateTarget(const Expr& expr) {
+    /*!
+     * \brief This function inserts compiler end to expr and maps the corresponding target to the
+     * new expression.
+     *
+     *  This function checks for expr existence within the map and inserts the annotation
+     *  Further, it propagates the target to the new expression and returns it
+     *
+     * \param expr A relay expression
+     * \return An annotated and target-propagated relay expression.
+     */
     Expr new_expr = expr;
     if (op_expr_to_target_.find(expr) != op_expr_to_target_.end()) {
       new_expr = InsertAnnotation(expr, op_expr_to_target_[expr], make_end_op);

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -352,6 +352,7 @@ def test_multiple_runs():
     expected = transform.AnnotateTarget(["A", "B"])(before())
     assert tvm.ir.structural_equal(expected, mod)
 
+
 def test_if_else():
     target = "test_if_else"
 
@@ -378,9 +379,9 @@ def test_if_else():
     """Test that If-else nodes compiles correctly when surrounded by supported nodes."""
 
     def before():
-        data = relay.var('data', shape=(1, 32))
-        eq1 = relay.var('e1', shape=[], dtype='int32')
-        eq2 = relay.var('e2', shape=[], dtype='int32')
+        data = relay.var("data", shape=(1, 32))
+        eq1 = relay.var("e1", shape=[], dtype="int32")
+        eq2 = relay.var("e2", shape=[], dtype="int32")
         eq = relay.equal(eq1, eq2)
 
         true_branch = relay.tanh(data)
@@ -394,9 +395,9 @@ def test_if_else():
 
     def after():
 
-        data = relay.var('data', shape=(1, 32))
-        eq1 = relay.var('e1', shape=[], dtype='int32')
-        eq2 = relay.var('e2', shape=[], dtype='int32')
+        data = relay.var("data", shape=(1, 32))
+        eq1 = relay.var("e1", shape=[], dtype="int32")
+        eq2 = relay.var("e2", shape=[], dtype="int32")
 
         cb_1 = relay.annotation.compiler_begin(eq1, target)
         cb_2 = relay.annotation.compiler_begin(eq2, target)
@@ -425,6 +426,7 @@ def test_if_else():
     result = transform.AnnotateTarget(target)(before())
     expected = transform.InferType()(after())
     assert tvm.ir.structural_equal(expected, result)
+
 
 def test_while_let():
     target = "test_while_let"
@@ -464,14 +466,12 @@ def test_while_let():
 
         loop = relay.var("while_loop")
         ii = var2 + relay.const(1, dtype="int32")
-        ss = var3 + var1    
-        true_branch = loop(ii,ss)
+        ss = var3 + var1
+        true_branch = loop(ii, ss)
         ife = relay.If(cond, true_branch, var3)
         func_1 = relay.Function([var2, var3], ife)
 
-        ret = relay.Let(
-            loop, func_1, loop(relay.const(0, dtype="int32"), relay.zeros_like(var1))
-        )
+        ret = relay.Let(loop, func_1, loop(relay.const(0, dtype="int32"), relay.zeros_like(var1)))
         func_2 = relay.Function([var1], ret)
         mod = tvm.IRModule.from_expr(func_2)
         return mod
@@ -481,7 +481,7 @@ def test_while_let():
         var2 = relay.var("var2", shape=(), dtype="int32")
         var3 = relay.var("var3", shape=(2,))
         var4 = relay.const(10, dtype="int32")
-        
+
         cb_1 = relay.annotation.compiler_begin(var2, target)
         cb_2 = relay.annotation.compiler_begin(var4, target)
 
@@ -501,7 +501,7 @@ def test_while_let():
         add_op_2 = relay.add(cb_6, cb_7)
         ce_3 = relay.annotation.compiler_end(add_op_2, target)
         cb_8 = relay.annotation.compiler_begin(ce_3, target)
-        true_branch = loop(cb_5, cb_8) # while loop 
+        true_branch = loop(cb_5, cb_8)  # while loop
         ce_4 = relay.annotation.compiler_end(true_branch, target)
         if_condition = relay.If(ce_1, ce_4, var3)
 
@@ -514,17 +514,16 @@ def test_while_let():
         ce_6 = relay.annotation.compiler_end(while_condition, target)
 
         func_1 = relay.Function([var2, var3], if_condition)
-        ret = relay.Let(
-            loop, func_1, ce_6
-        )
+        ret = relay.Let(loop, func_1, ce_6)
         func_2 = relay.Function([var1], ret)
         mod = tvm.IRModule.from_expr(func_2)
         return mod
 
     seq = tvm.transform.Sequential(
-            [
-                transform.AnnotateTarget(target),
-            ])
+        [
+            transform.AnnotateTarget(target),
+        ]
+    )
     result = seq(before())
     expected = transform.InferType()(after())
     # print(expected, result)

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -460,7 +460,7 @@ def test_while_let():
         var1 = relay.var("var1", shape=(2,))
         var2 = relay.var("var2", shape=(), dtype="int32")
         var3 = relay.var("var3", shape=(2,))
-        cond = var2 < relay.const(10, dtype="int32")
+        cond = relay.less(var2, relay.const(10, dtype="int32"))
 
         loop = relay.var("while_loop")
         ii = var2 + relay.const(1, dtype="int32")
@@ -485,7 +485,7 @@ def test_while_let():
         cb_1 = relay.annotation.compiler_begin(var2, target)
         cb_2 = relay.annotation.compiler_begin(var4, target)
 
-        less_condition = cb_1 < cb_2
+        less_condition = relay.less(cb_1, cb_2)
         ce_1 = relay.annotation.compiler_end(less_condition, target)
 
         loop = relay.var("while_loop")
@@ -527,7 +527,7 @@ def test_while_let():
             ])
     result = seq(before())
     expected = transform.InferType()(after())
-    print(expected, result)
+    # print(expected, result)
     assert tvm.ir.structural_equal(expected, result, map_free_vars=True)
 
 

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -441,10 +441,6 @@ def test_while_let():
     def If(attrs, args):  # pylint: disable=unused-variable
         return True
 
-    @tvm.ir.register_op_attr("scope_builder", "target." + target)
-    def scope_builder(attrs, args):  # pylint: disable=unused-variable
-        return True
-
     @tvm.ir.register_op_attr("Let", "target." + target)
     def Let(attrs, args):  # pylint: disable=unused-variable
         return True
@@ -523,7 +519,7 @@ def test_while_let():
     result = seq(before())
     expected = transform.InferType()(after())
     print(expected, result)
-    assert tvm.ir.structural_equal(expected, result)
+    assert tvm.ir.structural_equal(expected, result, map_free_vars=True)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -422,14 +422,7 @@ def test_if_else():
         mod = tvm.IRModule.from_expr(func)
         return mod
 
-    seq = tvm.transform.Sequential(
-            [
-                transform.AnnotateTarget(target),
-                transform.MergeCompilerRegions(),
-            ])
-    result = seq(before())
-
-    # result = transform.AnnotateTarget(target)(before())
+    result = transform.AnnotateTarget(target)(before())
     expected = transform.InferType()(after())
     assert tvm.ir.structural_equal(expected, result)
 


### PR DESCRIPTION
This PR adds changes to annotate_target to handle control flow(if-else nodes) and let nodes correctly. 
Context: The Neo team was trying to compile TF MobileNet SSD model and since the model is dynamic we noticed that the if-else and let nodes are not getting correctly compiled. Therefore this PR addresses those fixes. 