### PR TITLE
Improve error message for 1DConv shape relations

### DIFF
--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -102,7 +102,9 @@ bool Conv1DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
           << " channels=" << param->channels << " wshape=" << wshape;
     }
     if (!dshape_ncw[1].as<tir::AnyNode>() && !wshape[1].as<tir::AnyNode>()) {
-      ICHECK(reporter->AssertEQ(dshape_ncw[1], wshape[1]));
+      ICHECK(reporter->AssertEQ(dshape_ncw[1], wshape[1]))
+          << "Conv1D: shape of data input channels is inconsisten with wshape"
+          << " channels=" << dshape_ncw[1] << " wshape=" << wshape;
     }
     channels = wshape[0];
     dilated_ksize = 1 + (wshape[2] - 1) * param->dilation[0];


### PR DESCRIPTION
This test just adds a more informative error message to an exception i triggered when trying to import an onnx model and setting the wrong input shape. 
