### PR TITLE
[Contrib][TRT] Fix Conv2D construction when channels attribute is not available.

### DIFF
--- a/src/runtime/contrib/tensorrt/tensorrt_ops.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.cc
@@ -242,7 +242,7 @@ class Conv2DOpConverter : public TensorRTOpConverter {
     auto str_dilation = params->node.GetAttr<std::vector<std::string>>("dilation");
     auto str_padding = params->node.GetAttr<std::vector<std::string>>("padding");
     int groups = std::stoi(params->node.GetAttr<std::vector<std::string>>("groups")[0]);
-    int channels = std::stoi(params->node.GetAttr<std::vector<std::string>>("channels")[0]);
+    int channels = weight_shape[0];
     // TRT conv2d op doesn't support asymmetric padding before 5.1, so we
     // workaround by adding a padding layer before the pooling op.
     nvinfer1::DimsHW prepadding, postpadding;

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -251,7 +251,6 @@ def test_conv2d():
         out = relay.nn.conv2d(
             x,
             kernel,
-            channels=k_shape[0],
             kernel_size=k_shape[2:4],
             groups=groups,
             padding=padding,


### PR DESCRIPTION
This very small PR changes how channels are extracted from a Conv2D relay op when converting to TensorRT. Previously, we relied on the `channels` attribute being available. However, it is optional and often left as `None`. When attempting to convert in this case `stoi` fails with an unpleasant error. Since we are already enforcing that the weight layout is `OIHW`, there is no downside to instead extracting the channel info from the weight shape. I updated the corresponding conv2d test to not specify channels to confirm that this change resolves the issue.