### PR TITLE
Missing header for GraphRuntimeFactory in android_rpc

### DIFF
--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -42,6 +42,7 @@
 #include "../src/runtime/dso_library.cc"
 #include "../src/runtime/file_util.cc"
 #include "../src/runtime/graph/graph_runtime.cc"
+#include "../src/runtime/graph/graph_runtime_factory.cc"
 #include "../src/runtime/library_module.cc"
 #include "../src/runtime/module.cc"
 #include "../src/runtime/ndarray.cc"


### PR DESCRIPTION
When running `deploy_model_on_android.py` from the tutorial on mobile CPU, I got the following error. After searching on the web, it seems like the file for `GraphRuntimeFactory` is not included in the Android project. After the fix the demo runs without problem. This fix is originally from https://zhuanlan.zhihu.com/p/234413621 (in Chinese).

```
2020-10-07 15:19:27.490 29147-29163/org.apache.tvm.tvmrpc W/System.err: Load module from /data/user/0/org.apache.tvm.tvmrpc/cache/tvm4j_rpc_801593968118546428/net.so
2020-10-07 15:19:27.501 29147-29163/org.apache.tvm.tvmrpc D/TVM_RUNTIME: [15:19:27] /workspace/apps/android_rpc/app/src/main/jni/../../../../../../3rdparty/dmlc-core/include/dmlc/logging.h:454: [15:19:27] /workspace/apps/android_rpc/app/src/main/jni/../../../../../../include/../src/runtime/library_module.cc:149: Check failed: f != nullptr: Binary was created using GraphRuntimeFactory but a loader of that name is not registered. Available loaders are vulkan, opencl. Perhaps you need to recompile with this runtime enabled.
2020-10-07 15:19:27.540 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534] JNI DETECTED ERROR IN APPLICATION: JNI CallStaticVoidMethodV called with pending exception org.apache.tvm.Base$TVMError: TVMError: Check failed: f != nullptr: Binary was created using GraphRuntimeFactory but a loader of that name is not registered. Available loaders are vulkan, opencl. Perhaps you need to recompile with this runtime enabled.
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534] Stack trace:
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   File "/workspace/apps/android_rpc/app/src/main/jni/../../../../../../include/../src/runtime/library_module.cc", line 149
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534] 
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at void org.apache.tvm.Base.checkCall(int) (Base.java:173)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.TVMValue org.apache.tvm.Function.invoke() (Function.java:130)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.Module org.apache.tvm.Module.load(java.lang.String, java.lang.String) (Module.java:140)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.Module org.apache.tvm.Module.load(java.lang.String) (Module.java:146)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at java.lang.Object org.apache.tvm.rpc.NativeServerLoop$2.invoke(org.apache.tvm.TVMValue[]) (NativeServerLoop.java:89)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at java.lang.Object org.apache.tvm.Function.invokeRegisteredCbFunc(org.apache.tvm.Function$Callback, org.apache.tvm.TVMValue[]) (Function.java:330)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at int org.apache.tvm.LibInfo.tvmFuncCall(long, org.apache.tvm.Base$RefTVMValue) (LibInfo.java:-2)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.TVMValue org.apache.tvm.Function.invoke() (Function.java:130)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at void org.apache.tvm.rpc.NativeServerLoop.run() (NativeServerLoop.java:49)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at void org.apache.tvm.rpc.ConnectTrackerServerProcessor.run() (ConnectTrackerServerProcessor.java:166)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at void org.apache.tvm.tvmrpc.RPCProcessor.run() (RPCProcessor.java:64)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534] 
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]     in call to CallStaticVoidMethodV
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]     from int org.apache.tvm.LibInfo.tvmFuncCall(long, org.apache.tvm.Base$RefTVMValue)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534] "Thread-2" daemon prio=5 tid=12 Runnable
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   | group="main" sCount=0 dsCount=0 flags=0 obj=0x12f404b8 self=0x76bac98c00
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   | sysTid=29163 nice=0 cgrp=default sched=0/0 handle=0x76b13984f0
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   | state=R schedstat=( 814203549 133393511 937 ) utm=65 stm=15 core=7 HZ=100
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   | stack=0x76b1296000-0x76b1298000 stackSize=1037KB
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   | held mutexes= "mutator lock"(shared held)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #00 pc 00000000003ccb5c  /system/lib64/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, int, BacktraceMap*, char const*, art::ArtMethod*, void*)+208)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #01 pc 000000000049cdf4  /system/lib64/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, bool, BacktraceMap*, bool) const+348)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #02 pc 00000000002fe388  /system/lib64/libart.so (art::JavaVMExt::JniAbort(char const*, char const*)+1048)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #03 pc 00000000002fe788  /system/lib64/libart.so (art::JavaVMExt::JniAbortV(char const*, char const*, std::__va_list)+108)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #04 pc 000000000010e02c  /system/lib64/libart.so (art::ScopedCheck::AbortF(char const*, ...)+152)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #05 pc 000000000010db7c  /system/lib64/libart.so (art::ScopedCheck::CheckThread(_JNIEnv*)+500)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #06 pc 000000000010c03c  /system/lib64/libart.so (art::ScopedCheck::Check(art::ScopedObjectAccess&, bool, char const*, art::JniValueType*)+644)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #07 pc 0000000000111438  /system/lib64/libart.so (art::CheckJNI::CheckCallArgs(art::ScopedObjectAccess&, art::ScopedCheck&, _JNIEnv*, _jobject*, _jclass*, _jmethodID*, art::InvokeType, art::VarArgs const*)+132)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #08 pc 00000000001103a4  /system/lib64/libart.so (art::CheckJNI::CallMethodV(char const*, _JNIEnv*, _jobject*, _jclass*, _jmethodID*, std::__va_list, art::Primitive::Type, art::InvokeType)+656)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #09 pc 00000000001010e0  /system/lib64/libart.so (art::CheckJNI::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+84)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #10 pc 000000000009f500  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+116)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #11 pc 000000000009f2cc  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (funcInvokeCallback+492)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #12 pc 00000000000bd310  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (???)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #13 pc 00000000000a32d0  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (std::__ndk1::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+36)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #14 pc 0000000000084c84  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::PackedFunc::CallPacked(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+48)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #15 pc 0000000000093048  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::LocalSession::CallFunc(void*, TVMValue const*, int const*, int, std::__ndk1::function<void (tvm::runtime::TVMArgs)> const&)+60)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #16 pc 00000000000946ac  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCSession::AsyncCallFunc(void*, TVMValue const*, int const*, int, std::__ndk1::function<void (tvm::runtime::RPCCode, tvm::runtime::TVMArgs)>)+64)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #17 pc 00000000000b0c10  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCEndpoint::EventHandler::HandleNormalCallFunc()+132)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #18 pc 00000000000afb60  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCEndpoint::EventHandler::HandleProcessPacket(std::__ndk1::function<void (tvm::runtime::TVMArgs)>)+192)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #19 pc 0000000000090544  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCEndpoint::EventHandler::HandleNextEvent(bool, bool, std::__ndk1::function<void (tvm::runtime::TVMArgs)>)+220)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #20 pc 00000000000903ec  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCEndpoint::HandleUntilReturnEvent(bool, std::__ndk1::function<void (tvm::runtime::TVMArgs)>)+612)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #21 pc 0000000000090bd8  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCEndpoint::ServerLoop()+120)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #22 pc 00000000000958fc  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::RPCServerLoop(tvm::runtime::PackedFunc, tvm::runtime::PackedFunc)+132)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #23 pc 00000000000cfa60  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (???)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #24 pc 00000000000a32d0  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (std::__ndk1::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+36)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #25 pc 0000000000084c84  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (tvm::runtime::PackedFunc::CallPacked(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+48)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #26 pc 0000000000084b0c  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (TVMFuncCall+60)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #27 pc 000000000009ed80  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/lib/arm64/libtvm4j_runtime_packed.so (Java_org_apache_tvm_LibInfo_tvmFuncCall+168)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   native: #28 pc 00000000000009e0  /data/app/org.apache.tvm.tvmrpc-KP9FS8M-n6sjKsm3tnnDVw==/oat/arm64/base.odex (Java_org_apache_tvm_LibInfo_tvmFuncCall__JLorg_apache_tvm_Base_00024RefTVMValue_2+160)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.LibInfo.tvmFuncCall(Native method)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.Function.invoke(Function.java:130)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.rpc.NativeServerLoop.run(NativeServerLoop.java:49)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.rpc.ConnectTrackerServerProcessor.run(ConnectTrackerServerProcessor.java:166)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534]   at org.apache.tvm.tvmrpc.RPCProcessor.run(RPCProcessor.java:64)
2020-10-07 15:19:27.541 29147-29163/org.apache.tvm.tvmrpc A/zygote64: java_vm_ext.cc:534] 
```
