### PR TITLE
[µTVM] Add serial transport, parameterize µTVM Zephyr test, run on physical HW

### DIFF
--- a/python/tvm/exec/microtvm_debug_shell.py
+++ b/python/tvm/exec/microtvm_debug_shell.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=redefined-outer-name, invalid-name
+"""Start an RPC server intended for use as a microTVM debugger.
+
+microTVM aims to be runtime-agnostic, and to that end, frameworks often define command-line tools
+used to launch a debug flow. These tools often manage the process of connecting to an attached
+device using a hardware debugger, exposing a GDB server, and launching GDB connected to that
+server with a source file attached. It's also true that this debugger can typically not be executed
+concurrently with any flash tool, so this integration point is provided to allow TVM to launch and
+terminate any debuggers integrated with the larger microTVM compilation/autotuning flow.
+
+To use this tool, first launch this script in a separate terminal window. Then, provide the hostport
+to your compiler's Flasher instance.
+"""
+
+import argparse
+import logging
+import socket
+import struct
+
+import tvm.micro.debugger as _  # NOTE: imported to expose global PackedFuncs over RPC.
+
+from .._ffi.base import py_str
+from ..rpc import base
+from ..rpc import _ffi_api
+
+
+_LOG = logging.getLogger(__name__)
+
+
+def parse_args():
+    """Parse command line arguments to this script."""
+    parser = argparse.ArgumentParser(description="microTVM debug-tool runner")
+    parser.add_argument("--host", default="0.0.0.0", help="hostname to listen on")
+    parser.add_argument("--port", type=int, default=9090, help="hostname to listen on")
+    parser.add_argument(
+        "--impl",
+        help=(
+            "If given, name of a module underneath tvm.micro.contrib "
+            "which contains the Debugger implementation to use."
+        ),
+    )
+
+    return parser.parse_args()
+
+
+class ConnectionClosedError(Exception):
+    """Raised when the connection is closed."""
+
+
+def handle_conn(conn, rpc_key):
+    """Handle a single connection that has just been accept'd()."""
+
+    def send(data):
+        conn.sendall(data)
+        return len(data)
+
+    magic = struct.unpack("<i", base.recvall(conn, 4))[0]
+    if magic != base.RPC_MAGIC:
+        conn.close()
+        return
+
+    keylen = struct.unpack("<i", base.recvall(conn, 4))[0]
+    key = py_str(base.recvall(conn, keylen))
+    arr = key.split()
+    expect_header = "client:"
+    server_key = "server:" + rpc_key
+    if arr[0] != expect_header:
+        conn.sendall(struct.pack("<i", base.RPC_CODE_MISMATCH))
+        _LOG.warning("mismatch key from %s", addr)
+        return
+
+    conn.sendall(struct.pack("<i", base.RPC_CODE_SUCCESS))
+    conn.sendall(struct.pack("<i", len(server_key)))
+    conn.sendall(server_key.encode("utf-8"))
+    server = _ffi_api.CreateEventDrivenServer(send, "microtvm-rpc-debugger", key)
+
+    def _readall(n):
+        buf = bytearray()
+        while len(buf) < n:
+            x = conn.recv(n - len(buf))
+            if not x:
+                raise ConnectionClosedError()
+
+            buf = buf + x
+
+        return buf
+
+    while True:
+        packet_length_bytes = _readall(8)
+        packet_length = struct.unpack("<q", packet_length_bytes)[0]
+        if not packet_length:
+            break
+
+        status = server(packet_length_bytes, 3)
+        if status == 0:
+            break
+
+        packet_body = _readall(packet_length)
+        status = server(packet_body, 3)
+
+
+def main():
+    """Main entry point for microTVM debug shell."""
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO)
+    if args.impl:
+        package = None
+        if "." not in args.impl:
+            package = f"tvm.micro.contrib.{args.impl}"
+        importlib.import_module(args.impl, package)
+
+    sock = socket.socket(base.get_addr_family([args.host, args.port]), socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((args.host, args.port))
+    sock.listen(1)
+    bind_addr, bind_port = sock.getsockname()
+    _LOG.info("listening for connections on %s:%d", bind_addr, bind_port)
+
+    while True:
+        conn, peer = sock.accept()
+        _LOG.info("accepted connection from %s", peer)
+        try:
+            handle_conn(conn, "")
+        except ConnectionClosedError:
+            pass
+        finally:
+            conn.close()
+            _LOG.info("closed connection from %s", peer)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tvm/exec/microtvm_debug_shell.py
+++ b/python/tvm/exec/microtvm_debug_shell.py
@@ -52,7 +52,11 @@ def parse_args():
         "--impl",
         help=(
             "If given, name of a module underneath tvm.micro.contrib "
-            "which contains the Debugger implementation to use."
+            "which contains the Debugger implementation to use. For example, to enable a "
+            "debugger named BarDebugger in python/tvm/micro/contrib/foo.py, specify either "
+            "'tvm.micro.contrib.foo' or 'foo' here. To enable a debugger named BazDebugger in "
+            "a third-party module ext_package.debugger, specify 'ext_package.debugger' here. "
+            "NOTE: the module cannot be in a sub-package of tvm.micro.contrib."
         ),
     )
 

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -23,9 +23,7 @@ import multiprocessing
 import os
 import re
 import tempfile
