### PR TITLE
[ManifestAlloc] Handle TupleType inputs in CheckReshapeOnly

### DIFF
--- a/python/tvm/relay/transform/memory_alloc.py
+++ b/python/tvm/relay/transform/memory_alloc.py
@@ -84,6 +84,11 @@ class CheckReshapeOnly(ExprVisitor):
         for arg in call.args:
             self.visit(arg)
 
+    def visit_var(self, var):
+        var_type = var.checked_type
+        if not isinstance(var_type, ty.TensorType):
+            self.reshape_only = False
+
 
 def is_reshape_only(func):
     """Check if the primitive function contains only reshape ops."""

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -754,5 +754,21 @@ def test_vm_reshape_tensor():
     check_result([x_np, y_np], x_np.reshape([8, 2, 8]), mod)
 
 
+def test_vm_reshape_tuple(x_shape=(1, 4, 2), y_shape=(1, 2, 10)):
+    tup = relay.var(
+        "tup",
+        type_annotation=relay.TupleType([relay.TensorType(x_shape), relay.TensorType(y_shape)]),
+    )
+    out = relay.reshape(relay.TupleGetItem(tup, 0), (1, -1))
+    f = relay.Function([tup], out)
+
+    x_data = np.random.uniform(size=x_shape).astype("float32")
+    y_data = np.random.uniform(size=y_shape).astype("float32")
+
+    for tgt, ctx in tvm.testing.enabled_targets():
+        res = veval(f, (x_data, y_data))
+        tvm.testing.assert_allclose(res.asnumpy(), np.reshape(x_data, (1, -1)))
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -766,7 +766,7 @@ def test_vm_reshape_tuple(x_shape=(1, 4, 2), y_shape=(1, 2, 10)):
     y_data = np.random.uniform(size=y_shape).astype("float32")
 
     for tgt, ctx in tvm.testing.enabled_targets():
-        res = veval(f, (x_data, y_data))
+        res = veval(f, (x_data, y_data), ctx=ctx, target=tgt)
         tvm.testing.assert_allclose(res.asnumpy(), np.reshape(x_data, (1, -1)))
 
 


### PR DESCRIPTION
This arises insed ManifestAllocPass inside relay.vm.compile

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
