### PR TITLE
[LLVM] use ElementCount constructor in latest llvm

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -475,7 +475,10 @@ llvm::Value* CodeGenLLVM::CreateBroadcast(llvm::Value* value, int lanes) {
   llvm::Constant* undef = llvm::UndefValue::get(type);
   llvm::Constant* zero = ConstInt32(0);
   value = builder_->CreateInsertElement(undef, value, zero);
-#if TVM_LLVM_VERSION >= 110
+#if TVM_LLVM_VERSION >= 120
+  llvm::Constant* mask = llvm::ConstantVector::getSplat(
+      llvm::ElementCount(llvm::PolySize<unsigned>::getFixed(static_cast<unsigned>(lanes))), zero);
+#elif TVM_LLVM_VERSION >= 110
   llvm::Constant* mask =
       llvm::ConstantVector::getSplat(llvm::ElementCount(lanes, /*Scalable=*/false), zero);
 #else


### PR DESCRIPTION
The latest LLVM 12.0 has changed the ElementCount constructor. TVM cannot build with [this latest change](https://github.com/llvm/llvm-project/commit/c5ba0d33cc060cc06a28a5d9101060afd1c0ee9a).

cc @kparzysz-quic @ajtulloch 