### PR TITLE
Consolidate RPC Context helper functions

### DIFF
--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -243,9 +243,7 @@ inline const char* DeviceName(int type) {
 /*!
  * \brief Return true if a TVMContext is owned by an RPC session.
  */
-inline bool IsRPCSessionContext(TVMContext ctx) {
-  return (ctx.device_type / kRPCSessMask) > 0;
-}
+inline bool IsRPCSessionContext(TVMContext ctx) { return (ctx.device_type / kRPCSessMask) > 0; }
 
 /*!
  * \brief Return the RPCSessTable index of the RPC Session that owns this context.
@@ -279,9 +277,9 @@ inline std::ostream& operator<<(std::ostream& os, DLContext ctx);
  */
 inline TVMContext AddRPCSessionMask(TVMContext ctx, int session_table_index) {
   CHECK(!IsRPCSessionContext(ctx))
-    << "AddRPCSessionMask: ctx already non-zero RPCSessionIndex: " << ctx;
-  ctx.device_type = static_cast<DLDeviceType>(
-    ctx.device_type | (kRPCSessMask * (session_table_index + 1)));
+      << "AddRPCSessionMask: ctx already non-zero RPCSessionIndex: " << ctx;
+  ctx.device_type =
+      static_cast<DLDeviceType>(ctx.device_type | (kRPCSessMask * (session_table_index + 1)));
   return ctx;
 }
 

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -240,13 +240,57 @@ inline const char* DeviceName(int type) {
   }
 }
 
+/*!
+ * \brief Return true if a TVMContext is owned by an RPC session.
+ */
+inline bool IsRPCSessionContext(TVMContext ctx) {
+  return (ctx.device_type / kRPCSessMask) > 0;
+}
+
+/*!
+ * \brief Return the RPCSessTable index of the RPC Session that owns this context.
+ * \return the table index.
+ */
+inline int GetRPCSessionIndex(TVMContext ctx) {
+  ICHECK(IsRPCSessionContext(ctx)) << "GetRPCSessionIndex: ctx has no RPC session";
+  return ctx.device_type / kRPCSessMask - 1;
+}
+
+/*!
+ * \brief Remove the RPC session mask from a TVMContext.
+ * RPC clients typically do this when encoding a TVMContext for transmission to an RPC remote.
+ * On the wire, RPCContext are expected to be valid on the server without interpretation.
+ * \param ctx A TVMContext with non-zero RPC Session mask, valid on the RPC client.
+ * \return A TVMContext without any RPC Session mask, valid on the RPC server.
+ */
+inline TVMContext RemoveRPCSessionMask(TVMContext ctx) {
+  ctx.device_type = static_cast<DLDeviceType>(ctx.device_type % kRPCSessMask);
+  return ctx;
+}
+
+inline std::ostream& operator<<(std::ostream& os, DLContext ctx);
+
+/*!
+ * \brief Add a RPC session mask to a TVMContext.
+ * RPC clients typically do this when decoding a TVMContext received from a RPC remote.
+ * \param ctx A TVMContext without any RPC Session mask, valid on the RPC server.
+ * \param session_table_index Numeric index of the RPC session in the session table.
+ * \return A TVMContext with RPC session mask added, valid on the RPC client.
+ */
+inline TVMContext AddRPCSessionMask(TVMContext ctx, int session_table_index) {
+  CHECK(!IsRPCSessionContext(ctx))
+    << "AddRPCSessionMask: ctx already non-zero RPCSessionIndex: " << ctx;
+  ctx.device_type = static_cast<DLDeviceType>(
+    ctx.device_type | (kRPCSessMask * (session_table_index + 1)));
+  return ctx;
+}
+
 inline std::ostream& operator<<(std::ostream& os, DLContext ctx) {  // NOLINT(*)
-  int device_type = static_cast<int>(ctx.device_type);
-  if (device_type > kRPCSessMask) {
-    os << "remote[" << (device_type / kRPCSessMask) << "]-";
-    device_type = device_type % kRPCSessMask;
+  if (IsRPCSessionContext(ctx)) {
+    os << "remote[" << GetRPCSessionIndex(ctx) << "]-";
+    ctx = RemoveRPCSessionMask(ctx);
   }
-  os << runtime::DeviceName(device_type) << "(" << ctx.device_id << ")";
+  os << runtime::DeviceName(static_cast<int>(ctx.device_type)) << "(" << ctx.device_id << ")";
   return os;
 }
 }  // namespace runtime

