### PR TITLE
Make TVMLogf platform-independent

### DIFF
--- a/include/tvm/runtime/crt/platform.h
+++ b/include/tvm/runtime/crt/platform.h
@@ -25,6 +25,8 @@
 #ifndef TVM_RUNTIME_CRT_PLATFORM_H_
 #define TVM_RUNTIME_CRT_PLATFORM_H_
 
+#include <stdarg.h>
+#include <stddef.h>
 #include <tvm/runtime/crt/error_codes.h>
 
 #ifdef __cplusplus
@@ -38,6 +40,21 @@ extern "C" {
  * \param code An error code.
  */
 void __attribute__((noreturn)) TVMPlatformAbort(tvm_crt_error_t code);
+
+/*! \brief Called by the microTVM RPC server to implement TVMLogf.
+ *
+ * Not required to be implemented when the RPC server is not linked into the binary. This
+ * function's signature matches that of vsnprintf, so trivial implementations can just call
+ * vsnprintf.
+ *
+ * \param out_buf A char buffer where the formatted string should be written.
+ * \param out_buf_size_bytes Number of bytes available for writing in out_buf.
+ * \param fmt The printf-style formatstring.
+ * \param args extra arguments to be formatted.
+ * \return number of bytes written.
+ */
+size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes,
+                                const char* fmt, va_list args);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/tvm/runtime/crt/platform.h
+++ b/include/tvm/runtime/crt/platform.h
@@ -53,8 +53,8 @@ void __attribute__((noreturn)) TVMPlatformAbort(tvm_crt_error_t code);
  * \param args extra arguments to be formatted.
  * \return number of bytes written.
  */
-size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes,
-                                const char* fmt, va_list args);
+size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes, const char* fmt,
+                                va_list args);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -43,6 +43,11 @@ ssize_t UTvmWriteFunc(void* context, const uint8_t* data, size_t num_bytes) {
   return to_return;
 }
 
+size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes,
+                                const char* fmt, va_list args) {
+  return vsnprintf(out_buf, out_buf_size_bytes, fmt, args);
+}
+
 void TVMPlatformAbort(tvm_crt_error_t error_code) {
   std::cerr << "TVMPlatformAbort: " << error_code << std::endl;
   throw "Aborted";

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -43,8 +43,8 @@ ssize_t UTvmWriteFunc(void* context, const uint8_t* data, size_t num_bytes) {
   return to_return;
 }
 
-size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes,
-                                const char* fmt, va_list args) {
+size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes, const char* fmt,
+                                va_list args) {
   return vsnprintf(out_buf, out_buf_size_bytes, fmt, args);
 }
 

--- a/src/runtime/crt/utvm_rpc_server/rpc_server.cc
+++ b/src/runtime/crt/utvm_rpc_server/rpc_server.cc
@@ -219,7 +219,8 @@ void TVMLogf(const char* format, ...) {
   va_list args;
   char log_buffer[256];
   va_start(args, format);
-  size_t num_bytes_logged = vsnprintf(log_buffer, sizeof(log_buffer), format, args);
+  size_t num_bytes_logged = TVMPlatformFormatMessage(
+    log_buffer, sizeof(log_buffer), format, args);
   va_end(args);
 
   // Most header-based logging frameworks tend to insert '\n' at the end of the log message.

--- a/src/runtime/crt/utvm_rpc_server/rpc_server.cc
+++ b/src/runtime/crt/utvm_rpc_server/rpc_server.cc
@@ -219,8 +219,7 @@ void TVMLogf(const char* format, ...) {
   va_list args;
   char log_buffer[256];
   va_start(args, format);
-  size_t num_bytes_logged = TVMPlatformFormatMessage(
-    log_buffer, sizeof(log_buffer), format, args);
+  size_t num_bytes_logged = TVMPlatformFormatMessage(log_buffer, sizeof(log_buffer), format, args);
   va_end(args);
 
   // Most header-based logging frameworks tend to insert '\n' at the end of the log message.

--- a/tests/micro/qemu/zephyr-runtime/src/main.c
+++ b/tests/micro/qemu/zephyr-runtime/src/main.c
@@ -57,8 +57,8 @@ ssize_t write_serial(void* unused_context, const uint8_t* data, size_t size) {
   return size;
 }
 
-size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes,
-                                const char* fmt, va_list args) {
+size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes, const char* fmt,
+                                va_list args) {
   return vsnprintk(out_buf, out_buf_size_bytes, fmt, args);
 }
 

--- a/tests/micro/qemu/zephyr-runtime/src/main.c
+++ b/tests/micro/qemu/zephyr-runtime/src/main.c
@@ -57,6 +57,11 @@ ssize_t write_serial(void* unused_context, const uint8_t* data, size_t size) {
   return size;
 }
 
+size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes,
+                                const char* fmt, va_list args) {
+  return vsnprintk(out_buf, out_buf_size_bytes, fmt, args);
+}
+
 void TVMPlatformAbort(tvm_crt_error_t error) {
   sys_reboot(SYS_REBOOT_COLD);
   for (;;)


### PR DESCRIPTION
When debugging vmalloc() on ARM devices, %zu was printing as "zu." This change fixes that.

 * Some platforms need to use an alternate printf() to support basic
   things like %zu. Since %zu is platform-specific, we prefer to
   use a printf() that supports it or allow the platform to fix it up
   as needed.