### PR TITLE
Revert "[CI] Tensorflow version support upgrade from 2.1.0 to 2.3.1"

### DIFF
--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -20,4 +20,4 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install tensorflow==2.3.1 keras==2.3.1 h5py
+pip3 install tensorflow==2.1.0 keras==2.3.1 h5py

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1334,7 +1334,7 @@ def _fused_batch_norm():
             op_name="batch_norm",
             transforms={"scale_after_normalization": "scale", "variance_epsilon": "epsilon"},
             extras={"axis": axis},
-            ignores=["data_format", "U", "exponential_avg_factor"],
+            ignores=["data_format", "U"],
             disables=["momentum"],
         )(inputs, attr)
 
@@ -1364,7 +1364,7 @@ def _batch_norm():
             op_name="batch_norm",
             transforms={"scale_after_normalization": "scale", "variance_epsilon": "epsilon"},
             extras={"axis": axis},
-            ignores=["data_format", "exponential_avg_factor"],
+            ignores=["data_format"],
             disables=["momentum"],
         )(new_inputs, attr)
 

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -3644,7 +3644,7 @@ def test_forward_reduce():
     _test_math_op(tf.math.reduce_max)
     _test_math_op(tf.math.reduce_min)
     _test_math_op(tf.math.reduce_prod)
-    _test_math_op(tf.math.reduce_variance, dtypes=["float32"])
+    _test_math_op(tf.math.reduce_variance)
     _test_math_op(tf.math.reduce_std, dtypes=["float32"])
     _test_math_op(tf.math.reduce_logsumexp, dtypes=["float32"])
     if package_version.parse(tf.VERSION) >= package_version.parse("1.15.0"):
@@ -3855,11 +3855,11 @@ def test_forward_unravel_index():
     _test_forward_unravel_index([x, y])
 
     x = np.array([0, 1, 2, 5])
-    y = np.array([2, 3])
+    y = np.array([2, 2])
     _test_forward_unravel_index([x, y])
 
     x = np.array([0, 1, 2, 5])
-    y = np.array([6])
+    y = np.array([2])
     _test_forward_unravel_index([x, y])
 
     x = np.array([102, 300, 16])


### PR DESCRIPTION
Reverts apache/incubator-tvm#6706, as it breaks five TFLite tests. This is also reported in #6754.

On my machine I can see these fails when I have TF 2.3.1 installed:
```
tests/python/frontend/tflite/test_forward.py::test_forward_convolution
tests/python/frontend/tflite/test_forward.py::test_forward_transpose_conv
tests/python/frontend/tflite/test_forward.py::test_forward_quantize_dequantize
tests/python/frontend/tflite/test_forward.py::test_forward_padv2 - Run...
tests/python/frontend/tflite/test_forward.py::test_forward_relu - Valu...
```

_Note_: I used GitHub's "revert" functionality here, to revert the whole #6706, and I think we can just use the same to re-merge it, when sources are ready to cope with TF 2.3.x.

cc @tqchen @ANSHUMAN87 @u99127 