### PR TITLE
[AutoScheduler] Register workload when deserializing tasks

### DIFF
--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -61,7 +61,7 @@ class ComputeDAG(Object):
         if isinstance(compute_or_sche, str):
             compute = workload_key_to_tensors(compute_or_sche)
             sche = None
-        elif isinstance(compute_or_sche, list):
+        elif isinstance(compute_or_sche, (list, tvm.ir.container.Array)):
             for item in compute_or_sche:
                 if not isinstance(item, tvm.te.Tensor):
                     raise ValueError(

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -21,6 +21,7 @@ import tvm._ffi
 from tvm.runtime import Object
 
 from . import _ffi_api
+from .workload_registry import register_workload_tensors
 
 
 @tvm._ffi.register_object("auto_scheduler.SearchTask")
@@ -63,6 +64,7 @@ class SearchTask(Object):
     def __setstate__(self, state):
         self.dag = state["dag"]
         self.workload_key = state["workload_key"]
+        register_workload_tensors(self.dag.tensors, func_name=self.workload_key)
         self.target = state["target"]
         self.target_host = state["target_host"]
         self.hardware_params = state["hardware_params"]

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -67,10 +67,10 @@ class SearchTask(Object):
         self.dag = state["dag"]
         self.workload_key = state["workload_key"]
         try:
-            func_name, _ = json.loads(self.workload_key)
-        except Exception as err:  # pylint: disable=broad-except
+            func_name = json.loads(self.workload_key)[0]
+        except Exception:  # pylint: disable=broad-except
             raise RuntimeError("Invalid workload key %s" % self.workload_key)
-        register_workload_tensors(self.dag.tensors, func_name=func_name)
+        register_workload_tensors(func_name, self.dag.tensors)
         self.target = state["target"]
         self.target_host = state["target_host"]
         self.hardware_params = state["hardware_params"]

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -66,11 +66,19 @@ class SearchTask(Object):
     def __setstate__(self, state):
         self.dag = state["dag"]
         self.workload_key = state["workload_key"]
+
+        # Register the workload if needed
         try:
-            func_name = json.loads(self.workload_key)[0]
+            workload = json.loads(self.workload_key)
         except Exception:  # pylint: disable=broad-except
             raise RuntimeError("Invalid workload key %s" % self.workload_key)
-        register_workload_tensors(func_name, self.dag.tensors)
+
+        # The workload from a compute DAG does not have arguments and is not registered
+        # by default so we register it here. If the workload has already been registered,
+        # the later registration overrides the prvious one.
+        if len(workload) == 1:
+            register_workload_tensors(workload[0], self.dag.tensors)
+
         self.target = state["target"]
         self.target_host = state["target_host"]
         self.hardware_params = state["hardware_params"]

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -17,6 +17,8 @@
 
 """ The definiton of SearchTask """
 
+import json
+
 import tvm._ffi
 from tvm.runtime import Object
 
@@ -64,7 +66,11 @@ class SearchTask(Object):
     def __setstate__(self, state):
         self.dag = state["dag"]
         self.workload_key = state["workload_key"]
-        register_workload_tensors(self.dag.tensors, func_name=self.workload_key)
+        try:
+            func_name, _ = json.loads(self.workload_key)
+        except Exception as err: # pylint: disable=broad-except
+            raise RuntimeError("Invalid workload key %s" % self.workload_key)
+        register_workload_tensors(self.dag.tensors, func_name=func_name)
         self.target = state["target"]
         self.target_host = state["target_host"]
         self.hardware_params = state["hardware_params"]

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -68,7 +68,7 @@ class SearchTask(Object):
         self.workload_key = state["workload_key"]
         try:
             func_name, _ = json.loads(self.workload_key)
-        except Exception as err: # pylint: disable=broad-except
+        except Exception as err:  # pylint: disable=broad-except
             raise RuntimeError("Invalid workload key %s" % self.workload_key)
         register_workload_tensors(self.dag.tensors, func_name=func_name)
         self.target = state["target"]

--- a/python/tvm/auto_scheduler/workload_registry.py
+++ b/python/tvm/auto_scheduler/workload_registry.py
@@ -98,13 +98,16 @@ def register_workload(func_name, f=None, override=False):
     return register
 
 
-def register_workload_tensors(tensors):
+def register_workload_tensors(tensors, func_name=None):
     """Register a workload by provding input/output tensors
 
     Parameters
     ----------
     tensors: List[Tensor]
         The input/output tensors of a compute DAG
+    func_name: Optional[str]
+        The function name of the compute DAG. If not presented,
+        the hash key of the compute DAG will be used.
 
     Returns
     -------
@@ -120,6 +123,7 @@ def register_workload_tensors(tensors):
         logger.info("Failed to create a ComputeDAG for auto_scheduler: %s", str(err))
         return None
 
+    key = func_name if func_name is not None else ComputeDAG(tensors).hash_key()
     WORKLOAD_FUNC_REGISTRY[key] = tensors
     return json.dumps((key,))
 

--- a/python/tvm/auto_scheduler/workload_registry.py
+++ b/python/tvm/auto_scheduler/workload_registry.py
@@ -64,7 +64,7 @@ def register_workload(func_name, f=None, override=False):
     f : Optional[Function]
         The generation function to be registered.
     override : boolean = False
-        Whether override existing entry.
+        Whether to override existing entry.
 
     Examples
     --------
@@ -98,34 +98,26 @@ def register_workload(func_name, f=None, override=False):
     return register
 
 
-def register_workload_tensors(tensors, func_name=None):
-    """Register a workload by provding input/output tensors
+def register_workload_tensors(func_name, tensors, override=True):
+    """Register a workload by provding input/output tensors. Since this function is used
+    when extracting/deserializing tasks, it expects duplicated registrations by default.
 
     Parameters
     ----------
+    func_name: str
+        The function name or the hash key of the compute DAG.
     tensors: List[Tensor]
         The input/output tensors of a compute DAG
-    func_name: Optional[str]
-        The function name of the compute DAG. If not presented,
-        the hash key of the compute DAG will be used.
+    override : boolean = True
+        Whether to override existing entry.
 
     Returns
     -------
-    key: Optional[str]
-        The workload key, or None if failed to create a compute DAG.
+    key: str
+        The serialized JSON string as the workload key.
     """
-    # pylint: disable=import-outside-toplevel
-    from .compute_dag import ComputeDAG
-
-    try:
-        key = ComputeDAG(tensors).hash_key()
-    except tvm.error.TVMError as err:
-        logger.info("Failed to create a ComputeDAG for auto_scheduler: %s", str(err))
-        return None
-
-    key = func_name if func_name is not None else ComputeDAG(tensors).hash_key()
-    WORKLOAD_FUNC_REGISTRY[key] = tensors
-    return json.dumps((key,))
+    register_workload(func_name, override=override)(tensors)
+    return json.dumps((func_name,))
 
 
 def make_workload_key(func, args):

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -126,11 +126,8 @@ def test_stage_order():
         hardware_params=auto_scheduler.HardwareParams(100000, 16, 64),
     )
 
