### PR TITLE
[AutoTVM][RPCRunner] timeout is not passed correctly

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -228,7 +228,7 @@ class RPCRunner(Runner):
         self.host = host
         self.port = port
         self.priority = priority
-        self.timeout = timeout * (self.n_parallel + 1 )
+        self.timeout = timeout
 
         self.number = number
         self.repeat = repeat
@@ -240,7 +240,7 @@ class RPCRunner(Runner):
         self.check_correctness = check_correctness
         self.cooldown_interval = cooldown_interval
 
-        self.executor = LocalExecutor(timeout=self.timeout)
+        self.executor = LocalExecutor(timeout=timeout * (self.n_parallel + 1 ))
 
     def set_task(self, task):
         self.task = task

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -228,7 +228,7 @@ class RPCRunner(Runner):
         self.host = host
         self.port = port
         self.priority = priority
-        self.timeout = timeout
+        self.timeout = timeout * (self.n_parallel + 1 )
 
         self.number = number
         self.repeat = repeat
@@ -240,7 +240,7 @@ class RPCRunner(Runner):
         self.check_correctness = check_correctness
         self.cooldown_interval = cooldown_interval
 
-        self.executor = LocalExecutor(timeout=timeout)
+        self.executor = LocalExecutor(timeout=self.timeout)
 
     def set_task(self, task):
         self.task = task

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -240,7 +240,7 @@ class RPCRunner(Runner):
         self.check_correctness = check_correctness
         self.cooldown_interval = cooldown_interval
 
-        self.executor = LocalExecutor(timeout=timeout * (self.n_parallel + 1 ))
+        self.executor = LocalExecutor(timeout=timeout * (self.n_parallel + 1))
 
     def set_task(self, task):
         self.task = task

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -168,7 +168,7 @@ class RPCRunner(Runner):
     Parameters
     ----------
     timeout: float
-        The timeout of a compilation
+        The timeout of a RPCRunner measurement task
     n_parallel: int
         The number of tasks run in parallel. "None" will use all cpu cores
     key: str
@@ -240,7 +240,7 @@ class RPCRunner(Runner):
         self.check_correctness = check_correctness
         self.cooldown_interval = cooldown_interval
 
-        self.executor = LocalExecutor()
+        self.executor = LocalExecutor(timeout=timeout)
 
     def set_task(self, task):
         self.task = task


### PR DESCRIPTION
If we hand-over the timeout to the constructor of the LocalExecutor, like done in the LocalBuilder class it seems to solve the issue and the timeout is now correctly passed.
