### PR TITLE
[FIX,MICROTVM] Add requires_micro decorators to microtvm tests

### DIFF
--- a/tests/python/unittest/test_micro_artifact.py
+++ b/tests/python/unittest/test_micro_artifact.py
@@ -20,9 +20,9 @@
 import json
 import os
 import shutil
+import tvm
 
 from tvm.contrib import util
-from tvm.micro import artifact
 
 
 FILE_LIST = ["label1", "label2", "label12", "unlabelled"]
@@ -49,11 +49,13 @@ def build_artifact(artifact_path, immobile=False):
         os.path.join(artifact_path, "sub_dir"), os.path.join(artifact_path, "abs_dir_symlink")
     )
 
+    from tvm.micro import artifact
     art = artifact.Artifact(artifact_path, TEST_LABELS, TEST_METADATA, immobile=immobile)
 
     return art
 
 
+@tvm.testing.requires_micro
 def test_basic_functionality():
     temp_dir = util.tempdir()
     artifact_path = temp_dir.relpath("foo")
@@ -66,6 +68,7 @@ def test_basic_functionality():
         assert art.label_abspath(label) == [os.path.join(artifact_path, p) for p in paths]
 
 
+@tvm.testing.requires_micro
 def test_archive():
     temp_dir = util.tempdir()
     art = build_artifact(temp_dir.relpath("foo"))
@@ -100,6 +103,7 @@ def test_archive():
         assert os.path.exists(os.path.join(unarchive_base_dir, f))
 
 
+@tvm.testing.requires_micro
 def test_metadata_only():
     temp_dir = util.tempdir()
     base_dir = temp_dir.relpath("foo")

--- a/tests/python/unittest/test_micro_artifact.py
+++ b/tests/python/unittest/test_micro_artifact.py
@@ -50,6 +50,7 @@ def build_artifact(artifact_path, immobile=False):
     )
 
     from tvm.micro import artifact
+
     art = artifact.Artifact(artifact_path, TEST_LABELS, TEST_METADATA, immobile=immobile)
 
     return art

--- a/tests/python/unittest/test_micro_artifact.py
+++ b/tests/python/unittest/test_micro_artifact.py
@@ -71,6 +71,8 @@ def test_basic_functionality():
 
 @tvm.testing.requires_micro
 def test_archive():
+    from tvm.micro import artifact
+
     temp_dir = util.tempdir()
     art = build_artifact(temp_dir.relpath("foo"))
 
@@ -106,6 +108,8 @@ def test_archive():
 
 @tvm.testing.requires_micro
 def test_metadata_only():
+    from tvm.micro import artifact
+
     temp_dir = util.tempdir()
     base_dir = temp_dir.relpath("foo")
     art = build_artifact(base_dir)


### PR DESCRIPTION
The micro tvm tests were missing the appropriate decorator.

@areusch 