### PR TITLE
[CI] Introduce all platform test for windows/mac/linux.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,53 +34,55 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [windows-latest, macOS-latest]
+        os: [windows-2016, macOS-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - name: Lint Python
-      if: matrix.os == 'macOS-latest'
-      run: |
-        pip install flake8
-        flake8 . --count --select=E9,F63,F7 --show-source --statistics
     - name: Initialize submodules
       run: git submodule update --recursive --init
-
-    - name: Make Build Directory
-      run: cmake -E make_directory build.common
-
-    # configuration for Windows
-    - name: CMake@Win
-      if: matrix.os == 'windows-latest'
-      working-directory: build.common
+    - name: Lint Python
+      if: startsWith(matrix.os, 'macOS')
+      run: |
+        python3 -m pip install flake8
+        python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics
+    - uses: actions/cache@v1
+      env:
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/build-environment.yaml') }}
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        activate-environment: tvm-build
+        channel-priority: strict
+        environment-file: conda/build-environment.yaml
+        auto-activate-base: false
+        use-only-tar-bz2: true
+    - name: Conda info
+      run: |
+        conda info
+        conda list
+    - name: Conda-Build@Win
+      if: startsWith(matrix.os, 'windows')
+      shell: cmd /C call {0}
       run: >-
-        cmake
-        -DUSE_SORT=ON
-        -DUSE_RPC=ON
-        -DUSE_GRAPH_RUNTIME=ON
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_CONFIGURATION_TYPES="Release"
-        ..
-
-    # configuration for Mac
-    - name: CMake@MacOS
-      if: matrix.os  == 'macOS-latest'
-      working-directory: build.common
+        conda build --output-folder=conda/pkg conda/recipe &&
+        conda install tvm -c ./conda/pkg
+    - name: Conda-Build@MacOS
+      if: startsWith(matrix.os, 'macOS')
+      shell: bash -l {0}
       run: >-
-        cmake
-        "-DUSE_SORT=ON"
-        "-DUSE_RPC=ON"
-        "-DUSE_GRAPH_RUNTIME=ON"
-        "-DUSE_METAL=ON"
-        ..
-
-    - name: Build@Win
-      if: matrix.os == 'windows-latest'
-      run: cmake --build build.common --config Release -- /m
-
-    - name: Build@MacOS
-      if: matrix.os == 'macOS-latest'
-      run: cmake --build build.common --config Release -j3
+        conda build --output-folder=conda/pkg  conda/recipe &&
+        conda install tvm -c ./conda/pkg
+    - name: Test@Win
+      if: startsWith(matrix.os, 'windows')
+      shell: cmd /C call {0}
+      run: >-
+        python -m pytest -v tests/python/all-platform-minimal-test
+    - name: Test@MacOS
+      if: startsWith(matrix.os, 'macOS')
+      shell: bash -l {0}
+      run: >-
+        python -m pytest -v tests/python/all-platform-minimal-test

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,16 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+# Build environment.
+name: tvm-build
 
-source tests/scripts/setup-pytest-env.sh
+channels:
+  - anaconda
+  - conda-forge
 
-# cleanup pycache
-find . -type f -path "*.pyc" | xargs rm -f
-make cython3
-
-TVM_FFI=ctypes python3 -m pytest tests/python/all-platform-minimal-test
-TVM_FFI=cython python3 -m pytest tests/python/all-platform-minimal-test
-TVM_FFI=ctypes python3 -m pytest tests/python/unittest
-TVM_FFI=cython python3 -m pytest tests/python/unittest
+dependencies:
+  - conda-build
+  - git
+  - llvmdev ==10.0.0
+  - numpy
+  - pytest
+  - cython
+  - cmake
+  - bzip2
+  - make
+  - scipy

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -71,14 +71,20 @@ outputs:
     script: install_tvm_python.sh  # [not win]
     script: install_tvm_python.bat # [win]
     string: {{ build_tag }}_py{{ PY_VER | replace('.', '')}}
+    # skip bytecompile pyc to speedup CI speed
+    skip_compile_pyc:
+      - "*/**/*.py"
     requirements:
       host:
         - python
         - setuptools
+        - cython
+        - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
       run:
         - python
         - decorator
         - psutil
+        - scipy
         - {{ pin_compatible('numpy') }}
         - {{ pin_subpackage(pkg_name + '-libs', exact=True) }}
 

--- a/python/tvm/_ffi/registry.py
+++ b/python/tvm/_ffi/registry.py
@@ -29,8 +29,10 @@ try:
     from ._cy3.core import _register_object
     from ._cy3.core import _reg_extension
     from ._cy3.core import convert_to_tvm_func, _get_global_func, PackedFuncBase
-except (RuntimeError, ImportError):
+except (RuntimeError, ImportError) as error:
     # pylint: disable=wrong-import-position,unused-import
+    if _FFI_MODE == "cython":
+        raise error
     from ._ctypes.object import _register_object
     from ._ctypes.ndarray import _reg_extension
     from ._ctypes.packed_func import convert_to_tvm_func, _get_global_func, PackedFuncBase

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -30,8 +30,10 @@ try:
         raise ImportError()
     from tvm._ffi._cy3.core import _set_class_ndarray, _make_array, _from_dlpack
     from tvm._ffi._cy3.core import NDArrayBase
-except (RuntimeError, ImportError):
+except (RuntimeError, ImportError) as error:
     # pylint: disable=wrong-import-position
+    if _FFI_MODE == "cython":
+        raise error
     from tvm._ffi._ctypes.ndarray import _set_class_ndarray, _make_array, _from_dlpack
     from tvm._ffi._ctypes.ndarray import NDArrayBase
 

--- a/python/tvm/runtime/object.py
+++ b/python/tvm/runtime/object.py
@@ -28,8 +28,10 @@ try:
         raise ImportError()
     from tvm._ffi._cy3.core import _set_class_object, _set_class_object_generic
     from tvm._ffi._cy3.core import ObjectBase, PyNativeObject
-except (RuntimeError, ImportError):
+except (RuntimeError, ImportError) as error:
     # pylint: disable=wrong-import-position,unused-import
+    if _FFI_MODE == "cython":
+        raise error
     from tvm._ffi._ctypes.packed_func import _set_class_object, _set_class_object_generic
     from tvm._ffi._ctypes.object import ObjectBase, PyNativeObject
 

--- a/python/tvm/runtime/packed_func.py
+++ b/python/tvm/runtime/packed_func.py
@@ -27,8 +27,10 @@ try:
     from tvm._ffi._cy3.core import _set_class_packed_func, _set_class_module
     from tvm._ffi._cy3.core import PackedFuncBase
     from tvm._ffi._cy3.core import convert_to_tvm_func
-except (RuntimeError, ImportError):
+except (RuntimeError, ImportError) as error:
     # pylint: disable=wrong-import-position
+    if _FFI_MODE == "cython":
+        raise error
     from tvm._ffi._ctypes.packed_func import _set_class_packed_func, _set_class_module
     from tvm._ffi._ctypes.packed_func import PackedFuncBase
     from tvm._ffi._ctypes.packed_func import convert_to_tvm_func

--- a/tests/python/all-platform-minimal-test/README.md
+++ b/tests/python/all-platform-minimal-test/README.md
@@ -1,0 +1,29 @@
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
+# Core Cross Platform Regression Tests
+
+CI Unit test cases that will run on all platforms.
+To reduce the CI burden, we only put in test-cases that are platform sensitive.
+Please use the following guideline:
+
+- Always consider add tests to the unittest folder first.
+- If a problems that passes the Linux pipeline but fails in Windows or MacOS,
+  we should isolate the problem, write a minimal regression test case
+  and add it to this folder.
+- A test case in this folder should be minimal and finish in a reasonable amount of time.
+- Document about why it should be in the all-platform-minimal-test.

--- a/tests/python/all-platform-minimal-test/test_minimal_target_codegen_llvm.py
+++ b/tests/python/all-platform-minimal-test/test_minimal_target_codegen_llvm.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""LLVM enablement tests."""
+
+import tvm
+import tvm.testing
+from tvm import te
+from tvm import topi
+from tvm.contrib import util, clang
+import numpy as np
+import ctypes
+import math
+import re
+
+
+@tvm.testing.requires_llvm
+def test_llvm_add_pipeline():
+    """all-platform-minimal-test: Check LLVM enablement."""
+    nn = 1024
+    n = tvm.runtime.convert(nn)
+    A = te.placeholder((n,), name="A")
+    B = te.placeholder((n,), name="B")
+    AA = te.compute((n,), lambda *i: A(*i), name="A")
+    BB = te.compute((n,), lambda *i: B(*i), name="B")
+    T = te.compute(A.shape, lambda *i: AA(*i) + BB(*i), name="T")
+    C = te.compute(A.shape, lambda *i: T(*i), name="C")
+    s = te.create_schedule(C.op)
+    xo, xi = s[C].split(C.op.axis[0], factor=4)
+    xo1, xo2 = s[C].split(xo, factor=13)
+    s[C].parallel(xo2)
+    s[C].pragma(xo1, "parallel_launch_point")
+    s[C].pragma(xo2, "parallel_stride_pattern")
+    s[C].pragma(xo2, "parallel_barrier_when_finish")
+    s[C].vectorize(xi)
+
+    def check_llvm():
+        # Specifically allow offset to test codepath when offset is available
+        Ab = tvm.tir.decl_buffer(
+            A.shape, A.dtype, elem_offset=te.size_var("Aoffset"), offset_factor=8, name="A"
+        )
+        binds = {A: Ab}
+        # BUILD and invoke the kernel.
+        f = tvm.build(s, [A, B, C], "llvm", binds=binds)
+        ctx = tvm.cpu(0)
+        # launch the kernel.
+        n = nn
+        a = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.random.uniform(size=n).astype(B.dtype), ctx)
+        c = tvm.nd.array(np.zeros(n, dtype=C.dtype), ctx)
+        f(a, b, c)
+        tvm.testing.assert_allclose(c.asnumpy(), a.asnumpy() + b.asnumpy())
+
+    check_llvm()
+
+
+@tvm.testing.requires_llvm
+def test_llvm_import():
+    """all-platform-minimal-test: check shell dependent clang behavior."""
+    # extern "C" is necessary to get the correct signature
+    cc_code = """
+    extern "C" float my_add(float x, float y) {
+      return x + y;
+    }
+    """
+    n = 10
+    A = te.placeholder((n,), name="A")
+    B = te.compute(
+        (n,), lambda *i: tvm.tir.call_pure_extern("float32", "my_add", A(*i), 1.0), name="B"
+    )
+
+    def check_llvm(use_file):
+        if not clang.find_clang(required=False):
+            print("skip because clang is not available")
+            return
+        temp = util.tempdir()
+        ll_path = temp.relpath("temp.ll")
+        ll_code = clang.create_llvm(cc_code, output=ll_path)
+        s = te.create_schedule(B.op)
+        if use_file:
+            s[B].pragma(s[B].op.axis[0], "import_llvm", ll_path)
+        else:
+            s[B].pragma(s[B].op.axis[0], "import_llvm", ll_code)
+        # BUILD and invoke the kernel.
+        f = tvm.build(s, [A, B], "llvm")
+        ctx = tvm.cpu(0)
+        # launch the kernel.
+        a = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.random.uniform(size=n).astype(B.dtype), ctx)
+        f(a, b)
+        tvm.testing.assert_allclose(b.asnumpy(), a.asnumpy() + 1.0)
+
+    check_llvm(use_file=True)
+    check_llvm(use_file=False)

--- a/tests/python/all-platform-minimal-test/test_runtime_ndarray.py
+++ b/tests/python/all-platform-minimal-test/test_runtime_ndarray.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Basic runtime enablement test."""
+
 import tvm
 from tvm import te
 import numpy as np

--- a/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
+++ b/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test packed function FFI."""
+import tvm
+from tvm import te
+import tvm.testing
+import numpy as np
+
+
+def test_get_global():
+    targs = (10, 10.0, "hello")
+    # register into global function table
+    @tvm.register_func
+    def my_packed_func(*args):
+        assert tuple(args) == targs
+        return 10
+
+    # get it out from global function table
+    f = tvm.get_global_func("my_packed_func")
+    assert isinstance(f, tvm.runtime.PackedFunc)
+    y = f(*targs)
+    assert y == 10
+
+
+def test_get_callback_with_node():
+    x = tvm.runtime.convert(10)
+
+    def test(y):
+        assert y.handle != x.handle
+        return y
+
+    f2 = tvm.runtime.convert(test)
+    # register into global function table
+    @tvm.register_func
+    def my_callback_with_node(y, f):
+        assert y == x
+        return f(y)
+
+    # get it out from global function table
+    f = tvm.get_global_func("my_callback_with_node")
+    assert isinstance(f, tvm.runtime.PackedFunc)
+    y = f(x, f2)
+    assert y.value == 10
+
+
+def test_return_func():
+    def addy(y):
+        def add(x):
+            return tvm.runtime.convert(x + y)
+
+        return add
+
+    myf = tvm.runtime.convert(addy)
+    f = myf(10)
+    assert f(11).value == 21
+
+
+def test_convert():
+    # convert a function to tvm function
+    targs = (10, 10.0, "hello", 10)
+
+    def myfunc(*args):
+        assert tuple(args) == targs
+
+    f = tvm.runtime.convert(myfunc)
+    assert isinstance(f, tvm.runtime.PackedFunc)
+
+
+def test_byte_array():
+    s = "hello"
+    a = bytearray(s, encoding="ascii")
+
+    def myfunc(ss):
+        assert ss == a
+
+    f = tvm.runtime.convert(myfunc)
+    f(a)
+
+
+def test_empty_array():
+    def myfunc(ss):
+        assert tuple(ss) == ()
+
+    x = tvm.runtime.convert(())
+    tvm.runtime.convert(myfunc)(x)
+
+
+def test_ctx():
+    def test_ctx_func(ctx):
+        assert tvm.gpu(7) == ctx
+        return tvm.cpu(0)
+
+    x = test_ctx_func(tvm.gpu(7))
+    assert x == tvm.cpu(0)
+    x = tvm.opencl(10)
+    x = tvm.testing.context_test(x, x.device_type, x.device_id)
+    assert x == tvm.opencl(10)
+
+
+def test_rvalue_ref():
+    def callback(x, expected_count):
+        assert expected_count == tvm.testing.object_use_count(x)
+        return x
+
+    f = tvm.runtime.convert(callback)
+
+    def check0():
+        x = tvm.tir.Var("x", "int32")
+        assert tvm.testing.object_use_count(x) == 1
+        f(x, 2)
+        y = f(x._move(), 1)
+        assert x.handle.value == None
+
+    def check1():
+        x = tvm.tir.Var("x", "int32")
+        assert tvm.testing.object_use_count(x) == 1
+        y = f(x, 2)
+        z = f(x._move(), 2)
+        assert x.handle.value == None
+        assert y.handle.value is not None
+
+    check0()
+    check1()
+
+
+def test_numpy_scalar():
+    maxint = (1 << 63) - 1
+    assert tvm.testing.echo(np.int64(maxint)) == maxint
+
+
+def test_ndarray_args():
+    def check(arr):
+        assert not arr.is_view
+        assert tvm.testing.object_use_count(arr) == 2
+
+    fcheck = tvm.runtime.convert(check)
+    x = tvm.nd.array([1, 2, 3])
+    fcheck(x)
+    assert tvm.testing.object_use_count(x) == 1
+
+
+if __name__ == "__main__":
+    test_ndarray_args()
+    test_numpy_scalar()
+    test_rvalue_ref()
+    test_empty_array()
+    test_get_global()
+    test_get_callback_with_node()
+    test_convert()
+    test_return_func()
+    test_byte_array()
+    test_ctx()

--- a/tests/python/unittest/test_runtime_trace.py
+++ b/tests/python/unittest/test_runtime_trace.py
@@ -16,124 +16,7 @@
 # under the License.
 import tvm
 from tvm import te
-import tvm.testing
 import numpy as np
-
-
-def test_get_global():
-    targs = (10, 10.0, "hello")
-    # register into global function table
-    @tvm.register_func
-    def my_packed_func(*args):
-        assert tuple(args) == targs
-        return 10
-
-    # get it out from global function table
-    f = tvm.get_global_func("my_packed_func")
-    assert isinstance(f, tvm.runtime.PackedFunc)
-    y = f(*targs)
-    assert y == 10
-
-
-def test_get_callback_with_node():
-    x = tvm.runtime.convert(10)
-
-    def test(y):
-        assert y.handle != x.handle
-        return y
-
-    f2 = tvm.runtime.convert(test)
-    # register into global function table
-    @tvm.register_func
-    def my_callback_with_node(y, f):
-        assert y == x
-        return f(y)
-
-    # get it out from global function table
-    f = tvm.get_global_func("my_callback_with_node")
-    assert isinstance(f, tvm.runtime.PackedFunc)
-    y = f(x, f2)
-    assert y.value == 10
-
-
-def test_return_func():
-    def addy(y):
-        def add(x):
-            return tvm.runtime.convert(x + y)
-
-        return add
-
-    myf = tvm.runtime.convert(addy)
-    f = myf(10)
-    assert f(11).value == 21
-
-
-def test_convert():
-    # convert a function to tvm function
-    targs = (10, 10.0, "hello", 10)
-
-    def myfunc(*args):
-        assert tuple(args) == targs
-
-    f = tvm.runtime.convert(myfunc)
-    assert isinstance(f, tvm.runtime.PackedFunc)
-
-
-def test_byte_array():
-    s = "hello"
-    a = bytearray(s, encoding="ascii")
-
-    def myfunc(ss):
-        assert ss == a
-
-    f = tvm.runtime.convert(myfunc)
-    f(a)
-
-
-def test_empty_array():
-    def myfunc(ss):
-        assert tuple(ss) == ()
-
-    x = tvm.runtime.convert(())
-    tvm.runtime.convert(myfunc)(x)
-
-
-def test_ctx():
-    def test_ctx_func(ctx):
-        assert tvm.gpu(7) == ctx
-        return tvm.cpu(0)
-
-    x = test_ctx_func(tvm.gpu(7))
-    assert x == tvm.cpu(0)
-    x = tvm.opencl(10)
-    x = tvm.testing.context_test(x, x.device_type, x.device_id)
-    assert x == tvm.opencl(10)
-
-
-def test_rvalue_ref():
-    def callback(x, expected_count):
-        assert expected_count == tvm.testing.object_use_count(x)
-        return x
-
-    f = tvm.runtime.convert(callback)
-
-    def check0():
-        x = tvm.tir.Var("x", "int32")
-        assert tvm.testing.object_use_count(x) == 1
-        f(x, 2)
-        y = f(x._move(), 1)
-        assert x.handle.value == None
-
-    def check1():
-        x = tvm.tir.Var("x", "int32")
-        assert tvm.testing.object_use_count(x) == 1
-        y = f(x, 2)
-        z = f(x._move(), 2)
-        assert x.handle.value == None
-        assert y.handle.value is not None
-
-    check0()
-    check1()
 
 
 def test_trace_default_action():
@@ -328,33 +211,7 @@ def test_trace_can_change_traced_value_float():
         check_assign(t)
 
 
-def test_numpy_scalar():
-    maxint = (1 << 63) - 1
-    assert tvm.testing.echo(np.int64(maxint)) == maxint
-
-
-def test_ndarray_args():
-    def check(arr):
-        assert not arr.is_view
-        assert tvm.testing.object_use_count(arr) == 2
-
-    fcheck = tvm.runtime.convert(check)
-    x = tvm.nd.array([1, 2, 3])
-    fcheck(x)
-    assert tvm.testing.object_use_count(x) == 1
-
-
 if __name__ == "__main__":
-    test_ndarray_args()
-    test_numpy_scalar()
-    test_rvalue_ref()
-    test_empty_array()
-    test_get_global()
-    test_get_callback_with_node()
-    test_convert()
-    test_return_func()
-    test_byte_array()
-    test_ctx()
     test_trace_expr_assign()
     test_trace_expr_sum_generated()
     test_trace_expr_sum_custom()

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -77,45 +77,6 @@ def test_llvm_overloaded_intrin():
 
 
 @tvm.testing.requires_llvm
-def test_llvm_import():
-    # extern "C" is necessary to get the correct signature
-    cc_code = """
-    extern "C" float my_add(float x, float y) {
-      return x + y;
-    }
-    """
-    n = 10
-    A = te.placeholder((n,), name="A")
-    B = te.compute(
-        (n,), lambda *i: tvm.tir.call_pure_extern("float32", "my_add", A(*i), 1.0), name="B"
-    )
-
-    def check_llvm(use_file):
-        if not clang.find_clang(required=False):
-            print("skip because clang is not available")
-            return
-        temp = util.tempdir()
-        ll_path = temp.relpath("temp.ll")
-        ll_code = clang.create_llvm(cc_code, output=ll_path)
-        s = te.create_schedule(B.op)
-        if use_file:
-            s[B].pragma(s[B].op.axis[0], "import_llvm", ll_path)
-        else:
-            s[B].pragma(s[B].op.axis[0], "import_llvm", ll_code)
-        # BUILD and invoke the kernel.
-        f = tvm.build(s, [A, B], "llvm")
-        ctx = tvm.cpu(0)
-        # launch the kernel.
-        a = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), ctx)
-        b = tvm.nd.array(np.random.uniform(size=n).astype(B.dtype), ctx)
-        f(a, b)
-        tvm.testing.assert_allclose(b.asnumpy(), a.asnumpy() + 1.0)
-
-    check_llvm(use_file=True)
-    check_llvm(use_file=False)
-
-
-@tvm.testing.requires_llvm
 def test_llvm_lookup_intrin():
     ib = tvm.tir.ir_builder.create()
     A = ib.pointer("uint8x8", name="A")
@@ -143,45 +104,6 @@ def test_llvm_large_uintimm():
         a = tvm.nd.empty((), dtype=A.dtype, ctx=ctx)
         f(a)
         assert a.asnumpy() == value + 3
-
-    check_llvm()
-
-
-@tvm.testing.requires_llvm
-def test_llvm_add_pipeline():
-    nn = 1024
-    n = tvm.runtime.convert(nn)
-    A = te.placeholder((n,), name="A")
-    B = te.placeholder((n,), name="B")
-    AA = te.compute((n,), lambda *i: A(*i), name="A")
-    BB = te.compute((n,), lambda *i: B(*i), name="B")
-    T = te.compute(A.shape, lambda *i: AA(*i) + BB(*i), name="T")
-    C = te.compute(A.shape, lambda *i: T(*i), name="C")
-    s = te.create_schedule(C.op)
-    xo, xi = s[C].split(C.op.axis[0], factor=4)
-    xo1, xo2 = s[C].split(xo, factor=13)
-    s[C].parallel(xo2)
-    s[C].pragma(xo1, "parallel_launch_point")
-    s[C].pragma(xo2, "parallel_stride_pattern")
-    s[C].pragma(xo2, "parallel_barrier_when_finish")
-    s[C].vectorize(xi)
-
-    def check_llvm():
-        # Specifically allow offset to test codepath when offset is available
-        Ab = tvm.tir.decl_buffer(
-            A.shape, A.dtype, elem_offset=te.size_var("Aoffset"), offset_factor=8, name="A"
-        )
-        binds = {A: Ab}
-        # BUILD and invoke the kernel.
-        f = tvm.build(s, [A, B, C], "llvm", binds=binds)
-        ctx = tvm.cpu(0)
-        # launch the kernel.
-        n = nn
-        a = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), ctx)
-        b = tvm.nd.array(np.random.uniform(size=n).astype(B.dtype), ctx)
-        c = tvm.nd.array(np.zeros(n, dtype=C.dtype), ctx)
-        f(a, b, c)
-        tvm.testing.assert_allclose(c.asnumpy(), a.asnumpy() + b.asnumpy())
 
     check_llvm()
 


### PR DESCRIPTION
This PR introduces a minimal set of test cases that
are supposed to run in all platforms during CI.

The set of testcases are supposed to help on
platform dependent regression.

See tests/python/all-platform-minimal-test/README.md for guidelines.

- Enable windows mac LLVM build via conda with cython support.
- Test on all platform test cases.
- Update implementation to improve MSVC support.
