### PR TITLE
[TEST][CI] make sure graphviz is on both ci-cpu and ci-gpu images

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -41,7 +41,7 @@ COPY install/ubuntu_install_sphinx.sh /install/ubuntu_install_sphinx.sh
 RUN bash /install/ubuntu_install_sphinx.sh
 
 # Enable doxygen for c++ doc build
-RUN apt-get update && apt-get install -y doxygen graphviz libprotobuf-dev protobuf-compiler
+RUN apt-get update && apt-get install -y doxygen libprotobuf-dev protobuf-compiler
 
 COPY install/ubuntu_install_java.sh /install/ubuntu_install_java.sh
 RUN bash /install/ubuntu_install_java.sh

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -24,7 +24,7 @@ set -o pipefail
 apt-get update && apt-get install -y --no-install-recommends \
         git make libgtest-dev cmake wget unzip libtinfo-dev libz-dev\
         libcurl4-openssl-dev libopenblas-dev g++ sudo \
-        apt-transport-https
+        apt-transport-https graphviz
 
 
 cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib


### PR DESCRIPTION
This is a follow-up on top of #6643, to make sure when we re-generate Docker images, both `ci-cpu` and `ci-gpu` will have `graphviz` installed. All to deal with #6642.

cc @tqchen 