### PR TITLE
[CI] Install libc6-dev-i386 to compile wasm32

### DIFF
--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -32,7 +32,7 @@ rustup component add rustfmt
 # install wasmtime
 apt-get install -y --no-install-recommends libc6-dev-i386
 export WASMTIME_HOME=/opt/wasmtime
-bash <(curl https://wasmtime.dev/install.sh -sSf) --version v0.16.0
+curl https://wasmtime.dev/install.sh -sSf | bash
 export PATH="${WASMTIME_HOME}/bin:${PATH}"
 rustup target add wasm32-wasi
 

--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -30,8 +30,9 @@ curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default
 rustup component add rustfmt
 
 # install wasmtime
+apt-get install -y --no-install-recommends libc6-dev-i386
 export WASMTIME_HOME=/opt/wasmtime
-curl https://wasmtime.dev/install.sh -sSf | bash
+bash <(curl https://wasmtime.dev/install.sh -sSf) --version v0.16.0
 export PATH="${WASMTIME_HOME}/bin:${PATH}"
 rustup target add wasm32-wasi
 


### PR DESCRIPTION
The wasm32 test [doesn't work](https://github.com/apache/incubator-tvm/issues/6816#issue-734113134) with the current wasmtime (after the commit https://github.com/bytecodealliance/wasmtime/pull/1565).  It seems that we cannot generate a wasm binary which is compatible with the new WASI ABI.

This PR pins the wasmtime version to v0.16.0, the latest stable version which can work with our wasm32 test, and makes #6871 pass the CI.  This also installs libc6-dev-i386 needed for wasm32 compilation.

@jroesch @tqchen @nhynes 
