### PR TITLE
Fix version check bug

### DIFF
--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -22,5 +22,6 @@ def is_version_greater_than(ver):
     import torch
     import re
 
-    return version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',torch.__version__)[0])) > version.parse(
-        ''.join(re.findall('(\d+\.)(\d+\.)(\d)',ver)[0]))
+    return "".join(re.findall("(\d+\.)(\d+\.)(\d)", torch.__version__)[0]) > "".join(
+        re.findall("(\d+\.)(\d+\.)(\d)", ver)[0]
+    )

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -22,4 +22,5 @@ def is_version_greater_than(ver):
     import torch
     from packaging import version
 
-    return version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',torch.__version__)[0])) > version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',ver)[0]))
+    return version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',torch.__version__)[0])) > version.parse(
+        ''.join(re.findall('(\d+\.)(\d+\.)(\d)',ver)[0]))

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -22,6 +22,6 @@ def is_version_greater_than(ver):
     import torch
     import re
 
-    return "".join(re.findall("(\d+\.)(\d+\.)(\d)", torch.__version__)[0]) > "".join(
-        re.findall("(\d+\.)(\d+\.)(\d)", ver)[0]
+    return "".join(re.findall(r"(\d+\.)(\d+\.)(\d)", torch.__version__)[0]) > "".join(
+        re.findall(r"(\d+\.)(\d+\.)(\d)", ver)[0]
     )

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -22,4 +22,4 @@ def is_version_greater_than(ver):
     import torch
     from packaging import version
 
-    return version.parse(torch.__version__) > version.parse(ver)
+    return version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',torch.__version__)[0])) > version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',ver)[0]))

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -20,7 +20,7 @@
 
 def is_version_greater_than(ver):
     import torch
-    from packaging import version
+    import re
 
     return version.parse(''.join(re.findall('(\d+\.)(\d+\.)(\d)',torch.__version__)[0])) > version.parse(
         ''.join(re.findall('(\d+\.)(\d+\.)(\d)',ver)[0]))


### PR DESCRIPTION
Pytorch has versions like 1.5.x+cu1XX which cause bugs in version comparison checks. This PR fixes that. 