-    auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY.clear()
     task2 = pickle.loads(pickle.dumps(task))
-    assert (
-        json.loads(task2.workload_key)[0] in auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY
-    )
+    assert "test-key" in auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY
     assert str(task.dag.get_init_state()) == str(task2.dag.get_init_state())
     assert len(task.dag.get_init_state().stage_ops) == len(task2.dag.get_init_state().stage_ops)
     assert task.workload_key == task2.workload_key

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -124,7 +124,10 @@ def test_stage_order():
         tvm.target.Target("llvm"),
         hardware_params=auto_scheduler.HardwareParams(100000, 16, 64),
     )
+
+    auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY.clear()
     task2 = pickle.loads(pickle.dumps(task))
+    assert task2.workload_key in auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY
     assert str(task.dag.get_init_state()) == str(task2.dag.get_init_state())
     assert len(task.dag.get_init_state().stage_ops) == len(task2.dag.get_init_state().stage_ops)
     assert task.workload_key == task2.workload_key

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -16,6 +16,7 @@
 # under the License.
 
 """Test ComputeDAG (replay, infer bound)"""
+import json
 import pickle
 
 import tvm
@@ -120,14 +121,16 @@ def test_stage_order():
     # Serialize and deserialize the search task.
     task = auto_scheduler.SearchTask(
         dag,
-        "test1",
+        json.dumps(("test-key",)),
         tvm.target.Target("llvm"),
         hardware_params=auto_scheduler.HardwareParams(100000, 16, 64),
     )
 
     auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY.clear()
     task2 = pickle.loads(pickle.dumps(task))
-    assert task2.workload_key in auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY
+    assert (
+        json.loads(task2.workload_key)[0] in auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY
+    )
     assert str(task.dag.get_init_state()) == str(task2.dag.get_init_state())
     assert len(task.dag.get_init_state().stage_ops) == len(task2.dag.get_init_state().stage_ops)
     assert task.workload_key == task2.workload_key


### PR DESCRIPTION
One issue of the current auto_scheduler task serialization is that the workload won't be registered when deserializing a task so users have to manually call `register_workload_tensors` after deserialization. However, `register_workload_tensors` always uses compute DAG hash as the workload key. This could cause workload key mismatching if the task was from a TE function that uses function name as the workload key. This PR makes the following changes to make sure `WORKLOAD_FUNC_REGISTRY` is consist after deserializing a task.

* Simplify `register_workload_tensors` by moving the ComputeDAG out.
* Register the workload using the stored workload key when deserializing a task.

cc @merrymercy @jcf94 