-import termios
 import textwrap
-import signal
 import shlex
 import shutil
 import subprocess
@@ -40,6 +38,7 @@ from .. import debugger
 from ..transport import debug
 from ..transport import file_descriptor
 
+from ..transport import serial
 from ..transport import Transport, TransportClosedError, TransportTimeouts
 from ..transport import wakeup
 
@@ -219,7 +218,7 @@ class ZephyrCompiler(tvm.micro.Compiler):
         return tvm.micro.MicroBinary(
             output,
             binary_file=os.path.join("zephyr", "zephyr.elf"),
-            debug_files=[],
+            debug_files=[os.path.join("zephyr", "zephyr.elf")],
             labelled_files={
                 "cmake_cache": ["CMakeCache.txt"],
                 "device_tree": [os.path.join("zephyr", "zephyr.dts")],
@@ -289,6 +288,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
         openocd_serial=None,
         flash_args=None,
         debug_rpc_session=None,
+        serial_timeouts=None,
     ):
         zephyr_base = zephyr_base or os.environ["ZEPHYR_BASE"]
         sys.path.insert(0, os.path.join(zephyr_base, "scripts", "dts"))
@@ -308,6 +308,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
         self._subprocess_env = SubprocessEnv(subprocess_env)
         self._debug_rpc_session = debug_rpc_session
         self._nrfjprog_snr = nrfjprog_snr
+        self._serial_timeouts = serial_timeouts
 
     def _get_nrf_device_args(self):
         nrfjprog_args = ["nrfjprog", "--ids"]
@@ -361,7 +362,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
             serials.sort()
 
             self._autodetected_openocd_serial = serials[0]
-            print("autodetected", serials[0])
+            _LOG.debug("zephyr openocd driver: autodetected serial %s", serials[0])
 
         return self._autodetected_openocd_serial
 
@@ -457,7 +458,9 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
         _LOG.debug("zephyr transport: found UART baudrate from devicetree: %d", uart_baud)
 
         port_kwargs = self._find_serial_port(micro_binary)
-        serial_transport = serial.SerialTransport(baudrate=uart_baud, **port_kwargs)
+        serial_transport = serial.SerialTransport(
+            timeouts=self._serial_timeouts, baudrate=uart_baud, **port_kwargs
+        )
         if self._debug_rpc_session is None:
             return serial_transport
 
@@ -468,7 +471,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
                     ZephyrDebugger,
                     (
                         " ".join(shlex.quote(x) for x in self._west_cmd),
-                        os.path.join(self._project_dir, "__tvm_build"),
+                        os.path.dirname(micro_binary.abspath(micro_binary.label("cmake_cache")[0])),
                         micro_binary.abspath(micro_binary.debug_files[0]),
                         self._zephyr_base,
                     ),
@@ -566,8 +569,6 @@ class ZephyrQemuTransport(Transport):
             self.fd_transport = None
 
         if self.proc is not None:
-            #            self.proc.wait()
-            #            self.proc.terminate()
             self.proc = None
 
         if self.pipe_dir is not None:
@@ -585,23 +586,22 @@ class ZephyrQemuTransport(Transport):
         return self.fd_transport.write(data, timeout_sec)
 
 
-class ZephyrDebugger(debugger.Debugger):
+class ZephyrDebugger(debugger.GdbDebugger):
     """A Zephyr debugger implementation."""
 
     def __init__(self, west_cmd, build_dir, elf_path, zephyr_base):
-        debugger.Debugger.__init__(self)
+        super(ZephyrDebugger, self).__init__()
         self._west_cmd = shlex.split(west_cmd)
         self._build_dir = build_dir
         self._elf_path = elf_path
         self._zephyr_base = zephyr_base
 
-    def start(self):
+    def popen_kwargs(self):
         env = dict(os.environ)
         env["ZEPHYR_BASE"] = self._zephyr_base
-        sys.stdin = open(0)  # re-open stdin, closed by multiprocessing.
-        self._old_termios = termios.tcgetattr(sys.stdin)
-        self._proc = subprocess.Popen(
-            self._west_cmd
+
+        return dict(
+            args=self._west_cmd
             + [
                 "debug",
                 "--skip-rebuild",
@@ -612,10 +612,3 @@ class ZephyrDebugger(debugger.Debugger):
             ],
             env=env,
         )
-        self._old_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-    def stop(self):
-        signal.signal(signal.SIGINT, self._old_sigint_handler)
-        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self._old_termios)
-        self._proc.terminate()
-        self._proc.wait()

--- a/python/tvm/micro/transport/base.py
+++ b/python/tvm/micro/transport/base.py
@@ -213,7 +213,7 @@ class TransportLogger(Transport):
         except IoTimeoutError:
             self.logger.log(
                 self.level,
-                "%s read {%3.2fs} %4d B -> [IoTimeoutError %.2f s]",
+                "%s read {%5.2fs} %4d B -> [IoTimeoutError %.2f s]",
                 self.name,
                 timeout_sec,
                 n,
@@ -223,7 +223,7 @@ class TransportLogger(Transport):
         except Exception as err:
             self.logger.log(
                 self.level,
-                "%s read {%3.2fs} %4d B -> [err: %s]",
+                "%s read {%5.2fs} %4d B -> [err: %s]",
                 self.name,
                 timeout_sec,
                 n,
@@ -236,7 +236,7 @@ class TransportLogger(Transport):
         if len(hex_lines) > 1:
             self.logger.log(
                 self.level,
-                "%s read {%3.2fs} %4d B -> [%d B]:\n%s",
+                "%s read {%5.2fs} %4d B -> [%3d B]:\n%s",
                 self.name,
                 timeout_sec,
                 n,
@@ -246,7 +246,7 @@ class TransportLogger(Transport):
         else:
             self.logger.log(
                 self.level,
-                "%s read {%3.2fs} %4d B -> [%d B]: %s",
+                "%s read {%5.2fs} %4d B -> [%3d B]: %s",
                 self.name,
                 timeout_sec,
                 n,
@@ -262,7 +262,7 @@ class TransportLogger(Transport):
         except IoTimeoutError:
             self.logger.log(
                 self.level,
-                "%s write             <- [%d B]: [IoTimeoutError %.2f s]",
+                "%s write                <- [%3d B]: [IoTimeoutError %.2f s]",
                 self.name,
                 len(data),
                 timeout_sec,
@@ -271,7 +271,7 @@ class TransportLogger(Transport):
         except Exception as err:
             self.logger.log(
                 self.level,
-                "%s write             <- [%d B]: [err: %s]",
+                "%s write                <- [%3d B]: [err: %s]",
                 self.name,
                 len(data),
                 str(err),
@@ -283,14 +283,18 @@ class TransportLogger(Transport):
         if len(hex_lines) > 1:
             self.logger.log(
                 self.level,
-                "%s write      <- [%d B]:\n%s",
+                "%s write                <- [%3d B]:\n%s",
                 self.name,
                 bytes_written,
                 "\n".join(hex_lines),
             )
         else:
             self.logger.log(
-                self.level, "%s write      <- [%d B]: %s", self.name, bytes_written, hex_lines[0]
+                self.level,
+                "%s write                <- [%3d B]: %s",
+                self.name,
+                bytes_written,
+                hex_lines[0],
             )
 
         return bytes_written

--- a/python/tvm/micro/transport/debug.py
+++ b/python/tvm/micro/transport/debug.py
@@ -37,7 +37,9 @@ class DebugWrapperTransport(Transport):
         child_timeouts = self.transport.timeouts()
         return TransportTimeouts(
             session_start_retry_timeout_sec=(
-                0 if self.disable_session_start_retry else child_timeouts.session_start_retry
+                0
+                if self.disable_session_start_retry
+                else child_timeouts.session_start_retry_timeout_sec
             ),
             session_start_timeout_sec=0,
             session_established_timeout_sec=0,

--- a/python/tvm/micro/transport/file_descriptor.py
+++ b/python/tvm/micro/transport/file_descriptor.py
@@ -73,7 +73,7 @@ class FdTransport(base.Transport):
             timeout_sec = max(0, end_time - time.monotonic())
         rlist, wlist, xlist = select.select(rlist, wlist, rlist + wlist, timeout_sec)
         if not rlist and not wlist and not xlist:
-            raise IoTimeoutError()
+            raise base.IoTimeoutError()
 
         return True
 

--- a/python/tvm/micro/transport/serial.py
+++ b/python/tvm/micro/transport/serial.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Defines a Transport implementation using pyserial."""
+
+import atexit
+import time
+import serial
+import serial.tools.list_ports
+from .base import IoTimeoutError, Transport, TransportTimeouts
+
+
+_DEFAULT_SERIAL_TIMEOUTS = TransportTimeouts(
+    session_start_retry_timeout_sec=5,
+    session_start_timeout_sec=10.0,
+    session_established_timeout_sec=30.0,
+)
+
+
+class SerialTransport(Transport):
+    """A Transport implementation using pySerial."""
+
+    _OPEN_PORTS = []
+
+    @classmethod
+    def close_atexit(cls):
+        """Close all serial ports before exit.
+
+        Some USB-UART kernel drivers are particularly sensitive to being left open (i.e. require
+        unplugging and replugging of attached hardware or reboot of machine); try very hard to
+        close all serial ports at exit.
+        """
+        for port in cls._OPEN_PORTS:
+            try:
+                port.close()
+            except Exception:  # pylint: disable=broad-except
+                _LOG.warn("exception closing port", exc_info=True)
+
+        cls._OPEN_PORTS = []
+
+    def __init__(self, grep=None, port_path=None, timeouts=None, **kw):
+        self._port_path = port_path
+        self._grep = grep
+        self._timeouts = timeouts if timeouts is not None else _DEFAULT_SERIAL_TIMEOUTS
+        self._kw = kw
+        if self._port_path is None and self._grep is None:
+            raise SerialPortNotFoundError("Must specify one of grep= or port_path=")
+
+    def timeouts(self):
+        return self._timeouts
+
+    def open(self):
+        if self._port_path is not None:
+            port_path = self._port_path
+        else:
+            ports = list(serial.tools.list_ports.grep(self._grep, include_links=True))
+            if len(ports) != 1:
+                raise SerialPortNotFoundError(
+                    f"grep expression should find 1 serial port; found {ports!r}"
+                )
+
+            port_path = ports[0].device
+
+        self._port = serial.Serial(port_path, timeout=0.1, exclusive=True, **self._kw)
+        self._port.cancel_read()
+        self._port.reset_input_buffer()
+        self._port.reset_output_buffer()
+        self._OPEN_PORTS.append(self._port)
+
+    def close(self):
+        if self._port is None:
+            return
+
+        self._port.close()
+        self._OPEN_PORTS.remove(self._port)
+        self._port = None
+
+    def read(self, n, timeout_sec):
+        end_time = time.monotonic() + timeout_sec
+        to_return = bytearray()
+        while True:
+            timeout_remaining = end_time - time.monotonic()
+            if timeout_sec != 0 and timeout_remaining < 0:
+                break
+
+            # Read until *something* can be returned. If nothing is sent within 5 chars' time, stop.
+            # 5 is an arbitrary number.
+            self._port.timeout = 1 / self._port.baudrate * 5
+            try:
+                data = self._port.read(n if timeout_sec != 0 else 1)
+                if not data and to_return:
+                    break
+
+                to_return.extend(data)
+            except serial.SerialTimeoutException:
+                if to_return:
+                    break
+
+        if not to_return:
+            raise IoTimeoutError()
+
+        return to_return
+
+    def write(self, data, timeout_sec):
+        self._port.write_timeout = timeout_sec
+        try:
+            to_return = self._port.write(data)
+            self._port.flush()
+            return to_return
+        except serial.SerialTimeoutException:
+            raise IoTimeoutError()
+
+
+atexit.register(SerialTransport.close_atexit)

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -235,12 +235,13 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
         server_proc = multiprocessing.Process(
             target=_serve_loop, args=(conn, addr, load_library, work_path)
         )
-        server_proc.deamon = True
+
         server_proc.start()
         # close from our side.
         conn.close()
         # wait until server process finish or timeout
         server_proc.join(opts.get("timeout", None))
+
         if server_proc.is_alive():
             logger.info("Timeout in RPC session, kill..")
             # pylint: disable=import-outside-toplevel
@@ -280,7 +281,6 @@ def _connect_proxy_loop(addr, key, load_library):
             opts = _parse_server_opt(remote_key.split()[1:])
             logger.info("connected to %s", str(addr))
             process = multiprocessing.Process(target=_serve_loop, args=(sock, addr, load_library))
-            process.deamon = True
             process.start()
             sock.close()
             process.join(opts.get("timeout", None))
@@ -362,8 +362,6 @@ class Server(object):
         load_library=None,
         custom_addr=None,
         silent=False,
-        utvm_dev_id=None,
-        utvm_dev_config_args=None,
     ):
         try:
             if _ffi_api.ServerLoop is None:
@@ -397,10 +395,6 @@ class Server(object):
                 cmd += ["--custom-addr", custom_addr]
             if silent:
                 cmd += ["--silent"]
-            if utvm_dev_id is not None:
-                assert utvm_dev_config_args is not None
-                cmd += [f"--utvm-dev-id={utvm_dev_id}"]
-                cmd += [f"--utvm-dev-config-args={utvm_dev_config_args}"]
 
             # prexec_fn is not thread safe and may result in deadlock.
             # python 3.2 introduced the start_new_session parameter as
@@ -437,13 +431,11 @@ class Server(object):
                 target=_listen_loop,
                 args=(self.sock, self.port, key, tracker_addr, load_library, self.custom_addr),
             )
-            self.proc.deamon = True
             self.proc.start()
         else:
             self.proc = multiprocessing.Process(
                 target=_connect_proxy_loop, args=((host, port), key, load_library)
             )
-            self.proc.deamon = True
             self.proc.start()
 
     def terminate(self):

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -220,19 +220,24 @@ def intel_graphics(model="unknown", options=None):
     return Target(" ".join(["opencl"] + opts))
 
 
-def micro(hardware="unknown", options=None):
+def micro(model="unknown", options=None):
     """Returns a microTVM target.
 
     Parameters
     ----------
-    hardware : str
-        Canonically identifies the target device; typicaly one of cortex-mX, or a specific SoC model
-        when that model has been tested to work with microTVM.
+    model : str
+        Canonically identifies the target device. This is typically a CPU or board level name (other
+        flags such as -mcpu identify the ISA).
     options : str or list of str
         Additional options
     """
-    trans_table = {"host": ["-mcpu=native"]}
-    opts = _merge_opts(trans_table[hardware] + ["-runtime=c", "--system-lib"], options)
+    trans_table = {
+        "host": ["-mcpu=native"],
+        "stm32f746xx": ["-mcpu=cortex-m7"],
+    }
+    opts = _merge_opts(
+        trans_table[model] + ["-runtime=c", "--system-lib", f"-model={model}"], options
+    )
 
     # NOTE: in the future, the default micro target will be LLVM except when
     # external dependencies are present.

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -700,6 +700,14 @@ void RPCEndpoint::Init() {
   });
 }
 
+/*!
+ * \brief Create a new RPCEndpoint instance.
+ * \param channel RPCChannel used to communicate
+ * \param name Name of this session, used to identify log messages from this RPCEndpoint instance.
+ * \param The remote key reported during protocol initialization, or "%toinit" if the RPCEndpoint
+ *     should handle this phase of the protocol for you. Some servers may prefer to access parts of
+ *     the key to modify their behavior.
+ */
 std::shared_ptr<RPCEndpoint> RPCEndpoint::Create(std::unique_ptr<RPCChannel> channel,
                                                  std::string name, std::string remote_key) {
   std::shared_ptr<RPCEndpoint> endpt = std::make_shared<RPCEndpoint>();

--- a/tests/micro/qemu/.gitignore
+++ b/tests/micro/qemu/.gitignore
@@ -1,2 +1,2 @@
-/test_zephyr-workspace
+/test_zephyr*-workspace
 /*.micro-binary

--- a/tests/micro/qemu/conftest.py
+++ b/tests/micro/qemu/conftest.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--microtvm-platforms",
+        default="host",
+        help=(
+            "Specify a comma-separated list of test models (i.e. as passed to tvm.target.micro()) "
+            "for microTVM tests."
+        ),
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "platform" in metafunc.fixturenames:
+        metafunc.parametrize("platform", metafunc.config.getoption("microtvm_platforms").split(","))


### PR DESCRIPTION
This PR adds a pyserial transport to µTVM, allowing it to be used with physical hardware attached to the machine. This splits #6703 in half and adds just the zephyr-specific runtime components. To test this change, you can either run it locally if you have the necessary dependencies or use the VM in #6703 