### PR TITLE
[GCC] Fix GCC8.1 and GCC8.2 template dispatch compilation issue

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -413,6 +413,12 @@ inline void SetIntValue(T* ptr, const TVMArgValue& val) {
   }
 }
 
+// Workaround for GCC8.1 / GCC8.2
+template <>
+inline void SetValue<DataType>(DataType* ptr, const TVMArgValue& val) {
+  *ptr = val.operator DataType();
+}
+
 template <>
 inline void SetValue<std::string>(std::string* ptr, const TVMArgValue& val) {
   if (String::CanConvertFrom(val)) {


### PR DESCRIPTION
Solve https://github.com/apache/incubator-tvm/issues/6891

I could confirm this is the same issue of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86246 and https://github.com/apache/incubator-tvm/pull/1304

GCC 8.3 solves this issue.
