### PR TITLE
[AutoScheduler] Improve the GPU tutorial by deleting measure_ctx earlier

### DIFF
--- a/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
+++ b/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
@@ -63,7 +63,7 @@ def conv2d_layer(N, H, W, CO, CI, KH, KW, stride, padding):
 
 target = tvm.target.Target("cuda")
 
-# Use the last layer in resnet
+# Use the last layer in ResNet-50
 N, H, W, CO, CI, KH, KW, strides, padding = 1, 7, 7, 512, 512, 3, 3, (1, 1), (1, 1)
 task = auto_scheduler.create_task(conv2d_layer, (N, H, W, CO, CI, KH, KW, strides, padding), target)
 

--- a/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
+++ b/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
@@ -63,7 +63,7 @@ def conv2d_layer(N, H, W, CO, CI, KH, KW, stride, padding):
 
 target = tvm.target.Target("cuda")
 
-# the last layer in resnet
+# Use the last layer in resnet
 N, H, W, CO, CI, KH, KW, strides, padding = 1, 7, 7, 512, 512, 3, 3, (1, 1), (1, 1)
 task = auto_scheduler.create_task(conv2d_layer, (N, H, W, CO, CI, KH, KW, strides, padding), target)
 

--- a/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
+++ b/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
@@ -105,6 +105,9 @@ tune_option = auto_scheduler.TuningOptions(
 
 sch, args = auto_scheduler.auto_schedule(task, tuning_options=tune_option)
 
+# Kill the process for measurement
+del measure_ctx
+
 ######################################################################
 # We can lower the schedule to see the IR after auto-scheduling.
 # The auto-scheduler correctly performs optimizations including multi-level tiling,
@@ -119,7 +122,7 @@ print(tvm.lower(sch, args, simple_mode=True))
 
 func = tvm.build(sch, args, target)
 
-# check correctness
+# Check correctness
 data_np = np.random.uniform(size=(N, CI, H, W)).astype(np.float32)
 weight_np = np.random.uniform(size=(CO, CI, KH, KW)).astype(np.float32)
 bias_np = np.random.uniform(size=(1, CO, 1, 1)).astype(np.float32)
@@ -180,6 +183,7 @@ cost_model.update_from_file(log_file)
 search_policy = auto_scheduler.SketchPolicy(
     task, cost_model, init_search_callbacks=[auto_scheduler.PreloadMeasuredStates(log_file)]
 )
+measure_ctx = auto_scheduler.LocalRPCMeasureContext(min_repeat_ms=300)
 tune_option = auto_scheduler.TuningOptions(
     num_measure_trials=5,
     runner=measure_ctx.runner,
@@ -187,5 +191,5 @@ tune_option = auto_scheduler.TuningOptions(
 )
 sch, args = auto_scheduler.auto_schedule(task, search_policy, tuning_options=tune_option)
 
-# kill the measurement process
+# Kill the measurement process
 del measure_ctx


### PR DESCRIPTION
To avoid the confusion in #6570, we call `del measure_ctx` earlier in the tutorial, just after we finish the search.

`measure_ctx` overloads the `__del__`. Ideally, we do not need to call `del measure_ctx` explicitly.
However, I found `__del__` only works for local variables.
If we use `measure_ctx` as a local variable inside a function, it can be garbage-collected correctly.
But in the tutorial, `measure_ctx` is a global variable. It thus cannot be garbage-collected correctly.

There are two solutions to this problem.
**S1**. call `del measure_ctx` explicitly
**S2**. use 
```
with measure_ctx:
  tune_options = ...
  s, args = auto_scheduler.auto_schedule(...)
```

I think S1 is better. In S1, `del measure_ctx` is only required if `measure_ctx` is a global variable, which is a rare case (but unfortunately, this happens in the tutorial)
