### PR TITLE
Add include path to Rust build script

### DIFF
--- a/rust/tvm-sys/build.rs
+++ b/rust/tvm-sys/build.rs
@@ -67,6 +67,7 @@ fn main() -> Result<()> {
     bindgen::Builder::default()
         .header(format!("{}/include/tvm/runtime/c_runtime_api.h", tvm_home))
         .header(format!("{}/include/tvm/runtime/c_backend_api.h", tvm_home))
+        .clang_arg("-I/opt/llvm/10.0.1/lib/clang/10.0.1/include/")
         .clang_arg(format!("-I{}/3rdparty/dlpack/include/", tvm_home))
         .clang_arg(format!("-I{}/include/", tvm_home))
         .blacklist_type("max_align_t")


### PR DESCRIPTION
@jroesch 

I'm not sure what we want to do here. I needed to add this path to make the build script work on my system -- perhaps there's something I should do on my side, though?