### PR TITLE
[BUGFIX] Fix topi matrix multiplication using tensorcore to run faster

### DIFF
--- a/python/tvm/topi/cuda/dense_tensorcore.py
+++ b/python/tvm/topi/cuda/dense_tensorcore.py
@@ -199,6 +199,8 @@ def _schedule_dense_tensorcore(cfg, s, C):
     bb, bbii = s[CS].split(bb, factor=warp_row_tiles)
     oo, ooii = s[CS].split(oo, factor=warp_col_tiles)
     s[CS].reorder(bb, oo, bbii, ooii, bbi, ooi)
+    s[CS].bind(bb, thread_y)
+    s[CS].bind(oo, thread_z)
 
     # Schedule for wmma computation
     s[CF].compute_at(s[CS], oo)


### PR DESCRIPTION
This PR adds two "bind"s to the tensorcore matrix multiplication support in TOPI. The original code does not make full use of all warps in a thread block and therefore runs slowly. Adding these two "bind"s can make it run much faster.

cc @tqchen @Hzfengsy 