### PR TITLE
[IR] don't validate AttrInitEntry until a value has attempted to be set

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -336,7 +336,10 @@ struct AttrInitEntry {
   // internal value.
   T* value_;
   // whether the value is missing.
-  bool value_missing_{true};
+  // NOTE: initialize to false so that the destructor does not throw unless
+  // AttrInitVisitor::operator() is committed to returning an instance of this class.
+  // It is expected not to set this to true until that is true.
+  bool value_missing_{false};
 
   AttrInitEntry() = default;
 


### PR DESCRIPTION
Defensively setting this to false to hopefully avoid a repeat of #6653 