### PR TITLE
[AutoScheduler] Relay integration : Task extraction

### DIFF
--- a/python/tvm/auto_scheduler/__init__.py
+++ b/python/tvm/auto_scheduler/__init__.py
@@ -18,10 +18,13 @@
 """ Namespace for TVM Auto-scheduler. """
 
 from . import compute_dag
+from . import dispatcher
+from . import env
 from . import feature
 from . import loop_state
 from . import measure
 from . import measure_record
+from . import relay_integration
 from . import search_policy
 from . import search_task
 from . import task_scheduler
@@ -32,6 +35,8 @@ from . import workload_registry
 from .auto_schedule import TuningOptions, HardwareParams, create_task, auto_schedule
 from .compute_dag import ComputeDAG
 from .cost_model import RandomModel, XGBModel
+from .dispatcher import DispatchContext, ApplyHistoryBest
+from .env import enable_relay_integration, is_relay_integration_enabled
 from .measure import (
     MeasureInput,
     MeasureResult,
@@ -41,6 +46,7 @@ from .measure import (
     LocalRPCMeasureContext,
 )
 from .measure_record import RecordToFile, RecordReader, load_best, load_records, save_records
+from .relay_integration import extract_tasks
 from .search_task import SearchTask
 from .search_policy import EmptyPolicy, SketchPolicy, PreloadMeasuredStates
 from .task_scheduler import TaskScheduler

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -151,7 +151,14 @@ class ComputeDAG(Object):
                 updated_state.stage_id_map[k] = v
         return updated_state
 
-    def __hash__(self):
+    def hash_key(self):
+        """Return the hash key of this compute DAG.
+
+        Returns
+        -------
+        key: str
+            The hash key of this compute DAG
+        """
         # TODO(merrymercy): Implement this more carefully and move this to c++ as a member function
         # of ComputeDAG
         str_key = ""

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -23,10 +23,11 @@ from collections import defaultdict
 import time
 
 import numpy as np
-import xgboost as xgb
-from xgboost.core import EarlyStopException
-from xgboost.callback import _fmt_metric
-from xgboost.training import aggcv
+
+try:
+    import xgboost as xgb
+except ImportError:
+    xgb = None
 
 from tvm.autotvm.tuner.metric import max_curve
 from .cost_model import PythonBasedModel
@@ -92,6 +93,14 @@ class XGBModel(PythonBasedModel):
     """
 
     def __init__(self, verbose_eval=25, num_warmup_sample=100, seed=None):
+
+        if xgb is None:
+            raise ImportError(
+                "XGBoost is required for XGBModel. "
+                "Please install its python package first. "
+                "Help: (https://xgboost.readthedocs.io/en/latest/) "
+            )
+
         self.xgb_params = {
             "max_depth": 10,
             "gamma": 0.001,
@@ -505,6 +514,11 @@ def custom_callback(
     skip_every=2,
 ):
     """Callback function for xgboost to support multiple custom evaluation functions"""
+    # pylint: disable=import-outside-toplevel
+    from xgboost.core import EarlyStopException
+    from xgboost.callback import _fmt_metric
+    from xgboost.training import aggcv
+
     state = {}
     metric_shortname = metric.split("-")[1]
 

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -116,11 +116,10 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str or iterator of (MeasureInput, MeasureResult)
+    records : str or iterator of (auto_scheduler.measure.MeasureInput, auto_scheduler.meaure.MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
-                   Each row of this file is an encoded record pair.
-        Otherwise, it is an iterator.
+        Each row of this file is an encoded record pair. Otherwise, it is an iterator.
     n_lines: Optional[int]
         if it is not None, only load the first `n_lines` lines of log
     """
@@ -139,11 +138,10 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str or iterator of (MeasureInput, MeasureResult)
+        records : str or iterator of (auto_scheduler.measure.MeasureInput, auto_scheduler.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
-                       Each row of this file is an encoded record pair.
-            Otherwise, it is an iterator.
+            Each row of this file is an encoded record pair. Otherwise, it is an iterator.
         n_lines: Optional[int]
             if it is not None, only load the first `n_lines` lines of log
         """

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -116,7 +116,8 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str or iterator of (auto_scheduler.measure.MeasureInput, auto_scheduler.meaure.MeasureResult)
+    records : str or iterator of (auto_scheduler.measure.MeasureInput,\
+                                  auto_scheduler.measure.MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
         Each row of this file is an encoded record pair. Otherwise, it is an iterator.
@@ -138,7 +139,8 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str or iterator of (auto_scheduler.measure.MeasureInput, auto_scheduler.measure.MeasureResult)
+        records : str or iterator of (auto_scheduler.measure.MeasureInput,\
+                                      auto_scheduler.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
             Each row of this file is an encoded record pair. Otherwise, it is an iterator.

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -1,0 +1,271 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+The global context that dispatches best schedules to workloads.
+
+In auto-scheduler, a state (loop_state.py::StateObject) saves the
+schedule configuration by its transform_steps, so a state is used
+as a schedule configuration here.
+"""
+# pylint: disable=invalid-name
+
+import logging
+import pathlib
+
+import numpy as np
+
+from tvm.tir.expr import FloatImm
+from .measure_record import load_records
+
+logger = logging.getLogger("auto_scheduler")
+
+
+class DispatchContext(object):
+    """
+    Base class of dispatch context.
+    """
+
+    current = None
+
+    def __init__(self):
+        self._old_ctx = DispatchContext.current
+
+    def query(self, target, workload_key):
+        """
+        Query the context to get the specific config for a workload.
+        If cannot find the result inside this context, this function will query it
+        from the upper contexts.
+
+        Parameters
+        ----------
+        target: Target
+            The current target
+        workload_key : str
+            The workload key
+
+        Returns
+        -------
+        state : StateObject
+            The state that stores schedule configuration for the workload
+        """
+        ret = self._query_inside(target, workload_key)
+        if ret is None:
+            ret = self._old_ctx.query(target, workload_key)
+        return ret
+
+    def update(self, target, workload_key, state):
+        """
+        Update the config for a workload
+
+        Parameters
+        ----------
+        target: Target
+            The current target
+        workload_key : str
+            The current workload_key.
+        state : StateObject
+            The state that stores schedule configuration for the workload
+        """
+        raise NotImplementedError()
+
+    def _query_inside(self, target, workload_key):
+        """
+        Query the context to get the specific config for a workload.
+        This function only query config inside this context.
+
+        Parameters
+        ----------
+        target: Target
+            The current target
+        workload_key : str
+            The current workload_key.
+
+        Returns
+        -------
+        state : StateObject
+            The schedule configuration for the workload
+        """
+        raise NotImplementedError()
+
+    def __enter__(self):
+        self._old_ctx = DispatchContext.current
+        DispatchContext.current = self
+        return self
+
+    def __exit__(self, ptype, value, trace):
+        DispatchContext.current = self._old_ctx
+
+
+class ApplyHistoryBest(DispatchContext):
+    """
+    Apply the history best config
+
+    Parameters
+    ----------
+    records : str or iterator of (MeasureInput, MeasureResult)
+        Collection of tuning records.
+        If is str, then it should be the filename of a records log file.
+                   Each row of this file is an encoded record pair.
+        Otherwise, it is an iterator.
+    n_lines: Optional[int]
+        if it is not None, only load the first `n_lines` lines of log
+    """
+
+    def __init__(self, records, n_lines=None):
+        super(ApplyHistoryBest, self).__init__()
+
+        self.best_by_targetkey = {}
+        self.best_by_model = {}
+        self._best_user_defined = {}
+
+        self.load(records, n_lines)
+
+    def load(self, records, n_lines=None):
+        """Load records to this dispatch context
+
+        Parameters
+        ----------
+        records : str or iterator of (MeasureInput, MeasureResult)
+            Collection of tuning records.
+            If is str, then it should be the filename of a records log file.
+                       Each row of this file is an encoded record pair.
+            Otherwise, it is an iterator.
+        n_lines: Optional[int]
+            if it is not None, only load the first `n_lines` lines of log
+        """
+        if isinstance(records, pathlib.Path):
+            records = str(records)
+
+        if isinstance(records, str):
+            records = load_records(records)
+
+        if not records:
+            return
+
+        best_by_targetkey = self.best_by_targetkey
+        best_by_model = self.best_by_model
+
+        counter = 0
+        for inp, res in records:
+            if n_lines is not None and counter >= n_lines:
+                break
+            counter += 1
+            if res.error_no != 0:
+                continue
+
+            # use target keys in tvm target system as key to build best map
+            for k in inp.task.target.keys:
+                key = (k, inp.task.workload_key)
+                if key not in best_by_targetkey:
+                    best_by_targetkey[key] = (inp, res)
+                else:
+                    _, other_res = best_by_targetkey[key]
+                    other_costs = [x.value for x in other_res.costs if isinstance(x, FloatImm)]
+                    costs = [x.value for x in res.costs if isinstance(x, FloatImm)]
+                    if np.mean(other_costs) > np.mean(costs):
+                        best_by_targetkey[key] = (inp, res)
+
+            # use model as key to build best map
+            key = (inp.task.target.model, inp.task.workload_key)
+            if key not in best_by_model:
+                if inp.task.target.model != "unknown":
+                    best_by_model[key] = (inp, res)
+            else:
+                _, other_res = best_by_model[key]
+                other_costs = [x.value for x in other_res.costs if isinstance(x, FloatImm)]
+                costs = [x.value for x in res.costs if isinstance(x, FloatImm)]
+                if np.mean(other_costs) > np.mean(costs):
+                    best_by_model[key] = (inp, res)
+
+        logger.debug("Finish loading %d records", counter)
+
+    def _query_inside(self, target, workload_key):
+        if target is None:
+            raise RuntimeError(
+                "Need a target context to find the history best. "
+                "Hint: If your target is llvm, use `with tvm.target.create('llvm'):`"
+                " above the dispatcher call. So does other target. "
+            )
+
+        # first try matching by model
+        key = (target.model, workload_key)
+        if key in self._best_user_defined:
+            return self._best_user_defined[key]
+        if key in self.best_by_model:
+            return self.best_by_model[key][0].state
+
+        # then try matching by target key
+        for k in target.keys:
+            key = (k, workload_key)
+            if key in self._best_user_defined:
+                return self._best_user_defined[key]
+            if key in self.best_by_targetkey:
+                return self.best_by_targetkey[key][0].state
+
+        return None
+
+    def update(self, target, workload_key, state):
+        model = target.model
+        key = (model, workload)
+        self._best_user_defined[key] = state
+
+        for k in target.keys:
+            key = (k, workload)
+            self._best_user_defined[key] = state
+
+
+class FallbackContext(DispatchContext):
+    """
+    A fallback dispatch context.
+    This is used as the root context.
+    """
+
+    def __init__(self):
+        super(FallbackContext, self).__init__()
+        self.memory = {}
+        self.silent = False
+
+        # a set to prevent print duplicated message
+        self.messages = set()
+
+    def _query_inside(self, target, workload_key):
+        key = (str(target), workload_key)
+        if key in self.memory:
+            return self.memory[key]
+
+        if not self.silent:
+            msg = (
+                "Cannot find tuned schedule for target=%s, workload_key=%s. "
+                "A fallback schedule is used, "
+                "which may bring great performance regression." % (target, workload_key)
+            )
+            if msg not in self.messages:
+                self.messages.add(msg)
+                logger.warning(msg)
+
+        state = None
+
+        # cache this config to avoid duplicated warning message
+        self.memory[key] = state
+        return state
+
+    def update(self, target, workload_key, state):
+        key = (str(target), workload_key)
+        self.memory[key] = state
+
+
+DispatchContext.current = FallbackContext()

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -263,6 +263,10 @@ class FallbackContext(DispatchContext):
         self.memory[key] = state
         return state
 
+    def _query_inside(self, target, workload_key):
+        _ = target = workload_key
+        raise RuntimeError("This function should never be called")
+
     def update(self, target, workload_key, state):
         key = (str(target), workload_key)
         self.memory[key] = state

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -242,7 +242,7 @@ class FallbackContext(DispatchContext):
         # a set to prevent print duplicated message
         self.messages = set()
 
-    def _query_inside(self, target, workload_key):
+    def query(self, target, workload_key):
         key = (str(target), workload_key)
         if key in self.memory:
             return self.memory[key]

--- a/python/tvm/auto_scheduler/env.py
+++ b/python/tvm/auto_scheduler/env.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""The scope to store global environmental variables of the auto-scheduler"""
+
+
+class AutoSchedulerGlobalScope(object):
+    """The global scope to store environmental variables of the auot-scheduler"""
+
+    def __init__(self):
+        self.enable_relay_integration = False
+
+
+GLOBAL_SCOPE = AutoSchedulerGlobalScope()
+
+
+def is_relay_integration_enabled():
+    """Return whether the relay integration is enabled
+
+    Returns
+    -------
+    enabled: bool
+        Whether the relay integration is enabled
+    """
+    return GLOBAL_SCOPE.enable_relay_integration
+
+
+def enable_relay_integration(new_value=True):
+    """Set the relay integration
+
+    Parameters
+    ---------
+    new_value: bool = True
+        The new setting of relay integration
+
+    Returns
+    -------
+    old_value: bool
+        The old setting.
+    """
+    old_value = GLOBAL_SCOPE.enable_relay_integration
+    GLOBAL_SCOPE.enable_relay_integration = new_value
+    return old_value

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -102,9 +102,9 @@ class MeasureInput(Object):
 
     @staticmethod
     def deserialize(data):
-        x = _ffi_api.DeserializeMeasureInput(data[0])
-        deserialize_workload_registry_entry(x.task.workload_key, data[1])
-        return recover_measure_input(x)
+        inp = _ffi_api.DeserializeMeasureInput(data[0])
+        deserialize_workload_registry_entry(data[1])
+        return recover_measure_input(inp)
 
 
 @tvm._ffi.register_object("auto_scheduler.BuildResult")

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -1,0 +1,232 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-variable,invalid-name
+
+"""
+Integrate auto_scheduler into relay. It implements the following items:
+1. Extract search tasks from a relay program
+2. Provide auto-scheduling for all TOPI compute functions
+"""
+
+import threading
+
+import tvm
+from tvm import te, transform
+from tvm.te.tensor import ComputeOp, PlaceholderOp
+from .compute_dag import ComputeDAG
+from .dispatcher import DispatchContext
+from .search_task import SearchTask
+from .workload_registry import register_workload_tensors
+
+
+def call_all_topi_funcs(mod, params, target):
+    """Call all TOPI compute + schedule to extract tasks in a relay program"""
+    # pylint: disable=import-outside-toplevel
+    from tvm import relay
+    from tvm.relay.backend import graph_runtime_codegen
+
+    with transform.PassContext(opt_level=3):
+        opt_mod, _ = relay.optimize(mod, target, params)
+        grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
+        grc.codegen(opt_mod["main"])
+
+
+def extract_tasks(mod, params, target, target_host=None, hardware_params=None):
+    """Extract tuning tasks from a relay program.
+
+    Parameters
+    ----------
+    mod: tvm.IRModule or relay.function.Function
+        The module or function to tune
+    params: dict of str to numpy array
+        The associated parameters of the program
+    target: Union[tvm.target.Target, str]
+        The compilation target
+    target_host: Optional[Union[tvm.target.Target, str]]
+        The host compilation target
+    hardware_params : Optional[HardwareParams]
+        Hardware parameters used for the search tasks
+
+    Returns
+    -------
+    tasks: List[SearchTask]
+        The tasks in this network
+    weights: List[int]
+        The weight (i.e. the number of appearance) of extracted tasks
+    """
+    # pylint: disable=import-outside-toplevel
+    from tvm import relay
+
+    if isinstance(target, str):
+        target = Target(target)
+    if isinstance(target_host, str):
+        target_host = Target(target_host)
+
+    # Run the compiler to collect all TOPI calls during compilation.
+    env = TracingEnvironment(TracingMode.EXTRACT_TASK)
+    with env:
+        # Wrap build call in a new thread to avoid the conflict
+        # between python's multiprocessing and tvm's thread pool
+        build_thread = threading.Thread(target=call_all_topi_funcs, args=(mod, params, target))
+        build_thread.start()
+        build_thread.join()
+
+    # query the compile engine to get the number of occurrence of all tasks
+    engine = relay.backend.compile_engine.get()
+    use_count_dict = {}
+    for k, v in engine.items():
+        use_count_dict[k] = v.use_count
+
+    # create search tasks
+    tasks = []
+    weights = []
+    for wkl_key, ccache_key in env.wkl_key_to_ccache_key.items():
+        dag = ComputeDAG(wkl_key)
+        tasks.append(SearchTask(dag, wkl_key, target, target_host, hardware_params))
+        weights.append(use_count_dict[ccache_key] + 1)
+
+    # clean the cached lowering results
+    engine.clear()
+
+    return tasks, weights
+
+
+class TracingMode:
+    """Two modes for tracing"""
+
+    EXTRACT_TASK = 0  # trace all topi calls to extract tasks
+    PREPARE_LAYOUT_REWRITE = 1  # trace topi calls to prepare layout rewrite
+
+
+class TracingEnvironment:
+    """Global environment for tracing all topi function calls"""
+
+    current = None
+
+    def __init__(self, tracing_mode):
+        self.tracing_mode = tracing_mode
+        self.relay_disable_build_cache = "false"
+        self.wkl_key_to_ccache_key = {}
+
+    def __enter__(self):
+        TracingEnvironment.current = self
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        TracingEnvironment.current = None
+
+    def add_workload_key(self, workload_key, ccache_key):
+        """Add the workload key of a search task
+
+        Parameters
+        ----------
+        workload_key: str
+            The workload key of a task
+        ccache_key: CCacheKey
+            The corresponding ccache_key of the task
+        """
+        self.wkl_key_to_ccache_key[workload_key] = ccache_key
+
+
+def traverse_to_get_io_tensors(outs):
+    """Traverse from a list of output tensors to get both input and output tensors
+
+    Parameters
+    ----------
+    outs: List[Tensor]
+        The output tensors
+
+    Returns
+    -------
+    io_tensors: List[Tensor]
+        The input and output tensors
+    has_layout_free: bool
+        Whether the compute DAG has layout_free placeholders
+    """
+    layout_free_ops = []
+    inputs = []
+
+    visited = set()
+
+    def traverse(t):
+        if t in visited:
+            return
+        if isinstance(t.op, PlaceholderOp):
+            inputs.append(t)
+        elif isinstance(t.op, ComputeOp):
+            if "layout_free_placeholders" in t.op.attrs:
+                layout_free_ops.append(t.op)
+            for x in t.op.input_tensors:
+                traverse(x)
+        visited.add(t)
+
+    for t in outs:
+        traverse(t)
+
+    has_layout_free = len(layout_free_ops) > 0
+    return inputs + list(outs), has_layout_free
+
+
+# The suffix of implementations that use the auto-scheduler in the OpStrategy.
+auto_schedule_impl_suffix = ".auto_scheduler"
+
+
+def auto_schedule_topi(outs):
+    """Use auto-scheduler to schedule any topi compute function.
+
+    Note: This is used internally for relay integration. Do
+    not use this as a general user-facing API.
+
+    Parameters
+    ----------
+    outs: List[Tensor]
+        The output tensors of topi compute functions
+
+    Returns
+    -------
+    sch: te.Schedule
+        A topi schedule function
+    """
+    # pylint: disable=import-outside-toplevel
+    from tvm import relay
+
+    io_tensors, has_layout_free = traverse_to_get_io_tensors(outs)
+    key = register_workload_tensors(io_tensors)
+
+    # only enable layout rewrite for cpu backend
+    enable_layout_rewrite = "cpu" in tvm.target.Target.current().keys
+
+    env = TracingEnvironment.current
+    if env is None:  # in the final build mode
+        state = DispatchContext.current.query(tvm.target.Target.current(), key)
+        if state is None:
+            return te.create_schedule([x.op for x in outs])
+
+        dag = ComputeDAG(io_tensors)
+        schedule, _ = dag.apply_steps_from_state(state)
+    elif env.tracing_mode == TracingMode.EXTRACT_TASK:  # in the task extraction mode
+        engine = relay.backend.compile_engine.get()
+        ccache_key = engine.get_current_ccache_key()
+        env.add_workload_key(key, ccache_key)
+        schedule = te.create_schedule([x.op for x in outs])
+    elif env.tracing_mode == TracingMode.PREPARE_LAYOUT_REWRITE:
+        # todo(merrymercy, minminsun): port layout rewrite
+        raise NotImplementedError
+    else:
+        raise ValueError("Invalid tracing mode: " + env.tracing_mode)
+
+    return schedule

--- a/python/tvm/auto_scheduler/search_policy.py
+++ b/python/tvm/auto_scheduler/search_policy.py
@@ -148,7 +148,7 @@ class SketchPolicy(SearchPolicy):
     DEFAULT_PARAMS = {
         "eps_greedy": 0.05,
         "retry_search_one_round_on_empty": 10,
-        "sample_init_population": 50,
+        "sample_init_min_population": 50,
         "sample_init_use_measured_ratio": 0.2,
         "evolutionary_search_population": 2048,
         "evolutionary_search_num_iters": 10,
@@ -210,22 +210,17 @@ class SketchPolicy(SearchPolicy):
                 print(s)
         return sketches
 
-    def sample_initial_population(self, pop_size):
+    def sample_initial_population(self):
         """Sample initial population.
         This python interface is mainly used for debugging and testing.
         The actual search is all done in c++.
-
-        Parameters
-        ----------
-        pop_size : int
-            The size of sampled population
 
         Returns
         -------
         states: List[State]
             The sampled states
         """
-        states = _ffi_api.SketchPolicySampleInitialPopulation(self, pop_size)
+        states = _ffi_api.SketchPolicySampleInitialPopulation(self)
         return states
 
     def evolutionary_search(self, init_populations, out_size):

--- a/python/tvm/auto_scheduler/utils.py
+++ b/python/tvm/auto_scheduler/utils.py
@@ -30,7 +30,7 @@ import numpy as np
 try:
     import psutil
 except ImportError:
-    raise ImportError("psutil not found, try `pip install psutil` to fix this")
+    psutil = None
 
 from tvm import rpc
 from tvm.tir import expr
@@ -131,6 +131,9 @@ def deserialize_args(args):
 
 def kill_child_processes(parent_pid, sig=signal.SIGTERM):
     """kill all child processes recursively"""
+    if not psutil:
+        raise ImportError("psutil not found, try `pip install psutil` to fix this")
+
     try:
         parent = psutil.Process(parent_pid)
     except psutil.NoSuchProcess:

--- a/python/tvm/auto_scheduler/workload_registry.py
+++ b/python/tvm/auto_scheduler/workload_registry.py
@@ -212,15 +212,13 @@ def serialize_workload_registry_entry(workload_key):
     return name, value
 
 
-def deserialize_workload_registry_entry(workload_key, data):
+def deserialize_workload_registry_entry(data):
     """
     Deserialize a workload registry entry.
     This should be used along with :code:`serialize_workload_registry_entry`
 
     Parameters
     ----------
-    workload_key : str
-        The workload key
     data: Tuple
         The return value of :code:`serialize_workload_registry_entry`
     """

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -18,10 +18,10 @@
 """The base node types for the Relay language."""
 import tvm._ffi
 import tvm.ir
+from tvm.auto_scheduler.relay_integration import auto_schedule_topi, auto_schedule_impl_suffix
 from tvm.driver import lower, build
-
-from ...target import get_native_generic_func, GenericFunc
-from ...runtime import Object
+from tvm.target import get_native_generic_func, GenericFunc
+from tvm.runtime import Object
 from . import _make
 
 
@@ -143,6 +143,30 @@ class OpStrategy(Object):
             The priority level of implementation.
         """
         _OpStrategyAddImplementation(self, compute, schedule, name, plevel)
+
+    def add_auto_scheduler(self, compute, name, plevel=10):
+        """Add an implementation using the auto-scheduler.
+
+        Parameters
+        ----------
+        compute : function (attrs: Attrs, inputs: List[Tensor], out_type: Type)
+                           -> List[Tensor]
+            The compute function.
+
+        name : str
+            The name of implementation.
+
+        plevel : int
+            The priority level of implementation.
+        """
+
+        def wrap_schedule(attrs, outs, target):
+            with target:
+                return auto_schedule_topi(outs)
+
+        self.add_implementation(
+            compute, wrap_schedule, name=name + auto_schedule_impl_suffix, plevel=plevel
+        )
 
 
 def _wrap_default_fstrategy(compute, schedule, name):

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -20,9 +20,9 @@ from tvm import topi
 import tvm
 from tvm.te import SpecializedCondition
 from tvm.contrib import nvcc
+from tvm._ffi import get_global_func
 from .generic import *
 from .. import op as _op
-from .... import get_global_func
 
 
 @schedule_injective.register(["cuda", "gpu"])
@@ -160,6 +160,11 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                 wrap_topi_schedule(topi.cuda.schedule_conv2d_nhwc),
                 name="conv2d_nhwc.cuda",
             )
+
+            strategy.add_auto_scheduler(
+                wrap_compute_conv2d(topi.nn.conv2d_nhwc), name="conv2d_nhwc"
+            )
+
             N, H, W, _ = get_const_tuple(data.shape)
             KH, KW, CI, CO = get_const_tuple(kernel.shape)
             # Winograd shape related judgment
@@ -575,6 +580,12 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
             wrap_topi_schedule(topi.cuda.schedule_dense_small_batch),
             name="dense_small_batch.cuda",
         )