--- a/src/runtime/rpc/rpc_device_api.cc
+++ b/src/runtime/rpc/rpc_device_api.cc
@@ -34,19 +34,19 @@ namespace runtime {
 class RPCDeviceAPI final : public DeviceAPI {
  public:
   void SetDevice(TVMContext ctx) final {
-    auto remote_ctx = RemoveSessMask(ctx);
+    auto remote_ctx = RemoveRPCSessionMask(ctx);
     GetSess(ctx)->GetDeviceAPI(remote_ctx)->SetDevice(remote_ctx);
   }
 
   void GetAttr(TVMContext ctx, DeviceAttrKind kind, TVMRetValue* rv) final {
-    auto remote_ctx = RemoveSessMask(ctx);
+    auto remote_ctx = RemoveRPCSessionMask(ctx);
     GetSess(ctx)->GetDeviceAPI(remote_ctx)->GetAttr(remote_ctx, kind, rv);
   }
 
   void* AllocDataSpace(TVMContext ctx, size_t nbytes, size_t alignment,
                        DLDataType type_hint) final {
     auto sess = GetSess(ctx);
-    auto remote_ctx = RemoveSessMask(ctx);
+    auto remote_ctx = RemoveRPCSessionMask(ctx);
     void* data =
         sess->GetDeviceAPI(remote_ctx)->AllocDataSpace(remote_ctx, nbytes, alignment, type_hint);
 
@@ -57,7 +57,7 @@ class RPCDeviceAPI final : public DeviceAPI {
   }
   void FreeDataSpace(TVMContext ctx, void* ptr) final {
     RemoteSpace* space = static_cast<RemoteSpace*>(ptr);
-    auto remote_ctx = RemoveSessMask(ctx);
+    auto remote_ctx = RemoveRPCSessionMask(ctx);
     try {
       GetSess(ctx)->GetDeviceAPI(remote_ctx)->FreeDataSpace(remote_ctx, space->data);
     } catch (const dmlc::Error& e) {
@@ -68,13 +68,11 @@ class RPCDeviceAPI final : public DeviceAPI {
   void CopyDataFromTo(const void* from, size_t from_offset, void* to, size_t to_offset, size_t size,
                       TVMContext ctx_from, TVMContext ctx_to, DLDataType type_hint,
                       TVMStreamHandle stream) final {
-    int from_dev_type = ctx_from.device_type;
-    int to_dev_type = ctx_to.device_type;
-    if (from_dev_type > kRPCSessMask && to_dev_type > kRPCSessMask) {
+    if (IsRPCSessionContext(ctx_from) && IsRPCSessionContext(ctx_to)) {
       ICHECK(ctx_from.device_type == ctx_to.device_type)
           << "Cannot copy across two different remote session";
-      auto remote_ctx_from = RemoveSessMask(ctx_from);
-      auto remote_ctx_to = RemoveSessMask(ctx_to);
+      auto remote_ctx_from = RemoveRPCSessionMask(ctx_from);
+      auto remote_ctx_to = RemoveRPCSessionMask(ctx_to);
       auto remote_ctx = remote_ctx_from;
       if (remote_ctx.device_type == kDLCPU) remote_ctx = remote_ctx_to;
       GetSess(ctx_from)
@@ -82,12 +80,12 @@ class RPCDeviceAPI final : public DeviceAPI {
           ->CopyDataFromTo(static_cast<const RemoteSpace*>(from)->data, from_offset,
                            static_cast<const RemoteSpace*>(to)->data, to_offset, size,
                            remote_ctx_from, remote_ctx_to, type_hint, stream);
-    } else if (from_dev_type > kRPCSessMask && to_dev_type == kDLCPU) {
-      auto remote_ctx_from = RemoveSessMask(ctx_from);
+    } else if (IsRPCSessionContext(ctx_from) && ctx_to.device_type == kDLCPU) {
+      auto remote_ctx_from = RemoveRPCSessionMask(ctx_from);
       GetSess(ctx_from)->CopyFromRemote(static_cast<const RemoteSpace*>(from)->data, from_offset,
                                         to, to_offset, size, remote_ctx_from, type_hint);
-    } else if (from_dev_type == kDLCPU && to_dev_type > kRPCSessMask) {
-      auto remote_ctx_to = RemoveSessMask(ctx_to);
+    } else if (ctx_from.device_type == kDLCPU && IsRPCSessionContext(ctx_to)) {
+      auto remote_ctx_to = RemoveRPCSessionMask(ctx_to);
       GetSess(ctx_to)->CopyToRemote(const_cast<void*>(from), from_offset,
                                     static_cast<const RemoteSpace*>(to)->data, to_offset, size,
                                     remote_ctx_to, type_hint);
@@ -97,21 +95,14 @@ class RPCDeviceAPI final : public DeviceAPI {
   }
 
   void StreamSync(TVMContext ctx, TVMStreamHandle stream) final {
-    auto remote_ctx = RemoveSessMask(ctx);
+    auto remote_ctx = RemoveRPCSessionMask(ctx);
     GetSess(ctx)->GetDeviceAPI(remote_ctx)->StreamSync(remote_ctx, stream);
   }
 
  private:
   std::shared_ptr<RPCSession> GetSess(TVMContext ctx) {
-    int dev_type = ctx.device_type;
-    ICHECK_GE(dev_type, kRPCSessMask);
-    int tbl_index = dev_type / kRPCSessMask - 1;
+    int tbl_index = GetRPCSessionIndex(ctx);
     return RPCSession::Get(tbl_index);
-  }
-
-  static TVMContext RemoveSessMask(TVMContext ctx) {
-    ctx.device_type = static_cast<DLDeviceType>(ctx.device_type % kRPCSessMask);
-    return ctx;
   }
 };
 

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -178,7 +178,7 @@ class RPCEndpoint::EventHandler : public dmlc::Stream {
                    << args[i].AsObjectRef<ObjectRef>()->GetTypeKey() << " is not supported by RPC";
       } else if (tcode == kTVMContext) {
         DLContext ctx = args[i];
-        ICHECK_LT(static_cast<int>(ctx.device_type), kRPCSessMask)
+        ICHECK(!IsRPCSessionContext(ctx))
             << "InternalError: cannot pass RPC context in the channel";
       }
     }

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -36,51 +36,6 @@
 namespace tvm {
 namespace runtime {
 
-// deleter of RPC remote array
-static void RemoteNDArrayDeleter(Object* obj) {
-  auto* ptr = static_cast<NDArray::Container*>(obj);
-  RemoteSpace* space = static_cast<RemoteSpace*>(ptr->dl_tensor.data);
-  space->sess->FreeHandle(ptr->manager_ctx, kTVMNDArrayHandle);
-  delete space;
-  delete ptr;
-}
-
-/*!
- * \brief Build a local NDArray with remote backing storage.
- * \param handle A pointer valid on the remote end which should form the `data` field of the
- *     underlying DLTensor.
- * \param shape The shape field of this DLTensor.
- * \param ndim The rank of this DLTensor.
- * \param ctx Remote context used with this tensor. Must have non-zero RPCSessMask.
- * \param deleter A function invoked when the local NDArray object is no longer used. If `handle`
- *      needs to be explicitly deleted after the NDArray is freed, this function should do that.
- * \param deleter_ctx An opaque pointer passed to deleter to identify the tensor being deleted.
- */
-NDArray NDArrayFromRemoteOpaqueHandle(void* handle, int64_t* shape, int64_t ndim, DLContext* ctx,
-                                      FDeleter deleter, void* deleter_ctx) {
-  NDArray::Container* data = new NDArray::Container();
-  data->manager_ctx = deleter_ctx;
-  data->SetDeleter(deleter);
-  RemoteSpace* space = new RemoteSpace();
-  space->sess = sess_;
-  space->data = tensor->data;
-  data->dl_tensor.data = space;
-  NDArray ret(GetObjectPtr<Object>(data));
-  // RAII now in effect
-  data->shape_ = std::vector<int64_t>(tensor->shape, tensor->shape + tensor->ndim);
-  data->dl_tensor.shape = dmlc::BeginPtr(data->shape_);
-  data->dl_tensor.ndim = static_cast<int>(data->shape_.size());
-  // setup dtype
-  data->dl_tensor.dtype = tensor->dtype;
-  // setup ctx
-  data->dl_tensor.ctx = ctx;
-  // check strides.
-  ICHECK(tensor->strides == nullptr);
-  // setup byteoffset
-  data->dl_tensor.byte_offset = tensor->byte_offset;
-  return ret;
-}
-
 /*!
  * \brief A wrapped remote function as a PackedFunc.
  */
@@ -157,6 +112,41 @@ class RPCWrappedFunc : public Object {
     ICHECK_EQ(GetRPCSessionIndex(ctx), sess_->table_index())
         << "Can not pass in context with a different remote session";
     return RemoveRPCSessionMask(ctx);
+  }
+
+  // deleter of RPC remote array
+  static void RemoteNDArrayDeleter(Object* obj) {
+    auto* ptr = static_cast<NDArray::Container*>(obj);
+    RemoteSpace* space = static_cast<RemoteSpace*>(ptr->dl_tensor.data);
+    space->sess->FreeHandle(ptr->manager_ctx, kTVMNDArrayHandle);
+    delete space;
+    delete ptr;
+  }
+
+  // wrap return value as remote NDArray.
+  NDArray WrapRemoteNDArray(DLTensor* tensor, void* nd_handle) const {
+    NDArray::Container* data = new NDArray::Container();
+    data->manager_ctx = nd_handle;
+    data->SetDeleter(RemoteNDArrayDeleter);
+    RemoteSpace* space = new RemoteSpace();
+    space->sess = sess_;
+    space->data = tensor->data;
+    data->dl_tensor.data = space;
+    NDArray ret(GetObjectPtr<Object>(data));
+    // RAII now in effect
+    data->shape_ = std::vector<int64_t>(tensor->shape, tensor->shape + tensor->ndim);
+    data->dl_tensor.shape = dmlc::BeginPtr(data->shape_);
+    data->dl_tensor.ndim = static_cast<int>(data->shape_.size());
+    // setup dtype
+    data->dl_tensor.dtype = tensor->dtype;
+    // setup ctx, encode as remote session
+    data->dl_tensor.ctx = AddRPCSessionMask(tensor->ctx, sess_->table_index());
+    // check strides.
+    ICHECK(tensor->strides == nullptr);
+    // setup byteoffset
+    data->dl_tensor.byte_offset = tensor->byte_offset;
+
+    return ret;
   }
 };
 
@@ -290,9 +280,7 @@ void RPCWrappedFunc::WrapRemoteReturnToValue(TVMArgs args, TVMRetValue* rv) cons
     ICHECK_EQ(args.size(), 3);
     DLTensor* tensor = args[1];
     void* nd_handle = args[2];
-    *rv = NDArrayFromRemoteOpaqueHandle(tensor->data, tensor->shape, tensor->ndim,
-                                        AddRPCSessionMask(ctx, sess_->table_index()),
-                                        RemoteNDArrayDeleter, nd_handle);
+    *rv = WrapRemoteNDArray(tensor, nd_handle);
   } else {
     ICHECK_EQ(args.size(), 2);
     *rv = args[1];
@@ -477,11 +465,6 @@ TVM_REGISTER_GLOBAL("rpc.SessTableIndex").set_body([](TVMArgs args, TVMRetValue*
   ICHECK_EQ(tkey, "rpc");
   *rv = static_cast<RPCModuleNode*>(m.operator->())->sess()->table_index();
 });
-
-TVM_REGISTER_GLOBAL("tvm.rpc.wrap_remote_ndarray")
-    .set_body_typed([](void* remote_array, PackedFunc deleter) {
-      *rv = WrapRemoteNDArray(remote_array, [pf](Object* ctx) { pf(); });
-    });
 
 }  // namespace runtime
 }  // namespace tvm


### PR DESCRIPTION
Small cleanup PR to move logic around building and examining RPC contexts into a single place. Helpful when building the pre-linked parameter PR (coming soon).