### PR TITLE
[FIX][AUTOTVM] Make autotvm work with spawn

### DIFF
--- a/tests/python/unittest/test_autotvm_index_tuner.py
+++ b/tests/python/unittest/test_autotvm_index_tuner.py
@@ -16,6 +16,7 @@
 # under the License.
 """Test index based tuners"""
 
+import multiprocessing
 from test_autotvm_common import DummyRunner, get_sample_task
 from tvm import autotvm
 from tvm.autotvm.tuner import GridSearchTuner, RandomTuner
@@ -43,6 +44,18 @@ def test_gridsearch_tuner():
     assert not tuner.has_next()
 
 
+def grid_search_spawn():
+    assert multiprocessing.get_spawn_method(False) == "spawn"
+    test_gridsearch_tuner()
+
+
+def test_grid_search_tuner_spawn():
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=test_gridsearch_tuner)
+    p.start()
+    p.join()
+
+
 def test_random_tuner():
     """Test RandomTuner"""
 
@@ -65,4 +78,5 @@ def test_random_tuner():
 
 if __name__ == "__main__":
     test_gridsearch_tuner()
+    test_gridsearch_tuner_spawn()
     test_random_tuner()

--- a/tests/python/unittest/test_autotvm_measure.py
+++ b/tests/python/unittest/test_autotvm_measure.py
@@ -16,6 +16,7 @@
 # under the License.
 """Test builder and runner"""
 import logging
+import multiprocessing
 import time
 
 import numpy as np
@@ -44,6 +45,19 @@ def test_task_tuner_without_measurement():
         tuner = tuner_class(task)
         tuner.tune(n_trial=10, measure_option=measure_option)
         assert tuner.best_flops > 1
+
+
+def task_tuner_spawn():
+    assert multiprocessing.get_start_method(False) == "spawn"
+    test_task_tuner_without_measurement()
+
+
+def test_task_tuner_without_measurement_spawn():
+    # Subprocesses inherit the spawn method of their parents
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=task_tuner_spawn)
+    p.start()
+    p.join()
 
 
 def test_check_correctness():
@@ -77,4 +91,5 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
     test_task_tuner_without_measurement()
+    test_task_tuner_without_measurement_spawn()
     test_check_correctness()

--- a/tests/python/unittest/test_autotvm_xgboost_model.py
+++ b/tests/python/unittest/test_autotvm_xgboost_model.py
@@ -16,6 +16,7 @@
 # under the License.
 import time
 
+import multiprocessing
 import numpy as np
 
 import tvm
@@ -43,6 +44,19 @@ def test_fit():
     upper_model.fit(xs, ys, plan_size=32)
 
 
+def fit_spawn():
+    assert multiprocessing.get_start_method(False) == "spawn"
+    test_fit()
+
+
+def test_fit_spawn():
+    # Subprocesses inherit the spawn method of their parents
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=test_fit)
+    p.start()
+    p.join()
+
+
 def test_tuner():
     task, target = get_sample_task()
     records = get_sample_records(n=100)
@@ -53,4 +67,5 @@ def test_tuner():
 
 if __name__ == "__main__":
     test_fit()
+    test_fit_spawn()
     test_tuner()

--- a/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
+++ b/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
@@ -30,6 +30,10 @@ The auto-scheduler can automatically generate a large search space and
 find a good schedule in the space.
 
 We use a convolution layer as an example in this tutorial.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 import os

--- a/tutorials/auto_scheduler/tune_matmul_x86.py
+++ b/tutorials/auto_scheduler/tune_matmul_x86.py
@@ -27,6 +27,10 @@ The auto-scheduler can automatically generate a large search space and
 find a good schedule in the space.
 
 We use matrix multiplication as an example in this tutorial.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 import os

--- a/tutorials/autotvm/tune_conv2d_cuda.py
+++ b/tutorials/autotvm/tune_conv2d_cuda.py
@@ -22,6 +22,10 @@ Tuning High Performance Convolution on NVIDIA GPUs
 This is an advanced tutorial for writing high performance tunable template for
 NVIDIA GPU. By running auto-tuner on this template, we can outperform the
 vendor provided library CuDNN in many cases.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 ######################################################################

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -35,6 +35,10 @@ these operators, it will query this log file to get the best knob values.
 We also released pre-tuned parameters for some arm devices. You can go to
 `ARM CPU Benchmark <https://github.com/apache/incubator-tvm/wiki/Benchmark#arm-cpu>`_
 to see the results.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 ######################################################################

--- a/tutorials/autotvm/tune_relay_cuda.py
+++ b/tutorials/autotvm/tune_relay_cuda.py
@@ -33,6 +33,10 @@ these operators, it will query this log file to get the best knob values.
 We also released pre-tuned parameters for some NVIDIA GPUs. You can go to
 `NVIDIA GPU Benchmark <https://github.com/apache/incubator-tvm/wiki/Benchmark#nvidia-gpu>`_
 to see the results.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 ######################################################################

