### PR TITLE
[CI] Pin h5py version to < 3.0 to workaround issues with TF/Keras

### DIFF
--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -20,4 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install tensorflow==2.3.1 keras==2.4.3 h5py
+# h5py is pinned to minor than 3 due to issues with
+# tensorflow:
+# https://github.com/tensorflow/tensorflow/issues/44467
+pip3 install tensorflow==2.3.1 keras==2.3.1 "h5py<3.0"


### PR DESCRIPTION
`h5py` recently released version 3.0 (dates can be seen here: https://pypi.org/project/h5py/#history). This breaks TF 2.3 and Keras, as reported already by others, e.g. https://github.com/tensorflow/tensorflow/issues/44467.

Because of that, there are a few tests that fail:
```
FAILED tests/python/frontend/keras/test_forward.py::TestKeras::test_forward_resnet50[keras]
FAILED tests/python/frontend/keras/test_forward.py::TestKeras::test_forward_mobilenet[keras]
FAILED tests/python/frontend/keras/test_forward.py::TestKeras::test_forward_resnet50[tf_keras]
FAILED tests/python/frontend/keras/test_forward.py::TestKeras::test_forward_mobilenet[tf_keras]
ERROR tests/python/driver/tvmc/test_compiler.py::test_compile_keras__save_module
ERROR tests/python/driver/tvmc/test_compiler.py::test_cross_compile_aarch64_keras_module
ERROR tests/python/driver/tvmc/test_frontends.py::test_load_model__keras - At...
ERROR tests/python/driver/tvmc/test_frontends.py::test_load_model___wrong_language__to_tflite
```

The reason of the failures/errors indeed is the same as reported upstream:
```

    def load_weights_from_hdf5_group(f, layers):
      """Implements topological (order-based) weight loading.
    
      Arguments:
          f: A pointer to a HDF5 group.
          layers: a list of target layers.
    
      Raises:
          ValueError: in case of mismatch between provided layers
              and weights file.
      """
      if 'keras_version' in f.attrs:
>       original_keras_version = f.attrs['keras_version'].decode('utf8')
E       AttributeError: 'str' object has no attribute 'decode'

/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/saving/hdf5_format.py:660: AttributeError
```

To workaround that, this PR: 

 * Pin h5py to use the previous major release (2.x) and not new version 3.0, due to incompatibilities with TF and Keras that make TVMC and Frontend tests to fail

_Note_: just to make it clear, this is caused by the `h5py` release and affects TF >= 2.1.0 so it is *not related* in any way with the recent update to TF 2.3.1.

cc @tqchen @u99127 @areusch @ANSHUMAN87 
