### PR TITLE
[PYTHON][WINDOWS] More robust dll loading behavior after python3.8

### DIFF
--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -49,6 +49,11 @@ else:
 def _load_lib():
     """Load libary by searching possible path."""
     lib_path = libinfo.find_lib_path()
+    # The dll search path need to be added explicitly in
+    # windows after python 3.8
+    if sys.platform.startswith("win32") and sys.version_info >= (3, 8):
+        for path in libinfo.get_dll_directories():
+            os.add_dll_directory(path)
     lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
     lib.TVMGetLastError.restype = ctypes.c_char_p
     return lib, os.path.basename(lib_path[0])

--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -40,23 +40,8 @@ def split_env_var(env_var, split):
     return []
 
 
-def find_lib_path(name=None, search_path=None, optional=False):
-    """Find dynamic library files.
-
-    Parameters
-    ----------
-    name : list of str
-        List of names to be found.
-
-    Returns
-    -------
-    lib_path : list(string)
-        List of all found path to the libraries
-    """
-    use_runtime = os.environ.get("TVM_USE_RUNTIME_LIB", False)
-
-    # See https://github.com/apache/incubator-tvm/issues/281 for some background.
-
+def get_dll_directories():
+    """Get the possible dll directories"""
     # NB: This will either be the source directory (if TVM is run
     # inplace) or the install directory (if TVM is installed).
     # An installed TVM's curr_path will look something like:
@@ -94,11 +79,31 @@ def find_lib_path(name=None, search_path=None, optional=False):
         dll_path.append(os.path.join(source_dir, "web", "dist"))
 
     dll_path = [os.path.realpath(x) for x in dll_path]
+    return [x for x in dll_path if os.path.isdir(x)]
+
+
+def find_lib_path(name=None, search_path=None, optional=False):
+    """Find dynamic library files.
+
+    Parameters
+    ----------
+    name : list of str
+        List of names to be found.
+
+    Returns
+    -------
+    lib_path : list(string)
+        List of all found path to the libraries
+    """
+    use_runtime = os.environ.get("TVM_USE_RUNTIME_LIB", False)
+    dll_path = get_dll_directories()
+
     if search_path is not None:
         if isinstance(search_path, list):
             dll_path = dll_path + search_path
         else:
             dll_path.append(search_path)
+
     if name is not None:
         if isinstance(name, list):
             lib_dll_path = []


### PR DESCRIPTION
The dll search directories need to be manually added
by os.add_dll_directory after python3.8.
