### PR TITLE
[TIR] Make loop unrolling in LoopPartition optional

### DIFF
--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -40,12 +40,12 @@ namespace tir {
 
 struct LoopPartitionConfigNode : public tvm::AttrsNode<LoopPartitionConfigNode> {
   bool partition_const_loop;
-  bool no_unroll_single_iter_loop;
+  bool no_unroll_loop_with_extent_one;
 
   TVM_DECLARE_ATTRS(LoopPartitionConfigNode, "tir.transform.LoopPartitionConfig") {
     TVM_ATTR_FIELD(partition_const_loop).describe("Split constant loop").set_default(false);
-    TVM_ATTR_FIELD(no_unroll_single_iter_loop)
-        .describe("Don't unroll loops of extent 1")
+    TVM_ATTR_FIELD(no_unroll_loop_with_extent_one)
+        .describe("Don't unroll loops with extent 1")
         .set_default(false);
   }
 };
@@ -338,9 +338,9 @@ class ThreadPartitionInserter : public StmtMutator {
 // likely conditions
 class LoopPartitioner : public StmtMutator {
  public:
-  explicit LoopPartitioner(bool partition_const_loop, bool no_unroll_single_iter_loop)
+  explicit LoopPartitioner(bool partition_const_loop, bool no_unroll_loop_with_extent_one)
       : selector(CandidateSelector(partition_const_loop)),
-        no_unroll_single_iter_loop_(no_unroll_single_iter_loop) {}
+        no_unroll_loop_with_extent_one_(no_unroll_loop_with_extent_one) {}
 
   Stmt VisitAndMutate(Stmt stmt) {
     selector(stmt);
@@ -407,7 +407,7 @@ class LoopPartitioner : public StmtMutator {
   std::unordered_map<const VarNode*, IntSet> relax_map_;
   arith::Analyzer analyzer_;
   CandidateSelector selector;
-  bool no_unroll_single_iter_loop_;
+  bool no_unroll_loop_with_extent_one_;
 };
 
 // Returns an interval (in the first component) in which all the conditions
@@ -603,7 +603,7 @@ inline Stmt LoopPartitioner::MakeFor(const Object* node, PrimExpr extent, Stmt b
   const ForNode* for_node = static_cast<const ForNode*>(node);
   ICHECK(for_node);
   if (analyzer_.CanProve(extent == make_const(DataType::Int(32), 1)) &&
-      !no_unroll_single_iter_loop_) {
+      !no_unroll_loop_with_extent_one_) {
     // If the loop extent is 1, do not create the loop anymore
     return Substitute(body, {{Var{for_node->loop_var}, make_const(DataType::Int(32), 0)}});
   } else {
@@ -624,8 +624,8 @@ class RemoveLikelyTags : public StmtExprMutator {
   }
 };
 
-Stmt LoopPartition(Stmt stmt, bool partition_const_loop, bool no_unroll_single_iter_loop) {
-  stmt = LoopPartitioner(partition_const_loop, no_unroll_single_iter_loop)
+Stmt LoopPartition(Stmt stmt, bool partition_const_loop, bool no_unroll_loop_with_extent_one) {
+  stmt = LoopPartitioner(partition_const_loop, no_unroll_loop_with_extent_one)
              .VisitAndMutate(std::move(stmt));
   stmt = RemoveLikelyTags()(std::move(stmt));
   return stmt;
@@ -641,7 +641,7 @@ Pass LoopPartition() {
       cfg = AttrsWithDefaultValues<LoopPartitionConfig>();
     }
     n->body = LoopPartition(std::move(n->body), cfg.value()->partition_const_loop,
-                            cfg.value()->no_unroll_single_iter_loop);
+                            cfg.value()->no_unroll_loop_with_extent_one);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tir.LoopPartition", {});

--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -635,7 +635,8 @@ Pass LoopPartition() {
     if (!cfg.defined()) {
       cfg = AttrsWithDefaultValues<LoopPartitionConfig>();
     }
-    n->body = LoopPartition(std::move(n->body), cfg.value()->partition_const_loop, cfg.value()->unroll);
+    n->body =
+        LoopPartition(std::move(n->body), cfg.value()->partition_const_loop, cfg.value()->unroll);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tir.LoopPartition", {});

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -61,7 +61,7 @@ def test_const_loop():
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], stmt))
     with tvm.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True}}):
         mod = tvm.tir.transform.LoopPartition()(mod)
-        mod = tvm.tir.transform.Simplify()(mod)["main"].body
+        stmt = tvm.tir.transform.Simplify()(mod)["main"].body
 
     assert not any(collect_visit(stmt, lambda x: isinstance(x, tvm.tir.IfThenElse)))
 

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -61,8 +61,9 @@ def test_const_loop():
     stmt = tvm.te.schedule.ScheduleOps(s, bounds)
 
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], stmt))
-    with tvm.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True,
-                                                                 "unroll": False}}):
+    with tvm.transform.PassContext(
+        config={"tir.LoopPartition": {"partition_const_loop": True, "unroll": False}}
+    ):
         mod = tvm.tir.transform.LoopPartition()(mod)
         mod = tvm.tir.transform.Simplify()(mod)
         stmt = tvm.tir.transform.RemoveNoOp()(mod)["main"].body
