### PR TITLE
[LLVM][WINDOWS] Recover windows support for the latest LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ if(MSVC)
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
   add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
   add_definitions(-DNOMINMAX)
+  # regeneration does not work well with msbuild custom rules.
+  set(CMAKE_SUPPRESS_REGENERATION ON)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj")

--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -40,7 +40,6 @@ int mkdir(const char* path, int /* ignored */) { return _mkdir(path); }
 #include <string>
 #include <vector>
 
-#include "../../src/runtime/file_utils.h"
 #include "../../src/support/utils.h"
 #include "rpc_env.h"
 
@@ -115,7 +114,15 @@ RPCEnv::RPCEnv() {
         std::string file_name = this->GetPath(args[0]);
         file_name = BuildSharedLibrary(file_name);
         std::string bin;
-        LoadBinaryFromFile(file_name, &bin);
+
+        std::ifstream fs(file_name, std::ios::in | std::ios::binary);
+        CHECK(!fs.fail()) << "Cannot open " << file_name;
+        fs.seekg(0, std::ios::end);
+        size_t size = static_cast<size_t>(fs.tellg());
+        fs.seekg(0, std::ios::beg);
+        bin.resize(size);
+        fs.read(dmlc::BeginPtr(bin), size);
+
         TVMByteArray binarr;
         binarr.data = bin.data();
         binarr.size = bin.length();

--- a/apps/cpp_rpc/win32_process.h
+++ b/apps/cpp_rpc/win32_process.h
@@ -23,8 +23,12 @@
  */
 #ifndef TVM_APPS_CPP_RPC_WIN32_PROCESS_H_
 #define TVM_APPS_CPP_RPC_WIN32_PROCESS_H_
+
 #include <chrono>
 #include <string>
+
+#include "../../src/support/socket.h"
+
 namespace tvm {
 namespace runtime {
 /*!

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -233,6 +233,14 @@ void CodeGenCPU::AddMainFunction(const std::string& entry_func_name) {
 #else
   global->setAlignment(1);
 #endif
+  // comdat is needed for windows select any linking to work
+  // set comdat to Any(weak linking)
+  if (target_machine_->getTargetTriple().isOSWindows()) {
+    llvm::Comdat* comdat = module_->getOrInsertComdat(runtime::symbol::tvm_module_main);
+    comdat->setSelectionKind(llvm::Comdat::Any);
+    global->setComdat(comdat);
+  }
+
   global->setInitializer(llvm::ConstantDataArray::getString(*ctx_, entry_func_name));
   global->setDLLStorageClass(llvm::GlobalVariable::DLLExportStorageClass);
 }
@@ -358,6 +366,13 @@ llvm::GlobalVariable* CodeGenCPU::InitContextPtr(llvm::Type* p_type, std::string
 #endif
   gv->setInitializer(llvm::Constant::getNullValue(p_type));
   gv->setDLLStorageClass(llvm::GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
+  // comdat is needed for windows select any linking to work
+  // set comdat to Any(weak linking)
+  if (target_machine_->getTargetTriple().isOSWindows()) {
+    llvm::Comdat* comdat = module_->getOrInsertComdat(name);
+    comdat->setSelectionKind(llvm::Comdat::Any);
+    gv->setComdat(comdat);
+  }
   return gv;
 }
 


### PR DESCRIPTION
Windows COFF requires comdat information to support weak-like linkage(via any).
This patch fixes the windows LLVM support after LLVM-8.
