### PR TITLE
[AutoSchedule] Support multiple cache read and fix bugs

### DIFF
--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -200,10 +200,15 @@ class ComputeDAGNode : public Object {
  */
 class ComputeDAG : public ObjectRef {
  public:
-  /*! \brief The constructor.
+  /*! \brief Construct a DAG from a list of output tensors.
    * \param tensors `te::Tensor`s for a compute declaration.
    */
   TVM_DLL explicit ComputeDAG(Array<te::Tensor> tensors);
+
+  /*! \brief Construct a DAG based on a schedule.
+   * \param sch `te::Schedule`s for a compute declaration.
+   */
+  TVM_DLL explicit ComputeDAG(const te::Schedule& sch);
 
   /*!
    * \brief Rewrite the layout of placeholder specified by attr `layout_free_placeholders`

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -51,18 +51,25 @@ class ComputeDAG(Object):
         Input/output tensors or workload key for a compute declaration.
     """
 
-    def __init__(self, compute):
-        if isinstance(compute, str):
-            compute = workload_key_to_tensors(compute)
-        elif isinstance(compute, list):
-            for item in compute:
+    def __init__(self, compute_or_sche):
+        if isinstance(compute_or_sche, str):
+            compute = workload_key_to_tensors(compute_or_sche)
+            sche = None
+        elif isinstance(compute_or_sche, list):
+            for item in compute_or_sche:
                 if not isinstance(item, tvm.te.Tensor):
                     raise ValueError("The input of ComputeDAG should be a list of Tensor")
+            compute = compute_or_sche
+            sche = None
+        elif isinstance(compute_or_sche, tvm.te.Schedule):
+            compute = None
+            sche = compute_or_sche
         else:
             raise ValueError(
-                "Invalid compute: " + compute + " . ComputeDAG expects a string or list of Tensor"
+                "Invalid compute type: %s. ComputeDAG expects string, list of Tensor, or Schedule"
+                % type(compute)
             )
-        self.__init_handle_by_constructor__(_ffi_api.ComputeDAG, compute)
+        self.__init_handle_by_constructor__(_ffi_api.ComputeDAG, compute, sche)
 
     def get_init_state(self):
         """Get the init state of this ComputeDAG.

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -47,7 +47,7 @@ class ComputeDAG(Object):
 
     Parameters
     ----------
-    compute : Union[List[Tensor], str]
+    compute : Union[List[Tensor], str, Schedule]
         Input/output tensors or workload key for a compute declaration.
     """
 

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -984,8 +984,6 @@ void ComputeDAG::RewriteLayout(const Array<Step>& transform_steps) {
         }
       }
 
-      p_dag->init_state = State(p_dag->ops);
-
       Array<te::Tensor> old_tensors = p_dag->tensors;
       ArrayNode* p_tensors = p_dag->tensors.CopyOnWrite();
 

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1219,7 +1219,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
           ss << op->name << " = PLACEHOLDER " << op.output(0)->shape << "\n";
         } else if (auto pop = op.as<te::ComputeOpNode>()) {
           for (size_t k = 0; k < pop->body.size(); ++k) {
-            ss << op->name << "(";
+            ss << op->name << "[" << op.output(0)->shape << "](";
             for (size_t i = 0; i < pop->axis.size(); i++) {
               ss << pop->axis[i]->var->name_hint;
               if (i != pop->axis.size() - 1) {
@@ -1231,6 +1231,14 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
               ss << ".v" << k;
             }
             if (auto preduce = pop->body[k].as<ReduceNode>()) {
+              ss << "[";
+              for (size_t i = 0; i < preduce->axis.size(); i++) {
+                ss << preduce->axis[i]->var->name_hint << "(" << preduce->axis[i]->dom << ")";
+                if (i != preduce->axis.size() - 1) {
+                  ss << ", ";
+                }
+              }
+
               CHECK_LT(k, preduce->combiner->result.size());
               PrimExpr combiner = preduce->combiner->result[k];
               if (combiner->IsInstance<AddNode>()) {

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -662,7 +662,43 @@ ComputeDAG::ComputeDAG(Array<te::Tensor> tensors) {
   auto node = make_object<ComputeDAGNode>();
   node->tensors = std::move(tensors);
   node->access_analyzer = AccessAnalyzer(node->tensors);
-  node->ops = node->access_analyzer->ops_topo_order;
+
+  Array<te::Operation> out_ops;
+  for (const auto& op : node->access_analyzer->ops_topo_order) {
+    if (node->access_analyzer.IsOutput(op)) {
+      out_ops.push_back(op);
+    }
+  }
+  te::Schedule sch = te::create_schedule(out_ops);
+  for (auto stage : sch->stages) {
+    node->ops.push_back(stage->op);
+  }
+
+  //node->ops = node->access_analyzer->ops_topo_order;
+  node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
+  node->init_state = State(node->ops);
+  data_ = std::move(node);
+}
+
+ComputeDAG::ComputeDAG(const te::Schedule& sch) {
+  auto node = make_object<ComputeDAGNode>();
+
+  // Initialize ops. Here we enforce the order of ops and stages are consistent
+  for (auto stage : sch->stages) {
+    node->ops.push_back(stage->op);
+  }
+
+  // Collect output tensors
+  Array<te::Tensor> tensors;
+  for (auto stage : sch->stages) {
+    if (stage->op->IsInstance<te::PlaceholderOpNode>() || stage->is_output) {
+      for (auto i = 0; i < stage->op->num_outputs(); ++i) {
+        tensors.push_back(stage->op.output(i));
+      }
+    }
+  }
+  node->tensors = std::move(tensors);
+  node->access_analyzer = AccessAnalyzer(node->tensors);
   node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
   node->init_state = State(node->ops);
   data_ = std::move(node);
@@ -1144,17 +1180,7 @@ ComputeDAG ComputeDAG::ReplayAndGetDAG(const Array<Step>& transform_steps) const
   te::Schedule sch;
   Array<te::Tensor> old_tensors;
   std::tie(sch, old_tensors) = ApplySteps(transform_steps);
-
-  Array<te::Tensor> new_tensors;
-  for (auto stage : sch->stages) {
-    if (stage->op->IsInstance<te::PlaceholderOpNode>() || stage->is_output) {
-      for (auto i = 0; i < stage->op->num_outputs(); ++i) {
-        new_tensors.push_back(stage->op.output(i));
-      }
-    }
-  }
-
-  return ComputeDAG(new_tensors);
+  return ComputeDAG(sch);
 }
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
@@ -1267,9 +1293,16 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
       p->stream << ss.str();
     });
 
-TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAG").set_body_typed([](Array<te::Tensor> tensors) {
-  return ComputeDAG(tensors);
-});
+TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAG")
+    .set_body_typed([](Optional<Array<te::Tensor>> tensors, Optional<te::Schedule> sch) {
+      if (tensors) {
+        return ComputeDAG(tensors.value());
+      }
+      if (sch) {
+        return ComputeDAG(sch.value());
+      }
+      LOG(FATAL) << "Both tensors and schedule are null";
+    });
 
 TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAGApplyStepsFromState")
     .set_body_typed([](const ComputeDAG& dag, const State& state, const bool layout_rewrite) {

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1310,10 +1310,8 @@ TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAG")
       if (tensors) {
         return ComputeDAG(tensors.value());
       }
-      if (sch) {
-        return ComputeDAG(sch.value());
-      }
-      LOG(FATAL) << "Both tensors and schedule are null";
+      CHECK(sch) << "Both tensors and schedule are null"; 
+      return ComputeDAG(sch.value());
     });
 
 TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAGApplyStepsFromState")

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1257,7 +1257,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
           ss << op->name << " = PLACEHOLDER " << op.output(0)->shape << "\n";
         } else if (auto pop = op.as<te::ComputeOpNode>()) {
           for (size_t k = 0; k < pop->body.size(); ++k) {
-            ss << op->name << "[" << op.output(0)->shape << "](";
+            ss << op->name << "(";
             for (size_t i = 0; i < pop->axis.size(); i++) {
               ss << pop->axis[i]->var->name_hint;
               if (i != pop->axis.size() - 1) {
@@ -1269,14 +1269,6 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
               ss << ".v" << k;
             }
             if (auto preduce = pop->body[k].as<ReduceNode>()) {
-              ss << "[";
-              for (size_t i = 0; i < preduce->axis.size(); i++) {
-                ss << preduce->axis[i]->var->name_hint << "(" << preduce->axis[i]->dom << ")";
-                if (i != preduce->axis.size() - 1) {
-                  ss << ", ";
-                }
-              }
-
               CHECK_LT(k, preduce->combiner->result.size());
               PrimExpr combiner = preduce->combiner->result[k];
               if (combiner->IsInstance<AddNode>()) {
@@ -1310,7 +1302,7 @@ TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAG")
       if (tensors) {
         return ComputeDAG(tensors.value());
       }
-      CHECK(sch) << "Both tensors and schedule are null"; 
+      CHECK(sch) << "Both tensors and schedule are null";
       return ComputeDAG(sch.value());
     });
 

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -687,7 +687,7 @@ ComputeDAG::ComputeDAG(const te::Schedule& sch) {
     node->ops.push_back(stage->op);
   }
 
-  // Collect output tensors
+  // Collect input and output tensors
   Array<te::Tensor> tensors;
   for (auto stage : sch->stages) {
     if (stage->op->IsInstance<te::PlaceholderOpNode>() || stage->is_output) {

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -674,7 +674,6 @@ ComputeDAG::ComputeDAG(Array<te::Tensor> tensors) {
     node->ops.push_back(stage->op);
   }
 
-  //node->ops = node->access_analyzer->ops_topo_order;
   node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
   node->init_state = State(node->ops);
   data_ = std::move(node);

--- a/src/auto_scheduler/search_policy/sketch_policy_rules.cc
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.cc
@@ -331,7 +331,11 @@ SketchGenerationRule::ConditionKind RuleCrossThreadReduction::MeetCondition(
         GetCumulativeSpaceAndReductionLength(state->stages[stage_id]);
 
     if (NeedsMultilevelTiling(policy.search_task, state, stage_id)) {
-      // Do rfactor if we do not have enough parallelism on space iters
+      // Avoid rfactor if we have enough parallelism on space iters
+      if (cum_space_len > policy.search_task->hardware_params->max_threads_per_block) {
+        return ConditionKind::kSkip;
+      }
+
       return cum_space_len < cum_reduce_len ? ConditionKind::kApply : ConditionKind::kSkip;
     } else if (cum_reduce_len > 1) {
       // Try rfactor for other reduction operators

--- a/src/te/schedule/schedule_dataflow_rewrite.cc
+++ b/src/te/schedule/schedule_dataflow_rewrite.cc
@@ -136,7 +136,7 @@ Tensor Schedule::cache_read(const Tensor& tensor, const std::string& scope,
   if (tensor->op->num_outputs() != 1) {
     os << ".v" << tensor->value_index;
   }
-  
+
   // when a schedule has multiple cache_read on the same tensor,
   // we make sure their op names are unique. e.g., w.shared, w_d.shared, w_d_d.shared
   for (auto pair : (*this)->stage_map) {

--- a/src/te/schedule/schedule_dataflow_rewrite.cc
+++ b/src/te/schedule/schedule_dataflow_rewrite.cc
@@ -136,16 +136,16 @@ Tensor Schedule::cache_read(const Tensor& tensor, const std::string& scope,
   if (tensor->op->num_outputs() != 1) {
     os << ".v" << tensor->value_index;
   }
-  os << "." << scope;
-
+  
   // when a schedule has multiple cache_read on the same tensor,
-  // we make sure their op names are unique. e.g., w.shared, w.shared.d, w.shared.d.d
+  // we make sure their op names are unique. e.g., w.shared, w_d.shared, w_d_d.shared
   for (auto pair : (*this)->stage_map) {
     auto stage = pair.second;
-    if (stage->op->name == os.str()) {
+    if (stage->op->name == os.str() + "." + scope) {
       os << ".d";
     }
   }
+  os << "." << scope;
 
   std::unordered_map<Tensor, Tensor> vsub;
   Stage s = operator[](tensor->op);

--- a/src/te/schedule/schedule_dataflow_rewrite.cc
+++ b/src/te/schedule/schedule_dataflow_rewrite.cc
@@ -138,6 +138,15 @@ Tensor Schedule::cache_read(const Tensor& tensor, const std::string& scope,
   }
   os << "." << scope;
 
+  // when a schedule has multiple cache_read on the same tensor,
+  // we make sure their op names are unique. e.g., w.shared, w.shared.d, w.shared.d.d
+  for (auto pair : (*this)->stage_map) {
+    auto stage = pair.second;
+    if (stage->op->name == os.str()) {
+      os << ".d";
+    }
+  }
+
   std::unordered_map<Tensor, Tensor> vsub;
   Stage s = operator[](tensor->op);
   Tensor sugar_tensor = s->op.output(tensor->value_index);

--- a/tests/python/unittest/test_auto_scheduler_common.py
+++ b/tests/python/unittest/test_auto_scheduler_common.py
@@ -52,6 +52,18 @@ def double_matmul_auto_scheduler_test(N):
 
     return [A, B, C, E]
 
+@auto_scheduler.register_workload
+def parallel_matmul_auto_scheduler_test(N):
+    """Two parallel matmuls with shared A."""
+    A = te.placeholder((N, N), name="A", dtype="float32")
+    B = te.placeholder((N, N), name="B", dtype="float32")
+    C = te.placeholder((N, N), name="C", dtype="float32")
+    k = te.reduce_axis((0, N), name="k")
+    D = te.compute((N, N), lambda i, j: te.sum(A[i][k] * B[k][j], axis=[k]), name="D")
+    k = te.reduce_axis((0, N), name="k")
+    E = te.compute((N, N), lambda i, j: te.sum(A[i][k] * C[k][j], axis=[k]), name="E")
+
+    return [A, B, C, D, E]
 
 # Test for register_workload with different name
 @auto_scheduler.register_workload("matmul_auto_scheduler_test_rename_1")

--- a/tests/python/unittest/test_auto_scheduler_common.py
+++ b/tests/python/unittest/test_auto_scheduler_common.py
@@ -52,6 +52,7 @@ def double_matmul_auto_scheduler_test(N):
 
     return [A, B, C, E]
 
+
 @auto_scheduler.register_workload
 def parallel_matmul_auto_scheduler_test(N):
     """Two parallel matmuls with shared A."""
@@ -64,6 +65,7 @@ def parallel_matmul_auto_scheduler_test(N):
     E = te.compute((N, N), lambda i, j: te.sum(A[i][k] * C[k][j], axis=[k]), name="E")
 
     return [A, B, C, D, E]
+
 
 # Test for register_workload with different name
 @auto_scheduler.register_workload("matmul_auto_scheduler_test_rename_1")

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -81,7 +81,7 @@ def test_stage_order():
     for idx, op in enumerate(stage_ops_1):
         if op.name == "A":
             assert (
-                stage_ops_1[idx + 1].name == "A.shared.d"
+                stage_ops_1[idx + 1].name == "A.d.shared"
                 and stage_ops_1[idx + 2].name == "A.shared"
             )
         elif op.name in ["B", "C"]:

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -21,7 +21,11 @@ import tvm
 from tvm import topi
 from tvm import auto_scheduler, te
 
-from test_auto_scheduler_common import get_tiled_matmul, matmul_auto_scheduler_test
+from test_auto_scheduler_common import (
+    get_tiled_matmul,
+    matmul_auto_scheduler_test,
+    parallel_matmul_auto_scheduler_test,
+)
 
 
 def test_apply_steps():
@@ -56,7 +60,52 @@ def test_estimate_flop():
     assert abs(dag.flop_ct - (2 * N ** 3 + 1234)) < 0.5
 
 
+def test_stage_order():
+    N = 512
+    A, B, C, D, E = parallel_matmul_auto_scheduler_test(N)
+    sch = te.create_schedule([D.op, E.op])
+    (D_local,) = sch.cache_write([D], "local")
+    (E_local,) = sch.cache_write([E], "local")
+    sch.cache_read(A, "shared", [D_local])
+    sch.cache_read(B, "shared", [D_local])
+    sch.cache_read(A, "shared", [E_local])
+    sch.cache_read(C, "shared", [E_local])
+
+    dag = auto_scheduler.ComputeDAG(sch)
+    stage_ops_1 = dag.get_init_state().stage_ops
+
+    # 3 placeholder, 4 x.shared, 2 {D,E}.local, 2 {D,E} compute
+    assert len(stage_ops_1) == 11
+
+    # Cache read stage should follow the source stage
+    for idx, op in enumerate(stage_ops_1):
+        if op.name == "A":
+            assert (
+                stage_ops_1[idx + 1].name == "A.shared" and stage_ops_1[idx + 2].name == "A.shared"
+            )
+        elif op.name in ["B", "C"]:
+            assert stage_ops_1[idx + 1].name == "%s.shared" % op.name
+
+    # Apply the same schedule to Ansor state and it should have the same stage order
+    dag = auto_scheduler.ComputeDAG([A, B, C, D, E])
+    state = dag.get_init_state()
+
+    D_local = state.cache_write(D, "local")
+    E_local = state.cache_write(E, "local")
+    state.cache_read(A, "shared", [D_local])
+    state.cache_read(B, "shared", [D_local])
+    state.cache_read(A, "shared", [E_local])
+    state.cache_read(C, "shared", [E_local])
+
+    stage_ops_2 = state.stage_ops
+    assert len(stage_ops_1) == len(stage_ops_2)
+
+    # Cache read stage should follow the source stage
+    for op1, op2 in zip(stage_ops_1, stage_ops_2):
+        assert op1.name == op2.name
+
 if __name__ == "__main__":
     test_apply_steps()
     test_infer_bound()
     test_estimate_flop()
+    test_stage_order()

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -104,6 +104,7 @@ def test_stage_order():
     for op1, op2 in zip(stage_ops_1, stage_ops_2):
         assert op1.name == op2.name
 
+
 if __name__ == "__main__":
     test_apply_steps()
     test_infer_bound()

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -81,7 +81,8 @@ def test_stage_order():
     for idx, op in enumerate(stage_ops_1):
         if op.name == "A":
             assert (
-                stage_ops_1[idx + 1].name == "A.shared" and stage_ops_1[idx + 2].name == "A.shared"
+                stage_ops_1[idx + 1].name == "A.shared.d"
+                and stage_ops_1[idx + 2].name == "A.shared"
             )
         elif op.name in ["B", "C"]:
             assert stage_ops_1[idx + 1].name == "%s.shared" % op.name


### PR DESCRIPTION
This PR improves the cache read sketch generation rule in auto-scheduler to support multiple cache reads. Previously, cache read sketch generation rule will simply give up if a tensor has multiple consumers. This results in all consumers read that tensor directly from the host memory, which hurts the performance a lot. This PR resolves this limitation.

In addition, this PR also fixes the following bugs/issues:
- Consider `max_threads_per_block` in cross thread reduction rule condition, so that we can guarantee computation intensive ops won't have cross thread reduction sketch, which usually doesn't help.
- Add `.d` suffix to the name of redundant cache read ops to avoid conflict. Without this change, auto-scheduler outputs Python schedule APIs won't work for multiple cache reads.
- Add a new constructor of `ComputeDAG` by taking a schedule, so that we can enforce stage order consistency.

cc @merrymercy @jcf94 @tqchen 