### PR TITLE
[Frontend][Relay] Fix MXNet frontend to support NLP backbones in GluonNLP

### DIFF
--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -627,7 +627,7 @@ def _mx_expand_dims(inputs, attrs):
     return _op.expand_dims(inputs[0], axis=axis)
 
 
-def _mx_where(inputs, attrs):
+def _mx_where(inputs, _):
     cond, lhs, rhs = inputs
     cond_shape = get_const_tuple(_infer_type(cond).checked_type.shape)
     lhs_shape = get_const_tuple(_infer_type(lhs).checked_type.shape)
@@ -2339,7 +2339,6 @@ def _mx_npx_reshape(inputs, attrs):
     shape = attrs.get_int_tuple("newshape")
     reverse = attrs.get_bool("reverse", False)
     shape_list = list(shape)
-    new_shape_list = []
     old_shape = get_const_tuple(_infer_type(inputs[0]).checked_type.shape)
     new_shape = []
     if reverse:

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2427,8 +2427,8 @@ def _mx_split_v2(inputs, attrs):
 def _mx_npi_where_rscalar(inputs, attrs):
     cond, dat = inputs
     scalar = attrs.get_float("scalar")
-    cond_shape = get_tuple_shape(_infer_type(cond).checked_type.shape)
-    dat_shape = get_tuple_shape(_infer_type(dat).checked_type.shape)
+    cond_shape = get_const_tuple(_infer_type(cond).checked_type.shape)
+    dat_shape = get_const_tuple(_infer_type(dat).checked_type.shape)
     dtype = _infer_type(dat).checked_type.dtype
     # Check for broadcasting
     out_shape = np.broadcast(np.empty(cond_shape), np.empty(dat_shape)).shape

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2365,9 +2365,11 @@ def _mx_npx_reshape(inputs, attrs):
             ptr += 1
         elif ele == -3:
             if old_shape[ptr] != 1:
-                raise tvm.error.OpAttributeInvalid("Dimension of the original shape "
-                                                   "that corresponds to -3 must be 1. Received"
-                                                   " {}".format(old_shape[ptr]))
+                raise tvm.error.OpAttributeInvalid(
+                    "Dimension of the original shape "
+                    "that corresponds to -3 must be 1. Received"
+                    " {}".format(old_shape[ptr])
+                )
             ptr += 1
         elif ele == -4:
             new_shape += old_shape[ptr:]
@@ -2384,15 +2386,19 @@ def _mx_npx_reshape(inputs, attrs):
                 raise tvm.error.OpAttributeInvalid("The lhs and rhs can not both be -1.")
             if lhs == -1:
                 if old_shape[ptr] % rhs != 0:
-                    raise tvm.error.OpAttributeInvalid("When splitting the axis, "
-                                                       "the dimension of the split axis must "
-                                                       "be divisible by the splitted values.")
+                    raise tvm.error.OpAttributeInvalid(
+                        "When splitting the axis, "
+                        "the dimension of the split axis must "
+                        "be divisible by the splitted values."
+                    )
                 lhs = old_shape[ptr] // rhs
             if rhs == -1:
                 if old_shape[ptr] % lhs != 0:
-                    raise tvm.error.OpAttributeInvalid("When splitting the axis, "
-                                                       "the dimension of the split axis must "
-                                                       "be divisible by the splitted values.")
+                    raise tvm.error.OpAttributeInvalid(
+                        "When splitting the axis, "
+                        "the dimension of the split axis must "
+                        "be divisible by the splitted values."
+                    )
                 rhs = old_shape[ptr] // lhs
             new_shape.append(lhs)
             new_shape.append(rhs)

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2297,15 +2297,13 @@ def _mx_npi_pad(inputs, attrs):
         raise tvm.error.OpAttributeRequired('Attribute "mode" not found in operator pad.')
     if pad_mode not in ["constant", "edge", "reflect"]:
         raise tvm.error.OpAttributeInvalid("Value " + mode + ' in attribute "mode" is not valid')
-    # Special handling of pad_width
     if "pad_width" not in attrs.attrs:
         raise tvm.error.OpAttributeRequired('Attribute "pad_width" not found in operator pad.')
