### PR TITLE
[AutoScheduler] Add winograd support in tuning networks

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -132,13 +132,9 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                 )
             _, _, kh, kw = get_const_tuple(kernel.shape)
             if (
-                2 < kh < 8
-                and 2 < kw < 8
-                and kh == kw
-                and stride_h == 1
-                and stride_w == 1
-                and dilation_h == 1
-                and dilation_w == 1
+                (2 < kh < 8 and 2 < kw < 8 and kh == kw)
+                and (stride_h == 1 and stride_w == 1)
+                and (dilation_h == 1 and dilation_w == 1)
             ):
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.cuda.conv2d_nchw_winograd),
@@ -165,14 +161,10 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                 name="conv2d_nhwc.cuda",
             )
 
-            strategy.add_auto_scheduler(
-                wrap_compute_conv2d(topi.nn.conv2d_nhwc), name="conv2d_nhwc"
-            )
-
             N, H, W, _ = get_const_tuple(data.shape)
             KH, KW, CI, CO = get_const_tuple(kernel.shape)
             # Winograd shape related judgment
-            judge_winograd_tensorcore, judge_winograd_shape = winograd_judge(
+            judge_winograd_tensorcore, judge_winograd_shape = judge_winograd(
                 N,
                 H,
                 W,
@@ -206,19 +198,39 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                         name="conv2d_nhwc_winograd_direct.cuda",
                         plevel=5,
                     )
-            if target.kind.name == "cuda":
-                if nvcc.have_tensorcore(tvm.gpu(0).compute_version):
-                    if (
-                        (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
-                        or (N % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
-                        or (N % 32 == 0 and CI % 16 == 0 and CO % 8 == 0)
-                    ):
-                        strategy.add_implementation(
-                            wrap_compute_conv2d(topi.cuda.conv2d_nhwc_tensorcore),
-                            wrap_topi_schedule(topi.cuda.schedule_conv2d_nhwc_tensorcore),
-                            name="conv2d_nhwc_tensorcore.cuda",
-                            plevel=20,
-                        )
+            if (
+                target.kind.name == "cuda"
+                and nvcc.have_tensorcore(tvm.gpu(0).compute_version)
+                and (
+                    (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
+                    or (N % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
+                    or (N % 32 == 0 and CI % 16 == 0 and CO % 8 == 0)
+                )
+            ):
+                strategy.add_implementation(
+                    wrap_compute_conv2d(topi.cuda.conv2d_nhwc_tensorcore),
+                    wrap_topi_schedule(topi.cuda.schedule_conv2d_nhwc_tensorcore),
+                    name="conv2d_nhwc_tensorcore.cuda",
+                    plevel=20,
+                )
+
+            # register auto-scheduler implementations
+            judge_winograd_auto_scheduler = (
+                ("float" in data.dtype and "float" in kernel.dtype)
+                and (KH == 3 and KW == 3)
+                and (stride_h == 1 and stride_w == 1)
+                and (dilation_h == 1 and dilation_w == 1)
+            )
+
+            if judge_winograd_auto_scheduler:
+                strategy.add_auto_scheduler(
+                    wrap_compute_conv2d(topi.nn.conv2d_winograd_nhwc), name="conv2d_nhwc.winograd"
+                )
+            else:
+                strategy.add_auto_scheduler(
+                    wrap_compute_conv2d(topi.nn.conv2d_nhwc), name="conv2d_nhwc"
+                )
+
         elif layout == "HWNC":
             assert kernel_layout in ["HWOI", "HWOI16o16i", "HWOI8o32i", "HWOI32o16i"]
             _, _, N, in_channels = get_const_tuple(data.shape)
@@ -329,6 +341,39 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
     return strategy
 
 
+def judge_winograd(
+    N, H, W, KH, KW, CI, CO, padding, stride_h, stride_w, dilation_h, dilation_w, pre_flag
+):
+    """Winograd judgement about tensorcore and shape"""
+    if H % 8 == 0:
+        tile_size = 4
+    else:
+        tile_size = 2
+    if pre_flag:
+        alpha = KH
+        KH = KW = alpha + 1 - tile_size
+    pt, pl, pb, pr = topi.nn.get_pad_tuple(padding, (KH, KW))
+    OH = (H + pt + pb - KH) // stride_h + 1
+    OW = (W + pl + pr - KW) // stride_w + 1
+    nH, nW = (OH + tile_size - 1) // tile_size, (OW + tile_size - 1) // tile_size
+    P = N * nH * nW
+    judge_winograd_tensorcore = (
+        (P % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
+        or (P % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
+        or (P % 32 == 0 and CI % 16 == 0 and CO % 8 == 0)
+    )
+    judge_winograd_shape = (
+        2 < KH < 8
+        and 2 < KW < 8
+        and KH == KW
+        and stride_h == 1
+        and stride_w == 1
+        and dilation_h == 1
+        and dilation_w == 1
+    )
+    return judge_winograd_tensorcore, judge_winograd_shape
+
+
 @conv2d_winograd_without_weight_transfrom_strategy.register(["cuda", "gpu"])
 def conv2d_winograd_without_weight_transfrom_strategy_cuda(attrs, inputs, out_type, target):
     """conv2d_winograd_without_weight_transfrom cuda strategy"""
@@ -351,7 +396,7 @@ def conv2d_winograd_without_weight_transfrom_strategy_cuda(attrs, inputs, out_ty
         N, H, W, _ = get_const_tuple(data.shape)
         alpha, _, CI, CO = get_const_tuple(kernel.shape)
         dilation_h, dilation_w = dilation
-        judge_winograd_tensorcore, _ = winograd_judge(
+        judge_winograd_tensorcore, _ = judge_winograd(
             N,
             H,
             W,
@@ -388,6 +433,12 @@ def conv2d_winograd_without_weight_transfrom_strategy_cuda(attrs, inputs, out_ty
                 ),
                 name="conv2d_nhwc_winograd_direct_without_weight_transform.cuda",
             )
+
+        # register auto-scheduler implementations
+        strategy.add_auto_scheduler(
+            wrap_compute_conv2d(topi.nn.conv2d_winograd_nhwc_without_weight_transform),
+            name="conv2d_nhwc_winograd_without_weight_transform",
+        )
     else:
         raise RuntimeError(
             "Unsupported conv2d_winograd_without_weight_transfrom layout {}".format(layout)
@@ -833,39 +884,6 @@ def proposal_strategy_cuda(attrs, inputs, out_type, target):
         name="proposal.cuda",
     )
     return strategy
-
-
-def winograd_judge(
-    N, H, W, KH, KW, CI, CO, padding, stride_h, stride_w, dilation_h, dilation_w, pre_flag
-):
-    """Winograd judgement about tensorcore and shape"""
-    if H % 8 == 0:
-        tile_size = 4
-    else:
-        tile_size = 2
-    if pre_flag:
-        alpha = KH
-        KH = KW = alpha + 1 - tile_size
-    pt, pl, pb, pr = topi.nn.get_pad_tuple(padding, (KH, KW))
-    OH = (H + pt + pb - KH) // stride_h + 1
-    OW = (W + pl + pr - KW) // stride_w + 1
-    nH, nW = (OH + tile_size - 1) // tile_size, (OW + tile_size - 1) // tile_size
-    P = N * nH * nW
-    judge_winograd_tensorcore = (
-        (P % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
-        or (P % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
-        or (P % 32 == 0 and CI % 16 == 0 and CO % 8 == 0)
-    )
-    judge_winograd_shape = (
-        2 < KH < 8
-        and 2 < KW < 8
-        and KH == KW
-        and stride_h == 1
-        and stride_w == 1
-        and dilation_h == 1
-        and dilation_w == 1
-    )
-    return judge_winograd_tensorcore, judge_winograd_shape
 
 
 @correlation_strategy.register(["cuda", "gpu"])

--- a/python/tvm/topi/nn/conv2d.py
+++ b/python/tvm/topi/nn/conv2d.py
@@ -943,3 +943,212 @@ def unpack_NCHWc_to_nchw(packed_out, out_dtype):
         tag=tag.INJECTIVE + ",unpack_nchwc",
     )
     return unpacked_out
+
+
+def _conv2d_winograd_nhwc_impl(
+    data,
+    weight,
+    strides,
+    padding,
+    dilation,
+    out_dtype,
+    tile_size,
+    pre_computed=False,
+):
+    """Conv2D Winograd implementation in NHWC layout.
+    This is a clean version to be used by the auto-scheduler for both CPU and GPU.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        4-D with shape [batch, in_height, in_width, in_channel]
+    weight : tvm.Tensor
+        4-D with shape [filter_height, filter_width, in_channel, num_filter]
+    strides : int or a list/tuple of two ints
+        stride size, or [stride_height, stride_width]
+    padding : int or a list/tuple of two ints
+        padding size, or [pad_height, pad_width]
+    dilation: int or a list/tuple of two ints
+        dilation size, or [dilation_height, dilation_width]
+    out_dtype : str, optional
+        Specifies the output data type.
+    tile_size : int
+        The size of the tile to use for the Winograd filter
+    pre_computed: bool
+        Whether the kernel is precomputed
+
+    Returns
+    -------
+    output : tvm.Tensor
+        4-D with shape [batch, out_height, out_width, out_channel]
+    """
+    N, H, W, CI = get_const_tuple(data.shape)
+    if isinstance(dilation, int):
+        dilation_h = dilation_w = dilation
+    else:
+        dilation_h, dilation_w = dilation
+
+    assert (dilation_h, dilation_w) == (1, 1), "Does not support dilation"
+    if not pre_computed:
+        KH, KW, CI, CO = get_const_tuple(weight.shape)
+    else:
+        H_CAT, W_CAT, CO, CI = get_const_tuple(weight.shape)
+        KH, KW = H_CAT - tile_size + 1, W_CAT - tile_size + 1
+
+    pad_t, pad_l, pad_b, pad_r = get_pad_tuple(padding, (KH, KW))
+    HSTR, WSTR = (strides, strides) if isinstance(strides, int) else strides
+    assert HSTR == 1 and WSTR == 1 and KH == 3 and KW == 3
+
+    r = KW
+    m = tile_size
+    alpha = m + r - 1
+    A, B, G = winograd_transform_matrices(m, r, out_dtype)
+
+    H = (H + pad_t + pad_b - KH) // HSTR + 1
+    W = (W + pad_l + pad_r - KW) // WSTR + 1
+    nH, nW = (H + m - 1) // m, (W + m - 1) // m
+    P = N * nH * nW
+
+    pad_extra = (nW - 1) * m + alpha - (H + pad_t + pad_b)
+    data_pad = pad(
+        data, (0, pad_t, pad_l, 0), (0, pad_b + pad_extra, pad_r + pad_extra, 0), name="data_pad"
+    )
+
+    if not pre_computed:
+        r_kh = te.reduce_axis((0, KH), name="r_kh")
+        r_kw = te.reduce_axis((0, KW), name="r_kw")
+        kernel_pack = te.compute(
+            (alpha, alpha, CO, CI),
+            lambda eps, nu, co, ci: te.sum(
+                weight[r_kh][r_kw][ci][co] * G[eps][r_kh] * G[nu][r_kw], axis=[r_kh, r_kw]
+            ),
+            name="kernel_pack",
+        )
+    else:
+        kernel_pack = weight
+
+    # pack data tile
+    input_tile = te.compute(
+        (alpha, alpha, P, CI),
+        lambda eps, nu, p, ci: data_pad[p // (nH * nW)][((p // nW) % nH) * m + eps][
+            (p % nW) * m + nu
+        ][ci],
+        name="input_tile",
+    )
+
+    # transform data
+    r_a = te.reduce_axis((0, alpha), "r_a")
+    r_b = te.reduce_axis((0, alpha), "r_b")
+    data_pack = te.compute(
+        (alpha, alpha, P, CI),
+        lambda eps, nu, p, ci: te.sum(
+            input_tile[r_a][r_b][p][ci] * B[r_a][eps] * B[r_b][nu], axis=[r_a, r_b]
+        ),
+        name="data_pack",
+        attrs={"auto_scheduler_simplify_const_tensor_indices": ["eps", "nu", "r_a", "r_b"]},
+    )
+
+    # do batch gemm
+    ci = te.reduce_axis((0, CI), name="ci")
+    bgemm = te.compute(
+        (alpha, alpha, P, CO),
+        lambda eps, nu, p, co: te.sum(
+            data_pack[eps][nu][p][ci] * kernel_pack[eps][nu][co][ci], axis=[ci]
+        ),
+        name="bgemm",
+        attrs={"layout_free_placeholders": [kernel_pack]},
+    )
+
+    # inverse transform
+    r_a = te.reduce_axis((0, alpha), "r_a")
+    r_b = te.reduce_axis((0, alpha), "r_b")
+    inverse = te.compute(
+        (m, m, P, CO),
+        lambda vh, vw, p, co: te.sum(
+            bgemm[r_a][r_b][p][co] * A[r_a][vh] * A[r_b][vw], axis=[r_a, r_b]
+        ),
+        name="inverse",
+        attrs={"auto_scheduler_simplify_const_tensor_indices": ["vh", "vw", "r_a", "r_b"]},
+    )
+
+    # output
+    output = te.compute(
+        (N, H, W, CO),
+        lambda n, h, w, co: inverse[h % m, w % m, n * nH * nW + (h // m) * nW + (w // m), co],
+        name="conv2d_winograd",
+    )
+
+    return output
+
+
+@tvm.target.generic_func
+def conv2d_winograd_nhwc(data, weight, strides, padding, dilation, out_dtype, pre_computed=False):
+    """Conv2D Winograd in NHWC layout.
+    This is a clean version to be used by the auto-scheduler for both CPU and GPU.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        4-D with shape [batch, in_height, in_width, in_channel]
+    weight : tvm.Tensor
+        4-D with shape [filter_height, filter_width, in_channel, num_filter]
+    strides : int or a list/tuple of two ints
+        stride size, or [stride_height, stride_width]
+    padding : int or a list/tuple of two ints
+        padding size, or [pad_height, pad_width]
+    dilation: int or a list/tuple of two ints
+        dilation size, or [dilation_height, dilation_width]
+    out_dtype : str, optional
+        Specifies the output data type.
+    pre_computed: bool
+        Whether the kernel is precomputed
+
+    Returns
+    -------
+    output : tvm.Tensor
+        4-D with shape [batch, out_height, out_width, out_channel]
+    """
+    tile_size = 4
+
+    return _conv2d_winograd_nhwc_impl(
+        data,
+        weight,
+        strides,
+        padding,
+        dilation,
+        out_dtype,
+        tile_size,
+        pre_computed,
+    )
+
+
+def conv2d_winograd_nhwc_without_weight_transform(
+    data, weight, strides, padding, dilation, out_dtype
+):
+    """Conv2D Winograd without layout transform in NHWC layout.
+    This is a clean version to be used by the auto-scheduler for both CPU and GPU.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        4-D with shape [batch, in_height, in_width, in_channel]
+    weight : tvm.Tensor
+        4-D with shape [filter_height, filter_width, in_channel, num_filter]
+    strides : int or a list/tuple of two ints
+        stride size, or [stride_height, stride_width]
+    padding : int or a list/tuple of two ints
+        padding size, or [pad_height, pad_width]
+    dilation: int or a list/tuple of two ints
+        dilation size, or [dilation_height, dilation_width]
+    out_dtype : str, optional
+        Specifies the output data type.
+
+    Returns
+    -------
+    output : tvm.Tensor
+        4-D with shape [batch, out_height, out_width, out_channel]
+    """
+
+    return conv2d_winograd_nhwc(
+        data, weight, strides, padding, dilation, out_dtype, pre_computed=True
+    )

--- a/python/tvm/topi/nn/conv2d.py
+++ b/python/tvm/topi/nn/conv2d.py
@@ -1046,6 +1046,7 @@ def _conv2d_winograd_nhwc_impl(
         ),
         name="data_pack",
         attrs={"auto_scheduler_simplify_const_tensor_indices": ["eps", "nu", "r_a", "r_b"]},
+        # the attrs are necessary hints for the auto-scheduler
     )
 
     # do batch gemm
@@ -1069,6 +1070,7 @@ def _conv2d_winograd_nhwc_impl(
         ),
         name="inverse",
         attrs={"auto_scheduler_simplify_const_tensor_indices": ["vh", "vw", "r_a", "r_b"]},
+        # the attrs are necessary hints for the auto-scheduler
     )
 
     # output

--- a/src/auto_scheduler/search_policy/sketch_policy.cc
+++ b/src/auto_scheduler/search_policy/sketch_policy.cc
@@ -116,8 +116,8 @@ SketchPolicy::SketchPolicy(SearchTask task, CostModel program_cost_model,
   } else if (IsGPUTask(node->search_task)) {
     // Sketch Generation Rules
     node->sketch_rules.push_back(&rule_add_cache_read_stage);
-    node->sketch_rules.push_back(&rule_always_inline);
     node->sketch_rules.push_back(&rule_special_compute_location_gpu);
+    node->sketch_rules.push_back(&rule_always_inline);
     node->sketch_rules.push_back(&rule_simplify_compute_with_const_tensor);
     node->sketch_rules.push_back(&rule_cross_thread_reduction);
     node->sketch_rules.push_back(&rule_add_cache_write_stage);

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -43,6 +43,29 @@ def get_network(name, batch_size=1, layout="NHWC"):
         mod, params = relay.testing.resnet.get_workload(
             num_layers=50, batch_size=batch_size, layout=layout, image_shape=image_shape
         )
+    elif name == "winograd-test":
+        input_shape = [1, 7, 7, 64]
+        output_shape = input_shape
+
+        data = relay.var("data", shape=input_shape, dtype="float32")
+        net = relay.testing.layers.conv2d(
+            data=data,
+            channels=64,
+            kernel_size=3,
+            strides=1,
+            padding=1,
+            data_layout="NHWC",
+            kernel_layout="HWIO",
+            name="",
+        )
+        bias = relay.var("conv1_bias")
+        net = relay.nn.bias_add(net, bias, 3)
+        net = relay.nn.relu(net)
+        mod, params = relay.testing.create_workload(net)
+    elif name == "resnet3d-18":
+        mod, params = relay.testing.resnet_3d.get_workload(
+            num_layers=18, batch_size=batch_size, layout=layout, image_shape=image_shape
+        )
     elif name == "mobilenet":
         mod, params = relay.testing.mobilenet.get_workload(
             batch_size=batch_size, layout=layout, image_shape=image_shape

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -23,13 +23,12 @@ from tvm import auto_scheduler, relay
 from test_auto_scheduler_task_extraction import get_network
 
 
-@tvm.testing.requires_cuda
-def test_tuning_cuda():
+def tune_network(network, target):
     auto_scheduler.enable_relay_integration()
 
     # Extract tasks
-    mod, params = get_network("mlp")
-    target = tvm.target.Target("cuda")
+    mod, params = get_network(network)
+    target = tvm.target.Target(target)
     tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
     objective = lambda costs: sum(c * w for c, w in zip(costs, task_weights))
 
@@ -43,6 +42,7 @@ def test_tuning_cuda():
             num_measure_trials=2,
             num_measures_per_round=1,
             runner=measure_ctx.runner,
+            builder=auto_scheduler.LocalBuilder(timeout=100),
             measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
         )
         tuner.tune(tune_option, search_policy="sketch.random")
@@ -53,9 +53,17 @@ def test_tuning_cuda():
             with tvm.transform.PassContext(opt_level=3):
                 lib = relay.build(mod, target=target, params=params)
 
-    # Todo(merrymercy): compile without any history to test the fallback mechanism
+    # Todo(merrymercy): when the cpu backend is upstreamed, do the following things:
+    # 1. compile without history to test the fallback mechanism
+    # 2. check the correctness of layout rewrite / winograd pre-transform
 
     auto_scheduler.enable_relay_integration(False)
+
+
+@tvm.testing.requires_cuda
+def test_tuning_cuda():
+    tune_network("mlp", "cuda")
+    tune_network("winograd-test", "cuda")
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -39,8 +39,8 @@ def tune_network(network, target):
         measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=100)
         tuner = auto_scheduler.TaskScheduler(tasks, objective)
         tune_option = auto_scheduler.TuningOptions(
-            num_measure_trials=2,
-            num_measures_per_round=1,
+            num_measure_trials=4,
+            num_measures_per_round=2,
             runner=measure_ctx.runner,
             builder=auto_scheduler.LocalBuilder(timeout=100),
             measure_callbacks=[auto_scheduler.RecordToFile(log_file)],

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -36,13 +36,13 @@ def tune_network(network, target):
         log_file = fp.name
 
         # Tuning
-        measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=100)
+        measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=60)
         tuner = auto_scheduler.TaskScheduler(tasks, objective)
         tune_option = auto_scheduler.TuningOptions(
             num_measure_trials=4,
             num_measures_per_round=2,
             runner=measure_ctx.runner,
-            builder=auto_scheduler.LocalBuilder(timeout=100),
+            builder=auto_scheduler.LocalBuilder(timeout=60),
             measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
         )
         tuner.tune(tune_option, search_policy="sketch.random")

--- a/tests/python/topi/python/test_topi_conv2d_nhwc_winograd.py
+++ b/tests/python/topi/python/test_topi_conv2d_nhwc_winograd.py
@@ -74,7 +74,7 @@ def verify_conv2d_nhwc(
     bias_shape = get_const_tuple(bias.shape)
     dtype = A.dtype
 
-    @memoize("topi.tests.test_topi_conv2d_nhwc.verify_conv2d_nhwc")
+    @memoize("topi.tests.test_topi_conv2d_nhwc_winograd.verify_conv2d_nhwc")
     def get_ref_data():
         a_np = np.random.uniform(size=a_shape).astype(dtype)
         w_np = np.random.uniform(size=w_shape).astype(dtype)

--- a/tests/python/topi/python/test_topi_conv2d_winograd.py
+++ b/tests/python/topi/python/test_topi_conv2d_winograd.py
@@ -244,5 +244,5 @@ def test_conv2d_nhwc():
 
 
 if __name__ == "__main__":
-    # test_conv2d_nchw()
+    test_conv2d_nchw()
     test_conv2d_nhwc()

--- a/tests/python/topi/python/test_topi_conv2d_winograd.py
+++ b/tests/python/topi/python/test_topi_conv2d_winograd.py
@@ -67,7 +67,7 @@ def verify_conv2d_nchw(
     bias_shape = get_const_tuple(bias.shape)
     dtype = A.dtype
 
-    @memoize("topi.tests.test_topi_conv2d_nchw.verify_conv2d_nchw")
+    @memoize("topi.tests.test_topi_conv2d_winograd.verify_conv2d_nhwc")
     def get_ref_data():
         a_np = np.random.uniform(size=a_shape).astype(dtype)
         w_np = np.random.uniform(size=w_shape).astype(dtype)
@@ -140,7 +140,6 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1, 128, 28, 128, 3, 1, 1)
     verify_conv2d_nchw(1, 256, 14, 256, 3, 1, 1)
     verify_conv2d_nchw(1, 512, 7, 512, 3, 1, 1)
-    verify_conv2d_nchw(1, 48, 35, 64, 5, 1, 2, devices=["cuda"])
 
     # batch size = 2
     verify_conv2d_nchw(2, 64, 56, 64, 3, 1, 1)
@@ -154,6 +153,7 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1, 1, 1, 1, 3, 1, 1)
     verify_conv2d_nchw(3, 3, 3, 3, 3, 1, 1)
     verify_conv2d_nchw(2, 13, 71, 59, 3, 1, 1)
+    verify_conv2d_nchw(1, 48, 35, 64, 5, 1, 2, devices=["cuda"])
 
     # Asymmetric padding
     verify_conv2d_nchw(1, 48, 56, 48, 3, 1, (1, 1, 1, 1))
@@ -170,5 +170,79 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1, 48, 35, 48, 5, 1, "VALID", devices=["cuda"])
 
 
+def verify_conv2d_nhwc(
+    batch,
+    in_channel,
+    in_size,
+    num_filter,
+    kernel,
+    stride,
+    padding,
+    dilation=1,
+):
+    # This version is intented to be used by the auto-scheduler,
+    # so we only test the correctness of compute declaration
+    # with the default naive schedule in cpu
+
+    A = te.placeholder((batch, in_size, in_size, in_channel), name="A")
+    W = te.placeholder((kernel, kernel, in_channel, num_filter), name="W")
+    bias = te.placeholder((1, 1, 1, num_filter), name="bias")
+
+    a_shape = get_const_tuple(A.shape)
+    w_shape = get_const_tuple(W.shape)
+    bias_shape = get_const_tuple(bias.shape)
+    dtype = A.dtype
+
+    @memoize("topi.tests.test_topi_conv2d_winograd.verify_conv2d_nhwc")
+    def get_ref_data():
+        a_np = np.random.uniform(size=a_shape).astype(dtype)
+        w_np = np.random.uniform(size=w_shape).astype(dtype)
+        b_np = np.random.uniform(size=bias_shape).astype(dtype)
+        dw_np = tvm.topi.testing.dilate_python(w_np, (dilation, dilation, 1, 1))
+        c_np = tvm.topi.testing.conv2d_nhwc_python(a_np, dw_np, stride, padding)
+        return a_np, w_np, b_np, c_np
+
+    a_np, w_np, b_np, c_np = get_ref_data()
+
+    target = "llvm"
+    ctx = tvm.context(target)
+
+    C = topi.nn.conv2d_winograd_nhwc(A, W, stride, padding, dilation, dtype)
+    s = te.create_schedule([C.op])
+
+    a = tvm.nd.array(a_np, ctx=ctx)
+    w = tvm.nd.array(w_np, ctx=ctx)
+    b = tvm.nd.array(b_np, ctx=ctx)
+    c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), ctx=ctx)
+    func = tvm.build(s, [A, W, C], target=target)
+    func(a, w, c)
+
+    rtol = 1e-3
+    tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=rtol)
+
+
+def test_conv2d_nhwc():
+    # This version is intented to be used by the auto-scheduler,
+    # so we only test the correctness of compute declaration
+    # with the default naive schedule in cpu
+
+    # resnet 18 workloads
+    verify_conv2d_nhwc(1, 64, 56, 64, 3, 1, 1)
+    verify_conv2d_nhwc(1, 128, 28, 128, 3, 1, 1)
+    verify_conv2d_nhwc(1, 256, 14, 256, 3, 1, 1)
+    verify_conv2d_nhwc(1, 512, 7, 512, 3, 1, 1)
+
+    # more shapes
+    verify_conv2d_nhwc(2, 64, 56, 64, 3, 1, 1)
+    verify_conv2d_nhwc(1, 1, 1, 1, 3, 1, 1)
+    verify_conv2d_nhwc(3, 3, 3, 3, 3, 1, 1)
+    verify_conv2d_nhwc(2, 13, 71, 59, 3, 1, 1)
+
+    # Asymmetric padding
+    verify_conv2d_nhwc(1, 3, 7, 3, 3, 1, "SAME")
+    verify_conv2d_nhwc(1, 48, 35, 48, 3, 1, "VALID")
+
+
 if __name__ == "__main__":
-    test_conv2d_nchw()
+    # test_conv2d_nchw()
+    test_conv2d_nhwc()

--- a/tests/python/unittest/test_auto_scheduler_sketch_generation.py
+++ b/tests/python/unittest/test_auto_scheduler_sketch_generation.py
@@ -370,18 +370,19 @@ def test_cuda_conv2d_winograd_sketch():
     """ 1 multi-level tiling sketch """
     assert len(sketches) == 1
     assert_compute_at_condition(sketches[0].stages[1], "inlined")
-    assert_compute_at_condition(sketches[0].stages[2], "inlined")
+    assert_compute_at_condition(sketches[0].stages[2], "iter")
     assert_compute_at_condition(sketches[0].stages[3], "inlined")
     assert_is_tiled(sketches[0].stages[4])
     assert_has_cache_read(sketches[0], 4)
     assert_compute_at_condition(sketches[0].stages[5], "iter")
     assert_has_cache_read(sketches[0], 6)
     assert_compute_at_condition(sketches[0].stages[7], "iter")
-    assert_is_not_tiled(sketches[0].stages[8])
+    assert_is_tiled(sketches[0].stages[8])
     assert_compute_at_condition(sketches[0].stages[8], "iter")
-    assert_compute_at_condition(sketches[0].stages[9], "inlined")
-    assert_is_tiled(sketches[0].stages[10])
-    assert_is_not_tiled(sketches[0].stages[11])
+    assert_has_cache_write(sketches[0], 8)
+    assert_compute_at_condition(sketches[0].stages[9], "root")
+    assert_is_tiled(sketches[0].stages[11])
+    assert_is_not_tiled(sketches[0].stages[12])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the Winograd support for NHWC layout.

Now it is only enabled for GPU backend, but the CPU backend uses the same compute declaration. I will enable it in later PRs.

cc @jcf94 @FrozenGene @comaniac 