### PR TITLE
[VERSION] Enhance version.py to support git-describe.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -58,7 +58,19 @@ def get_lib_path():
     return libs, version
 
 
+def git_describe_version(original_version):
+    """Get git describe version."""
+    ver_py = os.path.join(CURRENT_DIR, "..", "version.py")
+    libver = {"__file__": ver_py}
+    exec(compile(open(ver_py, "rb").read(), ver_py, "exec"), libver, libver)
+    _, gd_version = libver["git_describe_version"]()
+    if gd_version != original_version and "--inplace" not in sys.argv:
+        print("Use git describe based version %s" % gd_version)
+    return gd_version
+
+
 LIB_LIST, __version__ = get_lib_path()
+__version__ = git_describe_version(__version__)
 
 
 def config_cython():

--- a/version.py
+++ b/version.py
@@ -27,14 +27,69 @@ List of affected files:
 """
 import os
 import re
+import argparse
+import logging
+import subprocess
 
 # current version
 # We use the version of the incoming release for code
 # that is under development
 __version__ = "0.8.dev0"
+# most recent tag, used for git describe validation
+__most_recent_tag__ = "v0.7.0"
+
+
+def py_str(cstr):
+    return cstr.decode("utf-8")
+
+
+def git_describe_version():
+    """Get the suffix by git describe.
+
+    Returns
+    -------
+    pub_ver: str
+        Public version.
+
+    local_ver: str
+        Local version(with additional label).
+    """
+    cmd = ["git", "describe", "--tags"]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    (out, _) = proc.communicate()
+
+    if proc.returncode != 0:
+        msg = py_str(out)
+        if msg.find("not a git repository") != -1:
+            return __version__, __version__
+        logging.warning("git describ error: %", msg)
+        return __version__, __version__
+    describe = py_str(out).strip()
+    arr_info = describe.split("-")
+
+    if not arr_info[0].endswith(__most_recent_tag__):
+        logging.warning("%s does not match most recent tag %s", describe, __most_recent_tag__)
+        return __version__, __version__
+
+    if arr_info[0].startswith("v"):
+        arr_info[0] = arr_info[0][1:]
+
+    # hit the exact tag
+    if len(arr_info) == 1:
+        return arr_info[0], arr_info[0]
+
+    if len(arr_info) != 3:
+        logging.warning("Invalid output from git describe %s", describe)
+        return __version__, __version__
+
+    dev_pos = __version__.find(".dev")
+    pub_ver = "%s.dev%s" % (__version__[:dev_pos], arr_info[1])
+    local_ver = "%s+%s" % (pub_ver, arr_info[2])
+    return pub_ver, local_ver
+
 
 # Implementations
-def update(file_name, pattern, repl):
+def update(file_name, pattern, repl, dry_run=False):
     update = []
     hit_counter = 0
     need_update = False
@@ -46,7 +101,7 @@ def update(file_name, pattern, repl):
             if result[0] != repl:
                 l = re.sub(pattern, repl, l)
                 need_update = True
-                print("%s: %s->%s" % (file_name, result[0], repl))
+                print("%s: %s -> %s" % (file_name, result[0], repl))
             else:
                 print("%s: version is already %s" % (file_name, repl))
 
@@ -54,33 +109,71 @@ def update(file_name, pattern, repl):
     if hit_counter != 1:
         raise RuntimeError("Cannot find version in %s" % file_name)
 
-    if need_update:
+    if need_update and not dry_run:
         with open(file_name, "w") as output_file:
             for l in update:
                 output_file.write(l)
 
 
-def main():
+def sync_version(pub_ver, local_ver, dry_run):
+    """Synchronize version."""
     proj_root = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    # python path
+
+    # python uses the PEP440: local version
     update(
         os.path.join(proj_root, "python", "tvm", "_ffi", "libinfo.py"),
-        r"(?<=__version__ = \")[.0-9a-z]+",
-        __version__,
+        r"(?<=__version__ = \")[.0-9a-z\+]+",
+        local_ver,
+        dry_run,
     )
+    # Use public version for other parts for now
+    # Note that full git hash is already available in libtvm
     # C++ header
     update(
         os.path.join(proj_root, "include", "tvm", "runtime", "c_runtime_api.h"),
-        '(?<=TVM_VERSION ")[.0-9a-z]+',
-        __version__,
+        r'(?<=TVM_VERSION ")[.0-9a-z\+]+',
+        pub_ver,
+        dry_run,
     )
     # conda
-    for path in ["recipe"]:
-        update(
-            os.path.join(proj_root, "conda", path, "meta.yaml"),
-            "(?<=version = ')[.0-9a-z]+",
-            __version__,
-        )
+    update(
+        os.path.join(proj_root, "conda", "recipe", "meta.yaml"),
+        r"(?<=version = ')[.0-9a-z\+]+",
+        pub_ver,
+        dry_run,
+    )
+    # web
+    dev_pos = pub_ver.find(".dev")
+    npm_ver = pub_ver if dev_pos == -1 else "%s.0-%s" % (pub_ver[:dev_pos], pub_ver[dev_pos + 1 :])
+    update(
+        os.path.join(proj_root, "web", "package.json"),
+        r'(?<="version": ")[.0-9a-z\+]+',
+        npm_ver,
+        dry_run,
+    )
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Detect and sychnronize version.")
+    parser.add_argument(
+        "--print-version", action="store_true", help="Print version to the command line."
+    )
+    parser.add_argument(
+        "--git-describe",
+        action="store_true",
+        help="Use git describe to generate development version.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+
+    opt = parser.parse_args()
+    pub_ver, local_ver = __version__, __version__
+    if opt.git_describe:
+        pub_ver, local_ver = git_describe_version()
+    if opt.print_version:
+        print(local_ver)
+    else:
+        sync_version(pub_ver, local_ver, opt.dry_run)
 
 
 if __name__ == "__main__":

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "tvmjs",
   "displayName": "TVM Wasm JS runtime",
   "license": "Apache-2.0",
-  "version": "0.7.0",
+  "version": "0.8.0-dev0",
   "scripts": {
     "prepwasm": "make && python3 tests/python/prepare_test_libs.py",
     "build": "tsc -b && make rmtypedep",


### PR DESCRIPTION
This PR enhances version.py with a --git-descrbe option
which allows it to generate a git describe based version
tag for potential dev related nightly packaging during the
development cycle.

The behavior of the normal relase remains the same.
Note that the version.py still modifies the files inplace
and we only recommend using it during a clean clone based workflow.

The setup.py is also updated to take advantage of the version.
Note that the git info is already captured by the c++ side in a previous PR.
The tool is mainly used to create PEP compatible python wheels.

Example version number on this commit: `0.8.dev94+g0d07a329e`
- 0.8 development cycle, 94 commits since las stable tag(v07.0), the short hash of the tag is `0d07a329e`