-    else:
-        # Begin to parse tuple of tuple
-        pad_width = attrs.attrs["pad_width"]
-        pad_width = pad_width.replace("(", "[")
-        pad_width = pad_width.replace(")", "]")
-        pad_width = json.loads(pad_width)
+    # Begin to parse tuple of tuple, we cannot use get_int_tuple here because it's a tuple of tuple.
+    pad_width = attrs.attrs["pad_width"]
+    pad_width = pad_width.replace("(", "[")
+    pad_width = pad_width.replace(")", "]")
+    pad_width = json.loads(pad_width)
     constant_values = attrs.get_float("constant_values", 0.0)
     return _op.nn.pad(
         data=inputs[0], pad_width=pad_width, pad_value=constant_values, pad_mode=pad_mode

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2297,18 +2297,18 @@ def _mx_npi_pad(inputs, attrs):
         raise tvm.error.OpAttributeRequired('Attribute "mode" not found in operator pad.')
     if pad_mode not in ["constant", "edge", "reflect"]:
         raise tvm.error.OpAttributeInvalid("Value " + mode + ' in attribute "mode" is not valid')
-    pad_width = attrs.get_int_tuple("pad_width", None)
-    if pad_width is None:
+    # Special handling of pad_width
+    if 'pad_width' not in attrs.attrs:
         raise tvm.error.OpAttributeRequired('Attribute "pad_width" not found in operator pad.')
-    if None in pad_width:
-        raise tvm.error.OpAttributeInvalid(
-            'Value None in attribute "pad_width" of operator Pad is not valid.'
-        )
+    else:
+        # Begin to parse tuple of tuple
+        pad_width = attrs.attrs['pad_width']
+        pad_width = pad_width.replace('(', '[')
+        pad_width = pad_width.replace(')', ']')
+        pad_width = json.loads(pad_width)
     constant_values = attrs.get_float("constant_values", 0.0)
-    padding = tuple(tuple((b, a)) for b, a in zip(pad_width[::2], pad_width[1::2]))
-
     return _op.nn.pad(
-        data=inputs[0], pad_width=padding, pad_value=constant_values, pad_mode=pad_mode
+        data=inputs[0], pad_width=pad_width, pad_value=constant_values, pad_mode=pad_mode
     )
 
 

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2450,7 +2450,7 @@ _identity_list = [
     "sinh",
     "tan",
     "tanh",
-    "where"
+    "where",
 ]
 
 _convert_map = {

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -627,21 +627,6 @@ def _mx_expand_dims(inputs, attrs):
     return _op.expand_dims(inputs[0], axis=axis)
 
 
-def _mx_where(inputs, _):
-    cond, lhs, rhs = inputs
-    cond_shape = get_const_tuple(_infer_type(cond).checked_type.shape)
-    lhs_shape = get_const_tuple(_infer_type(lhs).checked_type.shape)
-    rhs_shape = get_const_tuple(_infer_type(rhs).checked_type.shape)
-    out_shape = np.broadcast(np.empty(cond_shape), np.empty(lhs_shape), np.empty(rhs_shape)).shape
-    if out_shape != cond_shape:
-        cond = _op.broadcast_to(cond, out_shape)
-    if out_shape != lhs_shape:
-        lhs = _op.broadcast_to(lhs, out_shape)
-    if out_shape != rhs_shape:
-        rhs = _op.broadcast_to(rhs, out_shape)
-    return _op.where(cond, lhs, rhs)
-
-
 def _mx_pad(inputs, attrs):
     pad_mode = attrs.get_str("mode", None)
     if pad_mode is None:
@@ -2465,12 +2450,12 @@ _identity_list = [
     "sinh",
     "tan",
     "tanh",
+    "where"
 ]
 
 _convert_map = {
     "_copy": _rename(_op.copy),
     "relu": _rename(_op.nn.relu),
-    "where": _mx_where,
     "broadcast_add": _rename(_op.add),
     "broadcast_plus": _rename(_op.add),
     "broadcast_sub": _rename(_op.subtract),

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2677,6 +2677,7 @@ _convert_map = {
     "_npi_add_scalar": _binop_scalar(_op.add),
     "_npi_where_rscalar": _mx_npi_where_rscalar,
     "_npi_less": _rename(_op.less),
+    "_npi_less_equal": _mx_compare(_op.less_equal, _rename),
     "_npi_tanh": _rename(_op.tanh),
     "_npi_true_divide_scalar": _binop_scalar(_op.divide),
 }

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2298,13 +2298,13 @@ def _mx_npi_pad(inputs, attrs):
     if pad_mode not in ["constant", "edge", "reflect"]:
         raise tvm.error.OpAttributeInvalid("Value " + mode + ' in attribute "mode" is not valid')
     # Special handling of pad_width
-    if 'pad_width' not in attrs.attrs:
+    if "pad_width" not in attrs.attrs:
         raise tvm.error.OpAttributeRequired('Attribute "pad_width" not found in operator pad.')
     else:
         # Begin to parse tuple of tuple
-        pad_width = attrs.attrs['pad_width']
-        pad_width = pad_width.replace('(', '[')
-        pad_width = pad_width.replace(')', ']')
+        pad_width = attrs.attrs["pad_width"]
+        pad_width = pad_width.replace("(", "[")
+        pad_width = pad_width.replace(")", "]")
         pad_width = json.loads(pad_width)
     constant_values = attrs.get_float("constant_values", 0.0)
     return _op.nn.pad(

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -2302,7 +2302,7 @@ def _mx_npi_pad(inputs, attrs):
         raise tvm.error.OpAttributeRequired('Attribute "pad_width" not found in operator pad.')
     if None in pad_width:
         raise tvm.error.OpAttributeInvalid(
-            'Value None in attribute "pad_width" of operator Slice is not valid.'
+            'Value None in attribute "pad_width" of operator Pad is not valid.'
         )
     constant_values = attrs.get_float("constant_values", 0.0)
     padding = tuple(tuple((b, a)) for b, a in zip(pad_width[::2], pad_width[1::2]))

--- a/python/tvm/topi/x86/batch_matmul.py
+++ b/python/tvm/topi/x86/batch_matmul.py
@@ -37,6 +37,9 @@ def batch_matmul(cfg, x, y, out_shape=None):
         3-D with shape [batch, M, K]
     y : tvm.te.Tensor
         3-D with shape [batch, N, K]
+    out_shape : tuple or None
+        Shape of the outputs
+
     Returns
     -------
     output : tvm.te.Tensor
@@ -135,7 +138,7 @@ def _default_batch_matmul_config(cfg, M, N, K):
 
 
 @autotvm.register_topi_compute("batch_matmul_cblas.x86")
-def batch_matmul_cblas(cfg, x, y):
+def batch_matmul_cblas(cfg, x, y, out_shape=None):
     """Computes batch matrix multiplication of `x` and `y` when `x` and `y` are
     data in batch.
 
@@ -147,6 +150,9 @@ def batch_matmul_cblas(cfg, x, y):
         3-D with shape [batch, M, K]
     y : tvm.te.Tensor
         3-D with shape [batch, N, K]
+    out_shape : tuple or None
+        Shape of the output
+
     Returns
     -------
     output : tvm.te.Tensor
@@ -157,6 +163,10 @@ def batch_matmul_cblas(cfg, x, y):
     YB, N, YK = get_const_tuple(y.shape)
     assert XB == YB, "batch dimension doesn't match"
     assert XK == YK, "shapes of x and y is inconsistant"
+    if out_shape is not None:
+        assert out_shape[0] == XB, "got invalid output shape"
+        assert out_shape[1] == M, "got invalid output shape"
+        assert out_shape[2] == N, "got invalid output shape"
     cfg.add_flop(XB * M * N * XK * 2)
     return cblas.batch_matmul(x, y, False, True)
 

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -322,7 +322,7 @@ def test_forward_where(cond_shape, x_shape, y_shape):
     y = mx.sym.var("y")
     dtype = "float32"
     mx_sym = mx.sym.where(cond, x, y)
-    np_cond = np.random.randint(0, 2, cond_shape, dtype=dtype)
+    np_cond = np.random.randint(0, 2, cond_shape).astype(dtype=dtype)
     np_x = np.random.uniform(size=x_shape).astype(dtype)
     np_y = np.random.uniform(size=y_shape).astype(dtype)
     mx_cond = mx.nd.array(np_cond)

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -2105,12 +2105,7 @@ def test_forward_npi_tanh(data_shape, dtype, target, ctx, kind):
 @pytest.mark.skipif(not hasattr(mx.np, "where"), reason="mx.np.where hasn't been publish yet")
 @pytest.mark.parametrize(
     "data_shape,cond_shape",
-    [
-        [(2, 2, 2), (2, 2, 2)],
-        [(2, 7, 2), (7, 2)],
-        [(2, 2), (1, 2)],
-        [(1, 3), (3, 3)]
-    ]
+    [[(2, 2, 2), (2, 2, 2)], [(2, 7, 2), (7, 2)], [(2, 2), (1, 2)], [(1, 3), (3, 3)]],
 )
 @pytest.mark.parametrize("data_dtype", ["float64", "float32", "int64", "int32", "bool"])
 @pytest.mark.parametrize("cond_dtype", ["float64", "float32", "int64", "int32", "bool"])
@@ -2118,7 +2113,7 @@ def test_forward_npi_tanh(data_shape, dtype, target, ctx, kind):
 @tvm.testing.parametrize_targets
 @pytest.mark.parametrize("kind", ["graph", "vm", "debug"])
 def test_forward_npi_where_rscalar(
-        data_shape, cond_shape, data_dtype, cond_dtype, scalar, target, ctx, kind
+    data_shape, cond_shape, data_dtype, cond_dtype, scalar, target, ctx, kind
 ):
     if data_dtype == "bool":
         scalar = scalar == 0.0

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -1916,7 +1916,7 @@ def test_forward_softmax():
     "data_shape, pad_width",
     [
         ((1, 1, 3, 5), ((0, 0), (0, 0), (1, 2), (3, 4))),
-        ((1, 1, 3, 5, 7), ((0, 0), (0, 0), (1, 2), (3, 4), (5, 6)))
+        ((1, 1, 3, 5, 7), ((0, 0), (0, 0), (1, 2), (3, 4), (5, 6))),
     ],
 )
 @pytest.mark.parametrize("mode", ["constant", "edge", "reflect"])
@@ -1928,9 +1928,7 @@ def test_forward_npi_pad(data_shape, pad_width, mode, dtype, constant_value, tar
     data_np = np.random.uniform(size=data_shape).astype(dtype)
     data = mx.sym.var("data")
     if mode == "constant":
-        ref_res = np.pad(
-            data_np, mode=mode, pad_width=pad_width, constant_values=constant_value
-        )
+        ref_res = np.pad(data_np, mode=mode, pad_width=pad_width, constant_values=constant_value)
         mx_sym = mx.sym.np.pad(
             data.as_np_ndarray(), mode=mode, pad_width=pad_width, constant_values=constant_value
         )

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -329,13 +329,9 @@ def test_forward_where(cond_shape, x_shape, y_shape):
     mx_x = mx.nd.array(np_x)
     mx_y = mx.nd.array(np_y)
     shapes = {"cond": cond_shape, "x": x_shape, "y": y_shape}
-    mod = mx.mod.Module(mx_sym, label_names=None, data_names=["cond", "x", "y"])
-    mod.bind(data_shapes=shapes.items(), for_training=False)
-    mod.init_params()
-    args, auxs = mod.get_params()
     mx_out = mx.nd.where(mx_cond, mx_x, mx_y).asnumpy()
 
-    mod, _ = relay.frontend.from_mxnet(mx_sym, shapes, args, auxs)
+    mod, _ = relay.frontend.from_mxnet(mx_sym, shapes, None, None)
     for target, ctx in tvm.testing.enabled_targets():
         for kind in ["graph", "debug"]:
             intrp = relay.create_executor(kind, mod=mod, ctx=ctx, target=target)

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -312,20 +312,24 @@ def test_forward_slice():
 
 
 @tvm.testing.uses_gpu
-def test_forward_where():
+@pytest.mark.parametrize(
+    "cond_shape,x_shape,y_shape",
+    [[(2, 2, 2), (2, 2, 2), (2, 2, 2)], [(2, 7, 2), (7, 2), (7, 1)]],
+)
+def test_forward_where(cond_shape, x_shape, y_shape):
     cond = mx.sym.var("cond")
     x = mx.sym.var("x")
     y = mx.sym.var("y")
     dshape = (2, 2)
     dtype = "float32"
     mx_sym = mx.sym.where(cond, x, y)
-    np_cond = np.array([[0, 1], [-1, 0]]).astype(dtype)
-    np_x = np.random.uniform(size=dshape).astype(dtype)
-    np_y = np.random.uniform(size=dshape).astype(dtype)
+    np_cond = np.random.randint(0, 2, cond_shape, dtype=dtype)
+    np_x = np.random.uniform(size=x_shape).astype(dtype)
+    np_y = np.random.uniform(size=y_shape).astype(dtype)
     mx_cond = mx.nd.array(np_cond)
     mx_x = mx.nd.array(np_x)
     mx_y = mx.nd.array(np_y)
-    shapes = {"cond": dshape, "x": dshape, "y": dshape}
+    shapes = {"cond": cond_shape, "x": x_shape, "y": y_shape}
     mod = mx.mod.Module(mx_sym, label_names=None, data_names=["cond", "x", "y"])
     mod.bind(data_shapes=shapes.items(), for_training=False)
     mod.init_params()

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -320,7 +320,6 @@ def test_forward_where(cond_shape, x_shape, y_shape):
     cond = mx.sym.var("cond")
     x = mx.sym.var("x")
     y = mx.sym.var("y")
-    dshape = (2, 2)
     dtype = "float32"
     mx_sym = mx.sym.where(cond, x, y)
     np_cond = np.random.randint(0, 2, cond_shape, dtype=dtype)

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -2011,8 +2011,12 @@ def test_forward_np_copy(data_shape, dtype, target, ctx, kind):
         ((2, 3, 8), (-2, -2, 2, -1), False),
         ((8, 3, 3, 3, 4, 4), (-6, 2, -1, -4), False),
         ((8, 3, 3, 3, 4, 4), (-5, -4), False),
+        ((1, 8, 3, 3, 3, 4, 4), (-3, -5, -4), False),
+        ((8, 1, 3, 4), (-2, -3, -1), False),
         ((8, 3, 3, 3, 3, 8), (-4, -5), True),
         ((8, 3, 2, 4, 8), (-4, -1, 2, -6), True),
+        ((3, 2, 4, 8, 1, 1), (-4, -1, 2, -6, -5, -3), True),
+        ((2, 4, 1, 8), (-4, -3, -1, 2, -6), True),
     ],
 )
 def test_forward_npx_reshape(data_shape, out_shape, dtype, target, reverse, ctx, kind):
@@ -2099,16 +2103,26 @@ def test_forward_npi_tanh(data_shape, dtype, target, ctx, kind):
 
 
 @pytest.mark.skipif(not hasattr(mx.np, "where"), reason="mx.np.where hasn't been publish yet")
-@pytest.mark.parametrize("data_shape", [(2, 2, 2), (2, 7, 2), (1, 8), (2, 2), (1, 3)])
+@pytest.mark.parametrize(
+    "data_shape,cond_shape",
+    [
+        [(2, 2, 2), (2, 2, 2)],
+        [(2, 7, 2), (7, 2)],
+        [(2, 2), (1, 2)],
+        [(1, 3), (3, 3)]
+    ]
+)
 @pytest.mark.parametrize("data_dtype", ["float64", "float32", "int64", "int32", "bool"])
 @pytest.mark.parametrize("cond_dtype", ["float64", "float32", "int64", "int32", "bool"])
 @pytest.mark.parametrize("scalar", [1.0, 2.0])
 @tvm.testing.parametrize_targets
 @pytest.mark.parametrize("kind", ["graph", "vm", "debug"])
-def test_forward_npi_where_rscalar(data_shape, cond_dtype, data_dtype, scalar, target, ctx, kind):
+def test_forward_npi_where_rscalar(
+        data_shape, cond_shape, data_dtype, cond_dtype, scalar, target, ctx, kind
+):
     if data_dtype == "bool":
         scalar = scalar == 0.0
-    cond_np = np.random.uniform(size=data_shape).astype(cond_dtype)
+    cond_np = np.random.uniform(size=cond_shape).astype(cond_dtype)
     data_np = np.random.uniform(size=data_shape).astype(data_dtype)
     cond = mx.sym.var("condition")
     data = mx.sym.var("x")
@@ -2118,7 +2132,7 @@ def test_forward_npi_where_rscalar(data_shape, cond_dtype, data_dtype, scalar, t
     dtypeDic["condition"] = cond_dtype
     dtypeDic["x"] = data_dtype
     mod, _ = relay.frontend.from_mxnet(
-        mx_sym, shape={"condition": data_shape, "x": data_shape}, dtype=dtypeDic
+        mx_sym, shape={"condition": cond_shape, "x": data_shape}, dtype=dtypeDic
     )
     intrp = relay.create_executor(kind, mod=mod, ctx=ctx, target=target)
     op_res = intrp.evaluate()(cond_np, data_np)

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -134,7 +134,7 @@ def test_binary_op():
                     continue
                 intrp = relay.create_executor("graph", ctx=ctx, target=target)
                 op_res = intrp.evaluate(func)(x_data, y_data)
-                np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=0.01, atol=1E-3)
+                np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=0.01, atol=1e-3)
 
     for opfunc, ref in [
         (relay.add, np.add),

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -134,7 +134,7 @@ def test_binary_op():
                     continue
                 intrp = relay.create_executor("graph", ctx=ctx, target=target)
                 op_res = intrp.evaluate(func)(x_data, y_data)
-                np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=0.01)
+                np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=0.01, atol=1E-3)
 
     for opfunc, ref in [
         (relay.add, np.add),


### PR DESCRIPTION
Fix the MXNet 2.0 integration in relay. Tested the BERT and ALBERT model in the new [GluonNLP 1.0](https://github.com/dmlc/gluon-nlp/tree/master) and has passed the test. I will later add unittests in GluonNLP side to ensure that the backbones can be run with the graph runtime.

```python
import mxnet as mx
import numpy as np
import gluonnlp
from gluonnlp.models import get_backbone
import numpy.testing as npt

mx.npx.set_np()

model_cls, cfg, tokenizer, backbone_param_path, _ = get_backbone('google_albert_base_v2')

model = model_cls.from_cfg(cfg)
model.load_parameters(backbone_param_path)
model.hybridize()


batch_size = 1
seq_length = 128
token_ids = mx.np.random.randint(0, cfg.MODEL.vocab_size, (batch_size, seq_length), dtype=np.int32)
token_types = mx.np.random.randint(0, 2, (batch_size, seq_length), dtype=np.int32)
valid_length = mx.np.random.randint(seq_length // 2, seq_length, (batch_size,), dtype=np.int32)
mx_out = model(token_ids, token_types, valid_length)

import tvm
from tvm import relay
import tvm.contrib.graph_runtime as runtime

shape_dict = {
    'data0': (batch_size, seq_length),
    'data1': (batch_size, seq_length),
    'data2': (batch_size,)
}

dtype_dict = {
    'data0': 'int32',
    'data1': 'int32',
    'data2': 'int32'
}

sym = model._cached_graph[1]

params = {}
for k, v in model.collect_params().items():
    params[v._var_name] = tvm.nd.array(v.data().asnumpy())
mod, params = relay.frontend.from_mxnet(sym, shape=shape_dict, dtype=dtype_dict, arg_params=params)
print(mod)
# G4
target = "cuda -model=t4"

with relay.build_config(opt_level=3, required_pass=["FastMath"]):
    graph, lib, cparams = relay.build(mod, target, params=params)

ctx = tvm.gpu()
rt = runtime.create(graph, lib, ctx)
rt.set_input(**cparams)
rt.set_input(data0=token_ids, data1=token_types, data2=valid_length)
rt.run()
for i in range(rt.get_num_outputs()):
    out = rt.get_output(i)
    print(out.asnumpy())# verify the correctness
    npt.assert_allclose(out.asnumpy(), mx_out[i].asnumpy(), rtol=1e-3, atol=1e-2)
```