### PR TITLE
[QNN] Dynamic scale, zero point in qnn.op.dequantize

### DIFF
--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -24,6 +24,7 @@ from . import _make
 from ... import op as reg
 from ...op import OpPattern
 
+
 def requantize(
     data,
     input_scale,
@@ -497,6 +498,7 @@ def subtract(
         output_scale,
         output_zero_point,
     )
+
 
 # register fuse pattern for qnn ops
 reg.register_pattern("qnn.quantize", OpPattern.OPAQUE)

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -21,7 +21,8 @@ from __future__ import absolute_import as _abs
 from tvm.relay.expr import Tuple, TupleWrapper
 from tvm.relay.op.nn.utils import get_pad_tuple2d
 from . import _make
-
+from ... import op as reg
+from ...op import OpPattern
 
 def requantize(
     data,
@@ -496,3 +497,7 @@ def subtract(
         output_scale,
         output_zero_point,
     )
+
+# register fuse pattern for qnn ops
+reg.register_pattern("qnn.quantize", OpPattern.OPAQUE)
+reg.register_pattern("qnn.dequantize", OpPattern.OPAQUE)

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -30,7 +30,6 @@ import tvm
 import tvm.testing
 from tvm import relay
 from tvm.contrib import graph_runtime
-from tvm.relay import create_executor
 from tvm.relay.frontend.pytorch_utils import is_version_greater_than
 from tvm.contrib.download import download_testdata
 

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -29,7 +29,6 @@ from torch.quantization import fuse_modules, QuantWrapper
 import tvm
 import tvm.testing
 from tvm import relay
-from tvm.contrib import graph_runtime
 from tvm.relay.frontend.pytorch_utils import is_version_greater_than
 from tvm.contrib.download import download_testdata
 

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -31,7 +31,6 @@ import tvm.testing
 from tvm import relay
 from tvm.contrib import graph_runtime
 from tvm.relay import create_executor
-from tvm.relay.testing import run_infer_type
 from tvm.relay.frontend.pytorch_utils import is_version_greater_than
 from tvm.contrib.download import download_testdata
 
@@ -507,58 +506,6 @@ def test_serialized_modules():
     num_identical = np.sum(np.abs(tvm_result - pt_result) < 1e-2)
     match_ratio = num_identical / float(np.prod(tvm_result.shape))
     assert match_ratio > 0.90
-
-
-def test_dequantize_dynamic_unit():
-    x = relay.var("x", shape=(1, 2, 3, 4), dtype="int8")
-    scale_var = relay.var("scale", shape=(), dtype="float32")
-    zp_var = relay.var("zp", shape=(), dtype="int32")
-
-    deq_x = relay.qnn.op.dequantize(x, scale_var * scale_var, zp_var + zp_var)
-    tt = run_infer_type(deq_x)
-
-    assert tt.checked_type == relay.TensorType((1, 2, 3, 4), "float32")
-    func = relay.Function([x, scale_var, zp_var], deq_x)
-    data = np.random.uniform(size=(1, 2, 3, 4)).astype("int8")
-    scale = np.array(1).astype("float32")
-    zp = np.array(0).astype("int32")
-
-    mod = tvm.ir.IRModule.from_expr(func)
-
-    for target, ctx in tvm.testing.enabled_targets():
-        # TODO: (electriclilies) enable AlterOpLayout when it is fixed
-        with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
-            lib = relay.build(mod, target=target)
-
-    module = graph_runtime.GraphModule(lib["default"](ctx))
-    module.set_input(**{"x": data, "scale": scale, "zp": zp})
-    module.run()
-
-
-def test_quantize_dynamic_unit():
-    x = relay.var("x", shape=(1, 2, 3, 4), dtype="float32")
-    scale_var = relay.var("scale", shape=(), dtype="float32")
-    zp_var = relay.var("zp", shape=(), dtype="int32")
-
-    q_x = relay.qnn.op.quantize(x, scale_var * scale_var, zp_var + zp_var)
-    tt = run_infer_type(q_x)
-
-    assert tt.checked_type == relay.TensorType((1, 2, 3, 4), "int8")
-    func = relay.Function([x, scale_var, zp_var], q_x)
-    data = np.random.uniform(size=(1, 2, 3, 4)).astype("float32")
-    scale = np.array(1).astype("float32")
-    zp = np.array(0).astype("int32")
-
-    mod = tvm.ir.IRModule.from_expr(func)
-
-    for target, ctx in tvm.testing.enabled_targets():
-        # TODO: (electriclilies) enable AlterOpLayout when it is fixed
-        with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
-            lib = relay.build(mod, target=target)
-
-    module = graph_runtime.GraphModule(lib["default"](ctx))
-    module.set_input(**{"x": data, "scale": scale, "zp": zp})
-    module.run()
 
 
 def test_quantize_dynamic():

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -601,8 +601,3 @@ def test_quantize_dynamic():
             # Outputs from v1.6 seem reliable. TVM's outputs are always the same
             if is_version_greater_than("1.5.1"):
                 tvm.testing.assert_allclose(tvm_result, pt_result, rtol=1e-4, atol=1e-4)
-
-
-if __name__ == "__main__":
-    test_dequantize_dynamic_unit()
-    test_quantize_dynamic_unit()

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -508,55 +508,58 @@ def test_serialized_modules():
     match_ratio = num_identical / float(np.prod(tvm_result.shape))
     assert match_ratio > 0.90
 
+
 def test_dequantize_dynamic_unit():
-    x = relay.var('x', shape=(1, 2, 3, 4), dtype='int8')
-    scale_var = relay.var('scale', shape=(), dtype='float32')
-    zp_var = relay.var('zp', shape=(), dtype='int32')
+    x = relay.var("x", shape=(1, 2, 3, 4), dtype="int8")
+    scale_var = relay.var("scale", shape=(), dtype="float32")
+    zp_var = relay.var("zp", shape=(), dtype="int32")
 
     deq_x = relay.qnn.op.dequantize(x, scale_var * scale_var, zp_var + zp_var)
     tt = run_infer_type(deq_x)
 
     assert tt.checked_type == relay.TensorType((1, 2, 3, 4), "float32")
     func = relay.Function([x, scale_var, zp_var], deq_x)
-    data = np.random.uniform(size=(1, 2, 3, 4)).astype('int8')
-    scale = np.array(1).astype('float32')
-    zp = np.array(0).astype('int32')
+    data = np.random.uniform(size=(1, 2, 3, 4)).astype("int8")
+    scale = np.array(1).astype("float32")
+    zp = np.array(0).astype("int32")
 
     mod = tvm.ir.IRModule.from_expr(func)
 
     for target, ctx in tvm.testing.enabled_targets():
-        #TODO: (electriclilies) enable AlterOpLayout when it is fixed
+        # TODO: (electriclilies) enable AlterOpLayout when it is fixed
         with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
             lib = relay.build(mod, target=target)
-    
+
     module = graph_runtime.GraphModule(lib["default"](ctx))
-    module.set_input(**{'x': data, 'scale': scale, 'zp': zp})
+    module.set_input(**{"x": data, "scale": scale, "zp": zp})
     module.run()
-   
+
+
 def test_quantize_dynamic_unit():
-    x = relay.var('x', shape=(1, 2, 3, 4), dtype='float32')
-    scale_var = relay.var('scale', shape=(), dtype='float32')
-    zp_var = relay.var('zp', shape=(), dtype='int32')
+    x = relay.var("x", shape=(1, 2, 3, 4), dtype="float32")
+    scale_var = relay.var("scale", shape=(), dtype="float32")
+    zp_var = relay.var("zp", shape=(), dtype="int32")
 
     q_x = relay.qnn.op.quantize(x, scale_var * scale_var, zp_var + zp_var)
     tt = run_infer_type(q_x)
-    
+
     assert tt.checked_type == relay.TensorType((1, 2, 3, 4), "int8")
     func = relay.Function([x, scale_var, zp_var], q_x)
-    data = np.random.uniform(size=(1, 2, 3, 4)).astype('float32')
-    scale = np.array(1).astype('float32')
-    zp = np.array(0).astype('int32')
+    data = np.random.uniform(size=(1, 2, 3, 4)).astype("float32")
+    scale = np.array(1).astype("float32")
+    zp = np.array(0).astype("int32")
 
     mod = tvm.ir.IRModule.from_expr(func)
 
     for target, ctx in tvm.testing.enabled_targets():
-        #TODO: (electriclilies) enable AlterOpLayout when it is fixed
+        # TODO: (electriclilies) enable AlterOpLayout when it is fixed
         with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
             lib = relay.build(mod, target=target)
-    
+
     module = graph_runtime.GraphModule(lib["default"](ctx))
-    module.set_input(**{'x': data, 'scale': scale, 'zp': zp})
+    module.set_input(**{"x": data, "scale": scale, "zp": zp})
     module.run()
+
 
 def test_quantize_dynamic():
     # A wrapper is required for quantize_dynamic to work correctly
@@ -599,6 +602,7 @@ def test_quantize_dynamic():
             if is_version_greater_than("1.5.1"):
                 tvm.testing.assert_allclose(tvm_result, pt_result, rtol=1e-4, atol=1e-4)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_dequantize_dynamic_unit()
     test_quantize_dynamic_unit()

--- a/tests/python/relay/test_op_qnn_dequantize.py
+++ b/tests/python/relay/test_op_qnn_dequantize.py
@@ -20,6 +20,7 @@ from tvm import te
 import numpy as np
 from tvm import relay
 from tvm.contrib import graph_runtime
+from tvm.relay.testing import run_infer_type
 
 
 def dequantize_test_driver(in_dtype, quant_args, in_data, verify_output_data, axis):

--- a/tests/python/relay/test_op_qnn_dequantize.py
+++ b/tests/python/relay/test_op_qnn_dequantize.py
@@ -118,9 +118,36 @@ def test_channelwise_axis_0():
     )
 
 
+def test_dynamic_dequantize():
+    x = relay.var("x", shape=(1, 2, 3, 4), dtype="int8")
+    scale_var = relay.var("scale", shape=(), dtype="float32")
+    zp_var = relay.var("zp", shape=(), dtype="int32")
+
+    deq_x = relay.qnn.op.dequantize(x, scale_var * scale_var, zp_var + zp_var)
+    tt = run_infer_type(deq_x)
+
+    assert tt.checked_type == relay.TensorType((1, 2, 3, 4), "float32")
+    func = relay.Function([x, scale_var, zp_var], deq_x)
+    data = np.random.uniform(size=(1, 2, 3, 4)).astype("int8")
+    scale = np.array(1).astype("float32")
+    zp = np.array(0).astype("int32")
+
+    mod = tvm.ir.IRModule.from_expr(func)
+
+    for target, ctx in tvm.testing.enabled_targets():
+        # TODO: (electriclilies) enable AlterOpLayout when it is fixed
+        with relay.build_config(opt_level=3, disabled_pass=["AlterOpLayout"]):
+            lib = relay.build(mod, target=target)
+
+    module = graph_runtime.GraphModule(lib["default"](ctx))
+    module.set_input(**{"x": data, "scale": scale, "zp": zp})
+    module.run()
+
+
 if __name__ == "__main__":
     test_uint8_to_float32()
     test_int8_to_float32()
     test_int32_to_float32()
     test_channelwise_axis_1()
     test_channelwise_axis_0()
+    test_dynamic_dequantize()


### PR DESCRIPTION
This PR allows the qnn.op.dequantize op to accept dynamic scales and zero points. #6782 made similar changes to the qnn.quantize op. 

I also added unit tests to the qnn testing to make sure that the dynamic scale and zero points work for both quantize and dequantize.

@jwfromm @masahi Please take a look