### PR TITLE
[Runtime] Support appending new item into runtime::Array

### DIFF
--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -352,7 +352,7 @@ class ArrayNode : public Object, public InplaceArrayBase<ArrayNode, ObjectRef> {
    */
   void push_back(const ObjectRef item) {
     EnlargeBy(1);
-    SetItem(this->size_-1, item);
+    SetItem(this->size_ - 1, item);
   }
 
   /*!

--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -347,6 +347,15 @@ class ArrayNode : public Object, public InplaceArrayBase<ArrayNode, ObjectRef> {
   void clear() { ShrinkBy(size_); }
 
   /*!
+   * \brief push a new item to the back of the list
+   * \param item The item to be pushed.
+   */
+  void push_back(const ObjectRef item) {
+    EnlargeBy(1);
+    SetItem(this->size_-1, item);
+  }
+
+  /*!
    * \brief Set i-th element of the array in-place
    * \param i The index
    * \param item The value to be set

--- a/python/tvm/ir/container.py
+++ b/python/tvm/ir/container.py
@@ -38,6 +38,9 @@ class Array(Object):
     def __len__(self):
         return _ffi_node_api.ArraySize(self)
 
+    def append(self, item):
+        return _ffi_node_api.ArrayAppendItem(self, item)
+
 
 @tvm._ffi.register_object
 class Map(Object):

--- a/src/node/container.cc
+++ b/src/node/container.cc
@@ -187,6 +187,16 @@ TVM_REGISTER_GLOBAL("node.ArraySize").set_body([](TVMArgs args, TVMRetValue* ret
   *ret = static_cast<int64_t>(static_cast<const ArrayNode*>(ptr)->size());
 });
 
+TVM_REGISTER_GLOBAL("node.ArrayAppendItem").set_body([](TVMArgs args, TVMRetValue* ret) {
+  ObjectRef item = args[1];
+  ICHECK_EQ(args[0].type_code(), kTVMObjectHandle);
+  Object* ptr = static_cast<Object*>(args[0].value().v_handle);
+  ICHECK(ptr->IsInstance<ArrayNode>());
+  auto* n = static_cast<ArrayNode*>(ptr);
+  n->push_back(item);
+  *ret = static_cast<int64_t>(n->size());
+});
+
 struct MapNodeTrait {
   static constexpr const std::nullptr_t VisitAttrs = nullptr;
 

--- a/tests/python/unittest/test_ir_container.py
+++ b/tests/python/unittest/test_ir_container.py
@@ -30,6 +30,7 @@ def test_array():
     assert len(a) == 4
     assert a[-1].value == 4
 
+
 def test_array_save_load_json():
     a = tvm.runtime.convert([1, 2, 3])
     json_str = tvm.ir.save_json(a)

--- a/tests/python/unittest/test_ir_container.py
+++ b/tests/python/unittest/test_ir_container.py
@@ -26,6 +26,9 @@ def test_array():
     a_slice = a[-3:-1]
     assert (a_slice[0].value, a_slice[1].value) == (1, 2)
 
+    a.append(tvm.runtime.convert(4))
+    assert len(a) == 4
+    assert a[-1].value == 4
 
 def test_array_save_load_json():
     a = tvm.runtime.convert([1, 2, 3])


### PR DESCRIPTION
This PR improves the runtime::Array in #5585 by adding support to append new item in Python side, and push_back a new item in C++.

 