@@ -83,8 +84,9 @@ def test_no_unroll_loop():
     stmt = tvm.te.schedule.ScheduleOps(s, bounds)
 
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], stmt))
-    with tvm.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True,
-                                                                 "unroll": False}}):
+    with tvm.transform.PassContext(
+        config={"tir.LoopPartition": {"partition_const_loop": True, "unroll": False}}
+    ):
         mod = tvm.tir.transform.LoopPartition()(mod)
         mod = tvm.tir.transform.Simplify()(mod)
         stmt = tvm.tir.transform.RemoveNoOp()(mod)["main"].body

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -81,7 +81,10 @@ def test_no_unroll_loop():
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], stmt))
     with tvm.transform.PassContext(
         config={
-            "tir.LoopPartition": {"partition_const_loop": True, "no_unroll_single_iter_loop": True}
+            "tir.LoopPartition": {
+                "partition_const_loop": True,
+                "no_unroll_loop_with_extent_one": True,
+            }
         }
     ):
         mod = tvm.tir.transform.LoopPartition()(mod)

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -37,12 +37,10 @@ def test_basic():
 
     bounds = tvm.te.schedule.InferBound(s)
     stmt = tvm.te.schedule.ScheduleOps(s, bounds)
-    print(stmt)
 
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([n], stmt))
     mod = tvm.tir.transform.LoopPartition()(mod)
-    mod = tvm.tir.transform.Simplify()(mod)
-    print(mod)
+    stmt = tvm.tir.transform.Simplify()(mod)["main"].body
 
     assert not any(collect_visit(stmt.body.body[0], lambda x: isinstance(x, tvm.tir.IfThenElse)))
     assert any(collect_visit(stmt.body.body[1], lambda x: isinstance(x, tvm.tir.IfThenElse)))
@@ -61,12 +59,9 @@ def test_const_loop():
     stmt = tvm.te.schedule.ScheduleOps(s, bounds)
 
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], stmt))
-    with tvm.transform.PassContext(
-        config={"tir.LoopPartition": {"partition_const_loop": True, "unroll": False}}
-    ):
+    with tvm.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True}}):
         mod = tvm.tir.transform.LoopPartition()(mod)
-        mod = tvm.tir.transform.Simplify()(mod)
-        stmt = tvm.tir.transform.RemoveNoOp()(mod)["main"].body
+        mod = tvm.tir.transform.Simplify()(mod)["main"].body
 
     assert not any(collect_visit(stmt, lambda x: isinstance(x, tvm.tir.IfThenElse)))
 

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -80,7 +80,9 @@ def test_no_unroll_loop():
 
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([], stmt))
     with tvm.transform.PassContext(
-        config={"tir.LoopPartition": {"partition_const_loop": True, "unroll": False}}
+        config={
+            "tir.LoopPartition": {"partition_const_loop": True, "no_unroll_single_iter_loop": True}
+        }
     ):
         mod = tvm.tir.transform.LoopPartition()(mod)
         mod = tvm.tir.transform.Simplify()(mod)


### PR DESCRIPTION
For certain analysis/tensorization, it can be useful to keep the loop structure when partitioning loops. The current behaviour removes For loops of length 1. This change introduces the option to preserve these loops with the 'unroll' flag.