### PR TITLE
[CI] Move back Keras to 2.4.3

### DIFF
--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -23,4 +23,4 @@ set -o pipefail
 # h5py is pinned to minor than 3 due to issues with
 # tensorflow:
 # https://github.com/tensorflow/tensorflow/issues/44467
-pip3 install tensorflow==2.3.1 keras==2.3.1 "h5py<3.0"
+pip3 install tensorflow==2.3.1 keras==2.4.3 "h5py<3.0"


### PR DESCRIPTION
I mistakenly moved it back to 2.3.1, now fixing it. (mentioned in #6754)

cc @tqchen 