### PR TITLE
[TVMSCRIPT] Add synr dependency in preparation for tvmscript diagnostic overhaul

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -21,4 +21,4 @@ set -u
 set -o pipefail
 
 # install libraries for python package on ubuntu
-pip3 install six numpy pytest cython decorator scipy tornado typed_ast pytest pytest-xdist pytest-profiling mypy orderedset attrs requests Pillow packaging cloudpickle
+pip3 install six numpy pytest cython decorator scipy tornado typed_ast pytest pytest-xdist pytest-profiling mypy orderedset attrs requests Pillow packaging cloudpickle synr


### PR DESCRIPTION
This PR adds Synr (a little library for normalizing the python AST) to the docker images. I've uploaded built images to docker hub under `tkonolige/ci-{cpu,gpu,qemu,i386,wasm}`.

@tqchen