### PR TITLE
Add cloudpickle dependency to docker images

### DIFF
--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -21,6 +21,7 @@
 FROM ioft/i386-ubuntu:16.04
 
 RUN apt-get update --fix-missing
+RUN apt-get install -y ca-certificates
 
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
@@ -30,6 +31,9 @@ RUN bash /install/ubuntu_install_llvm.sh
 
 COPY install/ubuntu_install_python.sh /install/ubuntu_install_python.sh
 RUN bash /install/ubuntu_install_python.sh
+
+COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source.sh
+RUN bash /install/ubuntu_install_cmake_source.sh
 
 COPY install/ubuntu_install_python_package.sh /install/ubuntu_install_python_package.sh
 RUN bash /install/ubuntu_install_python_package.sh

--- a/docker/install/ubuntu_install_cmake_source.sh
+++ b/docker/install/ubuntu_install_cmake_source.sh
@@ -20,5 +20,13 @@ set -e
 set -u
 set -o pipefail
 
-# install libraries for python package on ubuntu
-pip3 install six numpy pytest cython decorator scipy tornado typed_ast pytest mypy orderedset attrs requests Pillow packaging cloudpickle
+v=3.13
+version=3.13.5
+wget https://cmake.org/files/v${v}/cmake-${version}.tar.gz
+tar xvf cmake-${version}.tar.gz
+cd cmake-${version}
+./bootstrap
+make -j$(nproc)
+make install
+cd ..
+rm -rf cmake-${version} cmake-${version}.tar.gz


### PR DESCRIPTION
This dependency is needed for #6679. I also had to add a cmake build from source to the i386 image so that xgboost builds (it builds from source because there is no wheel for i386).

@jroesch @tqchen 