### PR TITLE
[TVMC] 'tvmc tune' --rpc-tracker and --rpc-tracker fail due to argparse misconfiguration

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -92,12 +92,10 @@ def add_tune_parser(subparsers):
     )
     parser.add_argument(
         "--rpc-key",
-        nargs=1,
         help="the RPC tracker key of the target device. Required when --rpc-tracker is provided.",
     )
     parser.add_argument(
         "--rpc-tracker",
-        nargs=1,
         help="hostname (required) and port (optional, defaults to 9090) of the RPC tracker, "
         "e.g. '192.168.0.100:9999'",
     )


### PR DESCRIPTION
Fix an error with `tvmc tune`, that causes --rpc-tracker and --rpc-key to be identified as a list of strings, rather than the expected string type.

Removing the unnecessary nargs solves the issues.

This is a follow-up of https://github.com/apache/incubator-tvm/pull/6762

cc: @leandron 
