### PR TITLE
[Torch] Support bincount and scatter_add ops

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2376,6 +2376,17 @@ def _bincount():
     return _impl
 
 
+def _scatter_add():
+    def _impl(inputs, input_types):
+        data = inputs[0]
+        axis = inputs[1]
+        index = inputs[2]
+        src = inputs[3]
+        return _op.scatter_add(data, index, src, axis=axis)
+
+    return _impl
+
+
 def _pytorch_result_type(dtypes, non_tensor_inputs):
     """This promotes TVM dtypes like PyTorch would"""
     import torch
@@ -2719,6 +2730,7 @@ def _get_convert_map(prelude, default_dtype):
         "aten::numel": _numel(),
         "aten::empty": _empty(),
         "aten::bincount": _bincount(),
+        "aten::scatter_add": _scatter_add(),
     }
     return convert_map
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2364,7 +2364,8 @@ def _bincount():
         maximum = _op.max(data)
         dim = maximum + _expr.const(1, dtype="int64")
         if weights:
-            out_dtype = "float32"
+            weight_type = _infer_type(weights).checked_type
+            out_dtype = weight_type.dtype
             updates = weights
         else:
             out_dtype = "int64"

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3362,7 +3362,6 @@ def from_pytorch(script_module, input_infos, custom_convert_map=None, default_dt
 
     graph = script_module.graph.copy()
     _run_jit_passes(graph)
-    print(graph)
 
     if custom_convert_map:
         convert_map.update(custom_convert_map)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3376,10 +3376,6 @@ def test_bincount():
     verify_trace_model(Bincount(weights), [inp], ["llvm"])
 
 
-def test_scatter_add():
-    pass
-
-
 if __name__ == "__main__":
     # some structural tests
     test_forward_traced_function()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3147,11 +3147,20 @@ def test_forward_scatter():
         def forward(self, data, index, src):
             return torch.scatter(data, dim=self.dim, index=index, src=src)
 
+    class ScatterAdd(Module):
+        def __init__(self, dim=0):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, data, index, src):
+            return torch.scatter_add(data, dim=self.dim, index=index, src=src)
+
     in_data = torch.zeros(3, 5)
     in_index = torch.tensor([[0, 1, 2, 0, 0], [2, 0, 0, 1, 2]])
     in_src = torch.rand(2, 5)
     # TODO: add scatter gpu schedule to enable gpu test.
     verify_trace_model(Scatter(), [in_data, in_index, in_src], ["llvm"])
+    verify_trace_model(ScatterAdd(), [in_data, in_index, in_src], ["llvm"])
 
     in_data = torch.zeros(2, 4)
     in_index = torch.tensor([[2], [3]])
@@ -3159,6 +3168,7 @@ def test_forward_scatter():
 
     # TODO: add scatter gpu schedule to enable gpu test.
     verify_trace_model(Scatter(1), [in_data, in_index, in_src], ["llvm"])
+    verify_trace_model(ScatterAdd(1), [in_data, in_index, in_src], ["llvm"])
 
 
 def test_numel():

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3350,6 +3350,26 @@ def test_convert_torch_script_with_input_types():
     assert tvm.ir.structural_equal(expected_mod, mod["main"], map_free_vars=True)
 
 
+def test_bincount():
+    class Bincount(torch.nn.Module):
+        def __init__(self, weights=None):
+            super().__init__()
+            self.weights = weights
+
+        def forward(self, x):
+            return torch.bincount(x, weights=self.weights)
+
+    inp = torch.randint(0, 8, (5,), dtype=torch.int64)
+    weights = torch.linspace(0, 1, steps=5)
+
+    verify_trace_model(Bincount(), [inp], ["llvm"])
+    verify_trace_model(Bincount(weights), [inp], ["llvm"])
+
+
+def test_scatter_add():
+    pass
+
+
 if __name__ == "__main__":
     # some structural tests
     test_forward_traced_function()
@@ -3476,6 +3496,7 @@ if __name__ == "__main__":
     test_forward_nonzero()
     test_forward_scatter()
     test_numel()
+    test_bincount()
 
     # Model tests
     test_resnet18()


### PR DESCRIPTION
Add numpy style `bincount` op converter by combinations of existing ops. 
https://pytorch.org/docs/stable/generated/torch.bincount.html

This is a part of supporting hummingbird project. Also add a `scatter_add` op conversion, as requested.

I hope performance would not be too bad, so that we don't have to implement a native `bincount` op.

please review @siju-samuel @t-vi 
cc @interesaaat