### PR TITLE
Add pytest-xdist and pytest-profiling to the base installation packages.

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -21,4 +21,4 @@ set -u
 set -o pipefail
 
 # install libraries for python package on ubuntu
-pip3 install six numpy pytest cython decorator scipy tornado typed_ast pytest mypy orderedset attrs requests Pillow packaging cloudpickle
+pip3 install six numpy pytest cython decorator scipy tornado typed_ast pytest pytest-xdist pytest-profiling mypy orderedset attrs requests Pillow packaging cloudpickle


### PR DESCRIPTION
For building and testing and parallelizing some small portions 
of the python testsuite which are multicore safe and parallelizable
I've been playing off and on with xdist and pytest-profiling.

We know it's not safe for the entirity of CI yet but this could
enable smaller parts of pipelines that folks use using the
common scripts to be parallelized or indeed profiled for more
insight into where time is spent in building and testing TVM
and while I'm not currently proposing the jenkins flow to
parallelize more, having these in the base docker images will 
allow for more experimentation and thought.

if folks would like to try it with existing scripts the environment
variable CI_PYTEST_ADD_OPTIONS will help in this regard. 

So to use pytest-xdist one could provide 

CI_PYTEST_ADD_OPTIONS="-n 4" to run 4 instances using pytest-xdist
or 
CI_PYTEST_ADD_OPTIONS="--profiling --profiling-svg" to get profiling information for their build and test runs. 

Alternatively if they were using pytest on the command line they could do so with the same options on their command line. 


@tqchen @tmoreau89 - thoughts ? 