--- a/tutorials/autotvm/tune_relay_mobile_gpu.py
+++ b/tutorials/autotvm/tune_relay_mobile_gpu.py
@@ -33,6 +33,10 @@ these operators, it will query this log file to get the best knob values.
 We also released pre-tuned parameters for some arm devices. You can go to
 `Mobile GPU Benchmark <https://github.com/apache/incubator-tvm/wiki/Benchmark#mobile-gpu>`_
 to see the results.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 ######################################################################

--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -23,6 +23,10 @@ Auto-tuning a convolutional network for x86 CPU
 
 This is a tutorial about how to tune convolution neural network
 for x86 CPU.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 import os
 import numpy as np

--- a/tutorials/autotvm/tune_simple_template.py
+++ b/tutorials/autotvm/tune_simple_template.py
@@ -26,6 +26,10 @@ The first step is defining a search space.
 The second step is running a search algorithm to explore through this space.
 In this tutorial, you can learn how to perform these two steps in TVM.
 The whole workflow is illustrated by a matrix multiplication example.
+
+Note that this tutorial will not run on Windows or recent versions of macOS. To
+get it to run, you will need to wrap the body of this tutorial in a :code:`if
+__name__ == "__main__":` block.
 """
 
 ######################################################################


### PR DESCRIPTION
Like #6671 this PR fixes autotvm when using the spawn start method for multiprocessing. I've added some tests to make sure that things work with spawn in the CI. I've also added notices to the tutorials letting users know that they will not run on windows or macOS.

Here are performance results for `tutorials/autotvm/tune_conv2d_cuda.py` with n_trials = 100.
```
This PR

XGB iter:   0	tr-a-recall@64: 0.661270	tr-map: 0.100000
XGB iter:  25	tr-a-recall@64: 0.754100	tr-map: 1.000000
XGB stopped. Best iteration: [29] tr-a-recall@64:0.75971	tr-map:1.00000
XGB train: 1.08	obs: 64	error: 43	n_cache: 64
SA iter: 50	last_update: 49	max-0: 5.39	max-1: 6.08	temp: 0.90	elapsed: 3.41
SA iter: 100	last_update: 98	max-0: 5.72	max-1: 6.25	temp: 0.80	elapsed: 6.82
SA iter: 150	last_update: 148	max-0: 5.89	max-1: 6.51	temp: 0.70	elapsed: 10.38
SA iter: 200	last_update: 197	max-0: 5.97	max-1: 6.51	temp: 0.60	elapsed: 14.18
SA iter: 250	last_update: 248	max-0: 6.09	max-1: 6.51	temp: 0.50	elapsed: 18.02
SA iter: 300	last_update: 298	max-0: 6.15	max-1: 6.51	temp: 0.40	elapsed: 21.72
SA iter: 350	last_update: 348	max-0: 6.17	max-1: 6.51	temp: 0.30	elapsed: 25.30
SA iter: 400	last_update: 398	max-0: 6.21	max-1: 6.51	temp: 0.20	elapsed: 28.79
SA iter: 450	last_update: 447	max-0: 6.24	max-1: 6.51	temp: 0.10	elapsed: 32.20
SA iter: 500	last_update: 493	max-0: 6.25	max-1: 6.51	temp: 0.00	elapsed: 35.35
SA iter: 500	last_update: 493	elapsed: 35.35


main

XGB iter:   0	tr-a-recall@64: 0.610293	tr-map: 0.500000
XGB iter:  25	tr-a-recall@64: 0.671535	tr-map: 1.000000
XGB stopped. Best iteration: [29] tr-a-recall@64:0.67466	tr-map:1.00000
XGB train: 1.02	obs: 64	error: 50	n_cache: 64
SA iter: 50	last_update: 49	max-0: 5.41	max-1: 6.23	temp: 0.90	elapsed: 3.41
SA iter: 100	last_update: 98	max-0: 5.58	max-1: 6.23	temp: 0.80	elapsed: 6.94
SA iter: 150	last_update: 145	max-0: 5.72	max-1: 6.37	temp: 0.70	elapsed: 10.61
SA iter: 200	last_update: 198	max-0: 5.76	max-1: 6.37	temp: 0.60	elapsed: 14.25
SA iter: 250	last_update: 247	max-0: 5.83	max-1: 6.45	temp: 0.50	elapsed: 17.87
SA iter: 300	last_update: 298	max-0: 6.03	max-1: 6.45	temp: 0.40	elapsed: 21.81
SA iter: 350	last_update: 349	max-0: 6.07	max-1: 6.45	temp: 0.30	elapsed: 25.57
SA iter: 400	last_update: 397	max-0: 6.11	max-1: 6.45	temp: 0.20	elapsed: 28.99
SA iter: 450	last_update: 444	max-0: 6.13	max-1: 6.45	temp: 0.10	elapsed: 32.60
SA iter: 500	last_update: 489	max-0: 6.14	max-1: 6.45	temp: 0.00	elapsed: 35.76
SA iter: 500	last_update: 489	elapsed: 35.76
```

This is on a 64-core x86 ubuntu system with python 3.6.9. Performance is the same.