### PR TITLE
[CMake] Fix the cmake error for TensorRT

### DIFF
--- a/cmake/modules/contrib/TensorRT.cmake
+++ b/cmake/modules/contrib/TensorRT.cmake
@@ -18,6 +18,9 @@
 # TensorRT Codegen only. This can be enabled independently of USE_TENSORRT_RUNTIME to enable
 # compilation of TensorRT modules without requiring TensorRT to be installed. The compiled modules
 # will only be able to be executed using a TVM built with USE_TENSORRT_RUNTIME=ON.
+
+include (FindPackageHandleStandardArgs)
+
 if(USE_TENSORRT_CODEGEN)
     message(STATUS "Build with TensorRT codegen")
     file(GLOB COMPILER_TENSORRT_SRCS src/relay/backend/contrib/tensorrt/*.cc)


### PR DESCRIPTION
Fix the cmake error when using TensorRT: 
```
CMake Error at cmake/modules/contrib/TensorRT.cmake:39 (find_package_handle_standard_args):
  Unknown CMake command "find_package_handle_standard_args".
```

Thanks the help from @trevor-m 