+
+        strategy.add_auto_scheduler(
+            wrap_compute_dense(topi.nn.dense),
+            name="dense",
+        )
+
         with SpecializedCondition(b >= 32):
             strategy.add_implementation(
                 wrap_compute_dense(topi.cuda.dense_large_batch),

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -21,8 +21,8 @@ import logging
 import re
 from tvm import topi
 from tvm.topi.utils import get_const_int, get_const_float, get_const_tuple, get_float_tuple
+from tvm.target import generic_func, override_native_generic_func
 from .. import op as _op
-from ....target import generic_func, override_native_generic_func
 
 logger = logging.getLogger("strategy")
 

--- a/src/auto_scheduler/search_policy/sketch_policy.h
+++ b/src/auto_scheduler/search_policy/sketch_policy.h
@@ -57,8 +57,8 @@ struct SketchParamKey {
   static constexpr const char* empty_retry_count = "retry_search_one_round_on_empty";
 
   struct SampleInitPopulation {
-    /*! \brief The population size of initial sampling. */
-    static constexpr const char* population = "sample_init_population";
+    /*! \brief The minimal size of valid population in the initial sampling. */
+    static constexpr const char* min_population = "sample_init_min_population";
     /*! \brief The maximum percentage of measured states in the initial sampling. */
     static constexpr const char* use_measured_ratio = "sample_init_use_measured_ratio";
   };
@@ -124,10 +124,9 @@ class SketchPolicyNode : public SearchPolicyNode {
   /*!
    * \brief Sample the init population.
    * \param sketches The initial sketches for the sampled population
-   * \param out_size The number of output states.
    * \return The generated states (the initial population).
    */
-  Array<State> SampleInitPopulation(const Array<State>& sketches, int out_size);
+  Array<State> SampleInitPopulation(const Array<State>& sketches);
 
   /*!
    * \brief Perform evolutionary search.

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test task extraction for auto-scheduler"""
+import tvm.relay.testing
+import tvm.testing
+from tvm import auto_scheduler, relay
+
+
+def get_network(name, batch_size=1, layout="NHWC"):
+    """Get the symbol definition and random weight of a network"""
+
+    # auto-scheduler prefer NHWC layout
+    if layout == "NHWC":
+        image_shape = (224, 224, 3)
+    elif layout == "NCHW":
+        image_shape = (3, 224, 224)
+    else:
+        raise ValueError("Invalid layout: " + layout)
+
+    if name == "resnet-18":
+        mod, params = relay.testing.resnet.get_workload(
+            num_layers=18, batch_size=batch_size, layout=layout, image_shape=image_shape
+        )
+    elif name == "resnet-50":
+        mod, params = relay.testing.resnet.get_workload(
+            num_layers=50, batch_size=batch_size, layout=layout, image_shape=image_shape
+        )
+    elif name == "resnet3d-18":
+        mod, params = relay.testing.resnet_3d.get_workload(
+            num_layers=18, batch_size=batch_size, layout=layout, image_shape=image_shape
+        )
+    elif name == "mobilenet":
+        mod, params = relay.testing.mobilenet.get_workload(
+            batch_size=batch_size, layout=layout, image_shape=image_shape
+        )
+    elif name == "dcgan":
+        mod, params = relay.testing.dcgan.get_workload(batch_size=batch_size, layout=layout)
+    elif name == "mlp":
+        data = relay.var("data", shape=(batch_size, 128))
+        fc1 = relay.nn.dense(data, relay.var("fc1_weight"), units=128)
+        fc1 = relay.nn.bias_add(fc1, relay.var("fc1_bias"), axis=-1)
+        act1 = relay.nn.relu(fc1)
+        fc2 = relay.nn.dense(act1, relay.var("fc2_weight"), units=128)
+        fc2 = relay.nn.bias_add(fc2, relay.var("fc2_bias"), axis=-1)
+        act2 = relay.nn.relu(fc2)
+        mlp = act2
+        args = relay.analysis.free_vars(act2)
+        mlp = relay.Function(args, mlp)
+        mod, params = relay.testing.init.create_workload(mlp)
+    else:
+        raise ValueError("Unsupported network: " + name)
+
+    return mod, params
+
+
+@tvm.testing.requires_cuda
+def test_task_extraction_cuda():
+    auto_scheduler.enable_relay_integration()
+
+    mod, params = get_network("mlp")
+    target = tvm.target.Target("cuda")
+    tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
+
+    assert len(tasks) == 1
+    assert sum(task_weights) == 2
+
+    mod, params = get_network("resnet-18")
+    target = tvm.target.Target("cuda")
+    tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
+
+    assert len(tasks) == 21
+    assert sum(task_weights) == 22
+
+
+if __name__ == "__main__":
+    test_task_extraction_cuda()

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -50,11 +50,11 @@ def get_network(name, batch_size=1, layout="NHWC"):
     elif name == "dcgan":
         mod, params = relay.testing.dcgan.get_workload(batch_size=batch_size, layout=layout)
     elif name == "mlp":
-        data = relay.var("data", shape=(batch_size, 128))
-        fc1 = relay.nn.dense(data, relay.var("fc1_weight"), units=128)
+        data = relay.var("data", shape=(batch_size, 32))
+        fc1 = relay.nn.dense(data, relay.var("fc1_weight"), units=32)
         fc1 = relay.nn.bias_add(fc1, relay.var("fc1_bias"), axis=-1)
         act1 = relay.nn.relu(fc1)
-        fc2 = relay.nn.dense(act1, relay.var("fc2_weight"), units=128)
+        fc2 = relay.nn.dense(act1, relay.var("fc2_weight"), units=32)
         fc2 = relay.nn.bias_add(fc2, relay.var("fc2_bias"), axis=-1)
         act2 = relay.nn.relu(fc2)
         mlp = act2

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -52,6 +52,8 @@ def test_tuning_cuda():
             with tvm.transform.PassContext(opt_level=3):
                 lib = relay.build(mod, target=target, params=params)
 
+    auto_scheduler.enable_relay_integration(False)
+
 
 if __name__ == "__main__":
     test_tuning_cuda()

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -37,7 +37,7 @@ def test_tuning_cuda():
         log_file = fp.name
 
         # Tuning
-        measure_ctx = auto_scheduler.LocalRPCMeasureContext()
+        measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=100)
         tuner = auto_scheduler.TaskScheduler(tasks, objective)
         tune_option = auto_scheduler.TuningOptions(
             num_measure_trials=2,

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test end-to-end network tuning with auto-scheduler"""
+import tempfile
+
+import tvm.testing
+from tvm import auto_scheduler, relay
+
+from test_auto_scheduler_task_extraction import get_network
+
+
+@tvm.testing.requires_cuda
+def test_tuning_cuda():
+    auto_scheduler.enable_relay_integration()
+
+    mod, params = get_network("mlp")
+    target = tvm.target.Target("cuda")
+    tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
+
+    objective = lambda costs: sum(c * w for c, w in zip(costs, task_weights))
+
+    with tempfile.NamedTemporaryFile() as fp:
+        log_file = fp.name
+
+        measure_ctx = auto_scheduler.LocalRPCMeasureContext()
+
+        tuner = auto_scheduler.TaskScheduler(tasks, objective)
+        tune_option = auto_scheduler.TuningOptions(
+            num_measure_trials=2,
+            num_measures_per_round=1,
+            runner=measure_ctx.runner,
+            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
+        )
+
+        tuner.tune(tune_option, search_policy="sketch.random")
+
+        with auto_scheduler.ApplyHistoryBest(log_file):
+            with tvm.transform.PassContext(opt_level=3):
+                lib = relay.build(mod, target=target, params=params)
+
+
+if __name__ == "__main__":
+    test_tuning_cuda()

--- a/tests/python/unittest/test_auto_scheduler_cost_model.py
+++ b/tests/python/unittest/test_auto_scheduler_cost_model.py
@@ -32,7 +32,7 @@ def get_sample_records(number):
     N = 128
     task = auto_scheduler.create_task(matmul_auto_scheduler_test, (N, N, N), "llvm")
     policy = auto_scheduler.SketchPolicy(task, verbose=0)
-    states = policy.sample_initial_population(number)
+    states = policy.sample_initial_population()[:number]
 
     inputs = [auto_scheduler.MeasureInput(task, s) for s in states]
     results = [

--- a/tests/python/unittest/test_auto_scheduler_evolutionary_search.py
+++ b/tests/python/unittest/test_auto_scheduler_evolutionary_search.py
@@ -52,7 +52,7 @@ def test_mutate_tile_size():
     dag = auto_scheduler.ComputeDAG(workload_key)
     task = auto_scheduler.SearchTask(dag, workload_key, tvm.target.Target("llvm"))
     policy = auto_scheduler.SketchPolicy(task, program_cost_model=MockCostModel(), verbose=0)
-    states = policy.sample_initial_population(50)
+    states = policy.sample_initial_population()[:50]
 
     bad_states = []
     for state in states:
@@ -98,7 +98,7 @@ def test_mutate_parallel():
     found = False
     retry_ct = 0
     while retry_ct < 10 and not found:
-        states = policy.sample_initial_population(100)
+        states = policy.sample_initial_population()[:100]
         bad_states = []
         for state in states:
             if not MockCostModel.is_good_state(state):


### PR DESCRIPTION
This pr implements the basic relay integration for auto-scheduler.

## Approach
1. register auto-scheduler as an implementation in the OpStrategy. We have a universal schedule function for all topi compute functions.
2. Use tracing to extract all tasks similar to autotvm.

If auto-scheduler is enabled by `auto_scheduler.enable_relay_integration`, then auto-scheduler is always preferred to any other registered implementations.

## Limitation
Ideally, we should be able to mix autotvm, auto-scheduler, and static libraries,  then we can select the best implementation according to profiling records.
However, this is not trivial to implement, because auto-scheduler works on a subgraph level while the current OpStrategy is designed for single operator level.
The limitation of OpStrategy also makes auto-scheduler unable to support multiple compute declarations. For example, auto-scheduler cannot select direct vs. winograd based on profiling records, while autotvm can easily do this.

## Minor todo
- [x] Add an API to disable the cache in relay compilation, so we can extract the weights (i.e., the number of appearances) of each task for the task-scheduler.
- [x] Clean up `dispather.py`