### PR TITLE
[TEST][TEDD] improve TEDD tests to also run on CPU Docker image

### DIFF
--- a/tests/python/contrib/test_tedd.py
+++ b/tests/python/contrib/test_tedd.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from tvm import te
-import numpy as np
 import re
+
+from tvm import te
 from tvm import topi
 
 
@@ -25,7 +25,7 @@ def findany(pattern, str):
     assert len(matches) > 0, "Pattern not found.\nPattern: " + pattern + "\nString:  " + str
 
 
-def checkdepdency():
+def checkdependency():
     import pkg_resources
 
     return not {"graphviz", "ipython"} - {pkg.key for pkg in pkg_resources.working_set}
@@ -55,7 +55,7 @@ def test_dfg():
         findany(r"Tensor_3_0 -> Stage_4:I_1", str)
         findany(r"Stage_4:O_0 -> Tensor_4_0", str)
 
-    if checkdepdency():
+    if checkdependency():
         verify()
 
 
@@ -79,8 +79,8 @@ def test_itervar_relationship_graph():
         findany(r"subgraph cluster_Stage_0", str)
         findany(r"subgraph cluster_Stage_1", str)
         # Check itervars and their types
-        findany(r"i\(kDataPar\)\<br/\>range\(min=0, ext=n\)", str)
-        findany(r"k\(kCommReduce\)\<br/\>range\(min=0, ext=m\)", str)
+        findany(r"\(kDataPar\)\<br/\>range\(min=0, ext=n\)", str)
+        findany(r"\(kCommReduce\)\<br/\>range\(min=0, ext=m\)", str)
         # Check the split node
         findany(r"Split_Relation_1_0 +.+\>Split", str)
         # Check all edges to/from the split node
@@ -88,7 +88,7 @@ def test_itervar_relationship_graph():
         findany(r"Split_Relation_1_0:Outer -> IterVar_1_2:itervar", str)
         findany(r"Split_Relation_1_0:Inner -> IterVar_1_3:itervar", str)
 
-    if checkdepdency():
+    if checkdependency():
         verify()
 
 
@@ -129,18 +129,18 @@ def test_schedule_tree():
         # and compute
         findany(
             r"Stage_1.*A\.shared<br/>Scope: shared.+>0.+>"
-            r"ax0\(kDataPar\).+>1.+ax1\(kDataPar\).+>2.+>ax2\(kDataPar\).+>"
-            r"\[A\(ax0, ax1, ax2\)\]",
+            r"ax0.*\(kDataPar\).+>1.+ax1.*\(kDataPar\).+>2.+>ax2.*\(kDataPar\).+>"
+            r"\[A[\[\(]ax0, ax1, ax2[\)\]]\]",
             str,
         )
         # Check itervars of types different from KDataPar
-        findany(r"bk\(kVectorized\)", str)
-        findany(r"r.outer\(kCommReduce\)", str)
+        findany(r"bk.*\(kVectorized\)", str)
+        findany(r"r.outer.*\(kCommReduce\)", str)
         findany(r"label=ROOT", str)
         # Check the compute_at edge
         findany(r"Stage_1.*\[color\=\"\#000000\"\]", str)
 
-    if checkdepdency():
+    if checkdependency():
         verify()
 
 


### PR DESCRIPTION
This change improves TEDD testing, so that is can run on `ci-cpu` Docker image. It currently fails if you try to run it on a `ci-cpu` image that has `graphviz` installed. The test currently shows as "passing" in CI, but checks are not actually done.

We still need to have a separate PR to install graphviz on `ci-cpu`, to make this test to actually do something. In this PR, we only will be able to obeserve that it doesn't break the current setup. Reported on #6642 (more context there).

cc @yongfeng-nv @tqchen for reviews.