### PR TITLE
[Docker][CI][BYODT] add universal to Docker image

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -60,6 +60,10 @@ ENV PATH $PATH:$CARGO_HOME/bin:/usr/lib/go-1.10/bin
 COPY install/ubuntu_install_java.sh /install/ubuntu_install_java.sh
 RUN bash /install/ubuntu_install_java.sh
 
+# BYODT deps
+COPY install/ubuntu_install_universal.sh /install/ubuntu_install_universal.sh
+RUN bash /install/ubuntu_install_universal.sh
+
 # Chisel deps for TSIM
 COPY install/ubuntu_install_chisel.sh /install/ubuntu_install_chisel.sh
 RUN bash /install/ubuntu_install_chisel.sh

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -91,6 +91,10 @@ RUN bash /install/ubuntu_install_redis.sh
 COPY install/ubuntu_install_nnpack.sh /install/ubuntu_install_nnpack.sh
 RUN bash /install/ubuntu_install_nnpack.sh
 
+# BYODT deps
+COPY install/ubuntu_install_universal.sh /install/ubuntu_install_universal.sh
+RUN bash /install/ubuntu_install_universal.sh
+
 # Environment variables
 ENV PATH=/usr/local/nvidia/bin:${PATH}
 ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/docker/install/ubuntu_install_universal.sh
+++ b/docker/install/ubuntu_install_universal.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+git clone https://github.com/stillwater-sc/universal.git UNIVERSAL
+
+# Use specific versioning tag.
+(cd UNIVERSAL && git checkout e32899d551b53d758865fabd5fdd69eed35bfb0f)

--- a/docker/install/ubuntu_install_universal.sh
+++ b/docker/install/ubuntu_install_universal.sh
@@ -20,7 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-git clone https://github.com/stillwater-sc/universal.git UNIVERSAL
+git clone https://github.com/stillwater-sc/universal.git /opt/universal
 
 # Use specific versioning tag.
-(cd UNIVERSAL && git checkout e32899d551b53d758865fabd5fdd69eed35bfb0f)
+(cd /opt/universal && git checkout e32899d551b53d758865fabd5fdd69eed35bfb0f)


### PR DESCRIPTION
add universal repo to Docker image, as per our discussion from here: https://github.com/apache/incubator-tvm/pull/5812

cc: @tqchen are tutorial docs generated using the Docker gpu image?
If so, can we install the Universal repo to the Docker gpu image as well so that the tutorial can use the posit codepaths?