### PR TITLE
[µTVM] Fix problems with the debug flow

### DIFF
--- a/python/tvm/micro/debugger.py
+++ b/python/tvm/micro/debugger.py
@@ -216,7 +216,8 @@ class GdbTransportDebugger(GdbDebugger):
             raise NotImplementedError(f"System {sysname} is not yet supported")
 
         self.fd_transport = FdTransport(
-            stdout_read, stdin_write, transport.debug_transport_timeouts())
+            stdout_read, stdin_write, transport.debug_transport_timeouts()
+        )
         self.fd_transport.open()
 
         return {

--- a/python/tvm/micro/debugger.py
+++ b/python/tvm/micro/debugger.py
@@ -21,6 +21,7 @@ import atexit
 import abc
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -40,9 +41,6 @@ _LOG = logging.getLogger(__name__)
 class Debugger(metaclass=abc.ABCMeta):
     """An interface for controlling micro TVM debuggers."""
 
-    def __init__(self):
-        self.on_terminate_callbacks = []
-
     @abc.abstractmethod
     def start(self):
         """Start the debugger, but do not block on it.
@@ -55,13 +53,6 @@ class Debugger(metaclass=abc.ABCMeta):
     def stop(self):
         """Terminate the debugger."""
         raise NotImplementedError()
-
-    def _run_on_terminate_callbacks(self):
-        for callback in self.on_terminate_callbacks:
-            try:
-                callback()
-            except Exception:  # pylint: disable=broad-except
-                _LOG.warning("on_terminate_callback raised exception", exc_info=True)
 
 
 class GdbDebugger(Debugger):
@@ -82,23 +73,56 @@ class GdbDebugger(Debugger):
     def __init__(self):
         super(GdbDebugger, self).__init__()
         self._is_running = False
-        self._child_alive_lock = threading.RLock()
-        self._is_child_alive = False
+        self._is_running_lock = threading.RLock()
+        self._child_exited_event = threading.Event()
+        self._signals_reset_event = threading.Event()
 
     @abc.abstractmethod
     def popen_kwargs(self):
         raise NotImplementedError()
 
+    def _internal_stop(self):
+        if not self._is_running:
+            return
+
+        os.kill(os.getpid(), signal.SIGUSR1)
+        self._signals_reset_event.wait()
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSAFLUSH, self.old_termios)
+
+        try:
+            children = psutil.Process(self.popen.pid).children(recursive=True)
+            for c in children:
+                c.terminate()
+                _, alive = psutil.wait_procs(children, timeout=self._GRACEFUL_SHUTDOWN_TIMEOUT_SEC)
+                for a in alive:
+                    a.kill()
+        except psutil.NoSuchProcess:
+            pass
+        finally:
+            self.__class__._STARTED_INSTANCE = None
+            self._is_running = False
+            self._child_exited_event.set()
+
     def _wait_for_child(self):
         self.popen.wait()
-        with self._child_alive_lock:
-            self._is_child_alive = True
+        with self._is_running_lock:
+            self._internal_stop()
+
+    @classmethod
+    def _sigusr1_handler(cls, signum, stack_frame):  # pylint: disable=unused-argument
+        if cls._STARTED_INSTANCE is not None:
+            signal.signal(signal.SIGINT, cls._STARTED_INSTANCE.old_sigint_handler)
+            signal.signal(signal.SIGUSR1, cls._STARTED_INSTANCE.old_sigusr1_handler)
+            cls._STARTED_INSTANCE._signals_reset_event.set()
+            return
+
+        raise Exception()
 
     @classmethod
     def _sigint_handler(cls, signum, stack_frame):  # pylint: disable=unused-argument
         if cls._STARTED_INSTANCE is not None:
-            with cls._STARTED_INSTANCE._child_alive_lock:
-                exists = cls._STARTED_INSTANCE._is_child_alive
+            with cls._STARTED_INSTANCE._is_running_lock:
+                exists = cls._STARTED_INSTANCE._is_running
             if exists:
                 try:
                     os.killpg(cls._STARTED_INSTANCE.child_pgid, signal.SIGINT)
@@ -109,47 +133,32 @@ class GdbDebugger(Debugger):
         raise Exception()
 
     def start(self):
-        assert not self._is_running
-        assert not self._STARTED_INSTANCE
+        with self._is_running_lock:
+            assert not self._is_running
+            assert not self._STARTED_INSTANCE
 
-        kwargs = self.popen_kwargs()
-        self.did_start_new_session = kwargs.setdefault("start_new_session", True)
+            kwargs = self.popen_kwargs()
+            self.did_start_new_session = kwargs.setdefault("start_new_session", True)
 
-        self.old_termios = termios.tcgetattr(sys.stdin.fileno())
-        self.popen = subprocess.Popen(**kwargs)
-        self._is_running = True
-        self.__class__._STARTED_INSTANCE = self
-        try:
-            self.child_pgid = os.getpgid(self.popen.pid)
-        except Exception:
-            self.stop()
-            raise
-        with self._child_alive_lock:
-            self._is_child_alive = True
-        self.old_sigint_handler = signal.signal(signal.SIGINT, self._sigint_handler)
-        t = threading.Thread(target=self._wait_for_child)
-        t.daemon = True
-        t.start()
+            self.old_termios = termios.tcgetattr(sys.stdin.fileno())
+            self.popen = subprocess.Popen(**kwargs)
+            self._is_running = True
+            self.old_sigint_handler = signal.signal(signal.SIGINT, self._sigint_handler)
+            self.old_sigusr1_handler = signal.signal(signal.SIGUSR1, self._sigusr1_handler)
+            self.__class__._STARTED_INSTANCE = self
+            try:
+                self.child_pgid = os.getpgid(self.popen.pid)
+            except Exception:
+                self.stop()
+                raise
+            with self._is_running_lock:
+                self._is_child_alive = True
+            t = threading.Thread(target=self._wait_for_child)
+            t.daemon = True
+            t.start()
 
     def stop(self):
-        if not self._is_running:
-            return
-
-        signal.signal(signal.SIGINT, self.old_sigint_handler)
-        termios.tcsetattr(sys.stdin.fileno(), termios.TCSAFLUSH, self.old_termios)
-
-        try:
-            children = psutil.Process(self.popen.pid).children(recursive=True)
-            for c in children:
-                c.terminate()
-            _, alive = psutil.wait_procs(children, timeout=self._GRACEFUL_SHUTDOWN_TIMEOUT_SEC)
-            for a in alive:
-                a.kill()
-        finally:
-            self.__class__._STARTED_INSTANCE = None
-            self._is_running = False
-            self._run_on_terminate_callbacks()
-
+        self._child_exited_event.wait()
 
 atexit.register(GdbDebugger._stop_all)
 
@@ -190,7 +199,7 @@ class GdbTransportDebugger(GdbDebugger):
                 )
         elif sysname == "Linux":
             args = (
-                ["gdb", "--args"] + self.args + ["</dev/fd/{stdin_read}", ">/dev/fd/{stdout_write}"]
+                ["gdb", "-ex", f"file {self.args[0]}", "-ex", f"set args {' '.join(shlex.quote(a) for a in self.args[1:])} </dev/fd/{stdin_read} >/dev/fd/{stdout_write}"]
             )
         else:
             raise NotImplementedError(f"System {sysname} is not yet supported")
@@ -203,18 +212,9 @@ class GdbTransportDebugger(GdbDebugger):
             "pass_fds": [stdin_read, stdout_write],
         }
 
-    def _wait_for_process_death(self):
-        self.popen.wait()
+    def _internal_stop(self):
         self.fd_transport.close()
-
-    def start(self):
-        to_return = super(GdbTransportDebugger, self).start()
-        threading.Thread(target=self._wait_for_process_death, daemon=True).start()
-        return to_return
-
-    def stop(self):
-        self.fd_transport.close()
-        super(GdbTransportDebugger, self).stop()
+        super(GdbTransportDebugger, self)._internal_stop()
 
     class _Transport(transport.Transport):
         def __init__(self, gdb_transport_debugger):
@@ -227,10 +227,38 @@ class GdbTransportDebugger(GdbDebugger):
             pass  # Pipes opened by parent class.
 
         def write(self, data, timeout_sec):
-            return self.gdb_transport_debugger.fd_transport.write(data, timeout_sec)
+            end_time = time.monotonic() + timeout_sec if timeout_sec is not None else None
+            while True:
+                try:
+                    return self.gdb_transport_debugger.fd_transport.write(data, timeout_sec)
+                except OSError as exc:
+                    # NOTE: this error sometimes happens when writes are initiated before the child
+                    # process launches.
+                    if exc.errno == errno.EAGAIN:
+                        if end_time is None or time.monotonic() < end_time:
+                            time.sleep(0.1)  # sleep to avoid excessive CPU usage
+                            continue
+
+                    raise exc
+
+            raise base.IoTimeoutError()
 
         def read(self, n, timeout_sec):
-            return self.gdb_transport_debugger.fd_transport.read(n, timeout_sec)
+            end_time = time.monotonic() + timeout_sec if timeout_sec is not None else None
+            while True:
+                try:
+                    return self.gdb_transport_debugger.fd_transport.read(n, timeout_sec)
+                except OSError as exc:
+                    # NOTE: this error sometimes happens when reads are initiated before the child
+                    # process launches.
+                    if exc.errno == errno.EAGAIN:
+                        if end_time is None or time.monotonic() < end_time:
+                            time.sleep(0.1)  # sleep to avoid excessive CPU usage
+                            continue
+
+                    raise exc
+
+            raise base.IoTimeoutError()
 
         def close(self):
             pass  # Pipes closed by parent class.
@@ -343,7 +371,6 @@ class RpcDebugger(Debugger):
     def stop(self):
         try:
             self.stop_debugger()
-            self._run_on_terminate_callbacks()
         finally:
             if self.wrapping_context_manager is not None:
                 self.wrapping_context_manager.__exit__(None, None, None)

--- a/python/tvm/micro/debugger.py
+++ b/python/tvm/micro/debugger.py
@@ -160,6 +160,7 @@ class GdbDebugger(Debugger):
     def stop(self):
         self._child_exited_event.wait()
 
+
 atexit.register(GdbDebugger._stop_all)
 
 
@@ -198,9 +199,13 @@ class GdbTransportDebugger(GdbDebugger):
                     ["-O", "settings set target.run-args {}".format(" ".join(self.args[1:]))]
                 )
         elif sysname == "Linux":
-            args = (
-                ["gdb", "-ex", f"file {self.args[0]}", "-ex", f"set args {' '.join(shlex.quote(a) for a in self.args[1:])} </dev/fd/{stdin_read} >/dev/fd/{stdout_write}"]
-            )
+            args = [
+                "gdb",
+                "-ex",
+                f"file {self.args[0]}",
+                "-ex",
+                f"set args {' '.join(shlex.quote(a) for a in self.args[1:])} </dev/fd/{stdin_read} >/dev/fd/{stdout_write}",
+            ]
         else:
             raise NotImplementedError(f"System {sysname} is not yet supported")
 

--- a/python/tvm/micro/debugger.py
+++ b/python/tvm/micro/debugger.py
@@ -113,16 +113,18 @@ class GdbDebugger(Debugger):
 
     @classmethod
     def _sigusr1_handler(cls, signum, stack_frame):  # pylint: disable=unused-argument
-        assert cls._STARTED_INSTANCE is not None, (
-            "overridden sigusr1 handler should not be invoked when GDB not started")
+        assert (
+            cls._STARTED_INSTANCE is not None
+        ), "overridden sigusr1 handler should not be invoked when GDB not started"
         signal.signal(signal.SIGINT, cls._STARTED_INSTANCE.old_sigint_handler)
         signal.signal(signal.SIGUSR1, cls._STARTED_INSTANCE.old_sigusr1_handler)
         cls._STARTED_INSTANCE._signals_reset_event.set()
 
     @classmethod
     def _sigint_handler(cls, signum, stack_frame):  # pylint: disable=unused-argument
-        assert cls._STARTED_INSTANCE is not None, (
-            "overridden sigint handler should not be invoked when GDB not started")
+        assert (
+            cls._STARTED_INSTANCE is not None
+        ), "overridden sigint handler should not be invoked when GDB not started"
         with cls._STARTED_INSTANCE._is_running_lock:
             exists = cls._STARTED_INSTANCE._is_running
         if exists:

--- a/python/tvm/micro/debugger.py
+++ b/python/tvm/micro/debugger.py
@@ -204,7 +204,10 @@ class GdbTransportDebugger(GdbDebugger):
                 "-ex",
                 f"file {self.args[0]}",
                 "-ex",
-                f"set args {' '.join(shlex.quote(a) for a in self.args[1:])} </dev/fd/{stdin_read} >/dev/fd/{stdout_write}",
+                (
+                    f"set args {' '.join(shlex.quote(a) for a in self.args[1:])} "
+                    f"</dev/fd/{stdin_read} >/dev/fd/{stdout_write}"
+                ),
             ]
         else:
             raise NotImplementedError(f"System {sysname} is not yet supported")

--- a/python/tvm/micro/debugger.py
+++ b/python/tvm/micro/debugger.py
@@ -19,6 +19,7 @@
 
 import atexit
 import abc
+import errno
 import logging
 import os
 import shlex
@@ -27,12 +28,14 @@ import subprocess
 import sys
 import termios
 import threading
+import time
 
 import psutil
 
 from .._ffi import register_func
 from . import class_factory
 from . import transport
+from .transport.file_descriptor import FdTransport
 
 
 _LOG = logging.getLogger(__name__)
@@ -212,7 +215,8 @@ class GdbTransportDebugger(GdbDebugger):
         else:
             raise NotImplementedError(f"System {sysname} is not yet supported")
 
-        self.fd_transport = fd.FdTransport(stdout_read, stdin_write)
+        self.fd_transport = FdTransport(
+            stdout_read, stdin_write, transport.debug_transport_timeouts())
         self.fd_transport.open()
 
         return {

--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -99,7 +99,7 @@ class Session:
     def _wrap_transport_read(self, n, timeout_microsec):
         try:
             return self.transport.read(
-                n, float(timeout_microsec) / 1e6 if timeout_microsec is not None else 0
+                n, float(timeout_microsec) / 1e6 if timeout_microsec is not None else None
             )
         except IoTimeoutError:
             return bytes([])
@@ -107,7 +107,7 @@ class Session:
     def _wrap_transport_write(self, data, timeout_microsec):
         try:
             return self.transport.write(
-                data, float(timeout_microsec) / 1e6 if timeout_microsec is not None else 0
+                data, float(timeout_microsec) / 1e6 if timeout_microsec is not None else None
             )
         except IoTimeoutError:
             return 0

--- a/python/tvm/micro/transport/__init__.py
+++ b/python/tvm/micro/transport/__init__.py
@@ -22,5 +22,6 @@ from .base import Transport
 from .base import TransportClosedError
 from .base import TransportLogger
 from .base import TransportTimeouts
+from .base import debug_transport_timeouts
 from .debug import DebugWrapperTransport
 from .subprocess import SubprocessTransport

--- a/python/tvm/micro/transport/base.py
+++ b/python/tvm/micro/transport/base.py
@@ -108,11 +108,12 @@ class Transport(metaclass=abc.ABCMeta):
         ----------
         n : int
             Maximum number of bytes to read from the transport.
-        timeout_sec : float
+        timeout_sec : Union[float, None]
             Number of seconds to wait for all `n` bytes to be received before timing out. The
             transport can wait additional time to account for transport latency or bandwidth
             limitations based on the selected configuration and number of bytes being received. If
             timeout_sec is 0, read should attempt to service the request in a non-blocking fashion.
+            If timeout_sec is None, read should block until at least 1 byte of data can be returned.
 
         Returns
         -------
@@ -142,17 +143,19 @@ class Transport(metaclass=abc.ABCMeta):
         ----------
         data : bytes
             The data to write over the channel.
-        timeout_sec : float
-            Number of seconds to wait for all `n` bytes to be received before timing out. The
+        timeout_sec : Union[float, None]
+            Number of seconds to wait for at least one byte to be written before timing out. The
             transport can wait additional time to account for transport latency or bandwidth
             limitations based on the selected configuration and number of bytes being received. If
-            timeout_sec is 0, read should attempt to service the request in a non-blocking fashion.
+            timeout_sec is 0, write should attempt to service the request in a non-blocking fashion.
+            If timeout_sec is None, write should block until at least 1 byte of data can be
+            returned.
 
         Returns
         -------
         int :
             The number of bytes written to the underlying channel. This can be less than the length
-            of `data`, but cannot be 0.
+            of `data`, but cannot be 0 (raise an exception instead).
 
         Raises
         ------

--- a/python/tvm/micro/transport/base.py
+++ b/python/tvm/micro/transport/base.py
@@ -211,7 +211,7 @@ class TransportLogger(Transport):
         return self.child.close()
 
     def read(self, n, timeout_sec):
-        timeout_str = f'{timeout_sec:5.2f}s' if timeout_sec is not None else ' None '
+        timeout_str = f"{timeout_sec:5.2f}s" if timeout_sec is not None else " None "
         try:
             data = self.child.read(n, timeout_sec)
         except IoTimeoutError:
@@ -261,7 +261,7 @@ class TransportLogger(Transport):
         return data
 
     def write(self, data, timeout_sec):
-        timeout_str = f'{timeout_sec:5.2f}s' if timeout_sec is not None else ' None '
+        timeout_str = f"{timeout_sec:5.2f}s" if timeout_sec is not None else " None "
         try:
             bytes_written = self.child.write(data, timeout_sec)
         except IoTimeoutError:

--- a/python/tvm/micro/transport/base.py
+++ b/python/tvm/micro/transport/base.py
@@ -203,34 +203,35 @@ class TransportLogger(Transport):
         return self.child.timeouts()
 
     def open(self):
-        self.logger.log(self.level, "opening transport")
+        self.logger.log(self.level, "%s: opening transport", self.name)
         self.child.open()
 
     def close(self):
-        self.logger.log(self.level, "closing transport")
+        self.logger.log(self.level, "%s: closing transport", self.name)
         return self.child.close()
 
     def read(self, n, timeout_sec):
+        timeout_str = f'{timeout_sec:5.2f}s' if timeout_sec is not None else ' None '
         try:
             data = self.child.read(n, timeout_sec)
         except IoTimeoutError:
             self.logger.log(
                 self.level,
-                "%s read {%5.2fs} %4d B -> [IoTimeoutError %.2f s]",
+                "%s: read {%s} %4d B -> [IoTimeoutError %s]",
                 self.name,
-                timeout_sec,
+                timeout_str,
                 n,
-                timeout_sec,
+                timeout_str,
             )
             raise
         except Exception as err:
             self.logger.log(
                 self.level,
-                "%s read {%5.2fs} %4d B -> [err: %s]",
+                "%s: read {%s} %4d B -> [err: %s]",
                 self.name,
-                timeout_sec,
+                timeout_str,
                 n,
-                str(err),
+                err.__class__.__name__,
                 exc_info=1,
             )
             raise err
@@ -239,9 +240,9 @@ class TransportLogger(Transport):
         if len(hex_lines) > 1:
             self.logger.log(
                 self.level,
-                "%s read {%5.2fs} %4d B -> [%3d B]:\n%s",
+                "%s: read {%s} %4d B -> [%3d B]:\n%s",
                 self.name,
-                timeout_sec,
+                timeout_str,
                 n,
                 len(data),
                 "\n".join(hex_lines),
@@ -249,9 +250,9 @@ class TransportLogger(Transport):
         else:
             self.logger.log(
                 self.level,
-                "%s read {%5.2fs} %4d B -> [%3d B]: %s",
+                "%s: read {%s} %4d B -> [%3d B]: %s",
                 self.name,
-                timeout_sec,
+                timeout_str,
                 n,
                 len(data),
                 hex_lines[0],
@@ -260,24 +261,27 @@ class TransportLogger(Transport):
         return data
 
     def write(self, data, timeout_sec):
+        timeout_str = f'{timeout_sec:5.2f}s' if timeout_sec is not None else ' None '
         try:
             bytes_written = self.child.write(data, timeout_sec)
         except IoTimeoutError:
             self.logger.log(
                 self.level,
-                "%s write                <- [%3d B]: [IoTimeoutError %.2f s]",
+                "%s: write {%s}       <- [%3d B]: [IoTimeoutError %s]",
                 self.name,
+                timeout_str,
                 len(data),
-                timeout_sec,
+                timeout_str,
             )
             raise
         except Exception as err:
             self.logger.log(
                 self.level,
-                "%s write                <- [%3d B]: [err: %s]",
+                "%s: write {%s}       <- [%3d B]: [err: %s]",
                 self.name,
+                timeout_str,
                 len(data),
-                str(err),
+                err.__class__.__name__,
                 exc_info=1,
             )
             raise err
@@ -286,16 +290,18 @@ class TransportLogger(Transport):
         if len(hex_lines) > 1:
             self.logger.log(
                 self.level,
-                "%s write                <- [%3d B]:\n%s",
+                "%s: write {%s}        <- [%3d B]:\n%s",
                 self.name,
+                timeout_str,
                 bytes_written,
                 "\n".join(hex_lines),
             )
         else:
             self.logger.log(
                 self.level,
-                "%s write                <- [%3d B]: %s",
+                "%s: write {%s}        <- [%3d B]: %s",
                 self.name,
+                timeout_str,
                 bytes_written,
                 hex_lines[0],
             )

--- a/python/tvm/micro/transport/debug.py
+++ b/python/tvm/micro/transport/debug.py
@@ -31,7 +31,6 @@ class DebugWrapperTransport(Transport):
         self.debugger = debugger
         self.transport = transport
         self.disable_session_start_retry = disable_session_start_retry
-        self.debugger.on_terminate_callbacks.append(self.transport.close)
 
     def timeouts(self):
         child_timeouts = self.transport.timeouts()

--- a/python/tvm/micro/transport/file_descriptor.py
+++ b/python/tvm/micro/transport/file_descriptor.py
@@ -20,7 +20,6 @@
 import fcntl
 import os
 import select
-import time
 from . import base
 
 

--- a/python/tvm/micro/transport/serial.py
+++ b/python/tvm/micro/transport/serial.py
@@ -90,6 +90,10 @@ class SerialTransport(Transport):
         self._port = None
 
     def read(self, n, timeout_sec):
+        if timeout_sec is None:
+            self._port.timeout = None
+            return self._port.read(n)
+
         end_time = time.monotonic() + timeout_sec
         to_return = bytearray()
         while True:

--- a/src/runtime/micro/micro_session.cc
+++ b/src/runtime/micro/micro_session.cc
@@ -55,8 +55,11 @@ class CallbackWriteStream : public WriteStream {
     TVMByteArray bytes;
     bytes.data = (const char*)data;
     bytes.size = data_size_bytes;
-    int64_t n = fsend_(bytes, write_timeout_.count());
-    return n;
+    if (write_timeout_ == ::std::chrono::microseconds::zero()) {
+      return static_cast<int64_t>(fsend_(bytes, nullptr));
+    } else {
+      return static_cast<int64_t>(fsend_(bytes, write_timeout_.count()));
+    }
   }
 
   void PacketDone(bool is_valid) override {}
@@ -76,6 +79,21 @@ class MicroTransportChannel : public RPCChannel {
     kSessionEstablished = 2,  // session is alive.
   };
 
+  /*!
+   * \brief Construct a new MicroTransportChannel.
+   * \param fsend A PackedFunc accepting (data_bytes, timeout_usec) and returning the number of
+   *  bytes sent. If a timeout_usec elapses before all data is sent, it should return 0.
+   * \param frecv A PackedFunc accepting (num_bytes, timeout_usec) and returning a string containing
+   *  the received data. Must not return an empty string, except to indicate a timeout.
+   * \param session_start_retry_timeout During session initialization, the session start message is
+   *  re-sent after this many microseconds elapse without a reply. If 0, the session start message
+   *  is sent only once.
+   * \param session_start_timeout Session initialization is considered "timed out" if no reply is
+   *  received this many microseconds after the session start is sent. If 0, a session start never
+   *  times out.
+   * \param session_established_timeout Timeout used for the Recv() function. This is used for
+   *  messages sent after a session is already established. If 0, Recv() never times out.
+   */
   MicroTransportChannel(PackedFunc fsend, PackedFunc frecv,
                         ::std::chrono::microseconds session_start_retry_timeout,
                         ::std::chrono::microseconds session_start_timeout,
@@ -93,41 +111,46 @@ class MicroTransportChannel : public RPCChannel {
         frecv_{frecv},
         message_buffer_{nullptr} {}
 
-  bool ReceiveUntil(TypedPackedFunc<bool(void)> pf, ::std::chrono::microseconds timeout) {
-    size_t bytes_received = 0;
+ private:
+  static constexpr const size_t kReceiveBufferSizeBytes = 128;
+
+  /*
+   * \brief Receive data until either pf() returns true or a timeout occurs.
+   *
+   * The condition function is called first, so this function may return without performing a read.
+   * Following this call, received data is consumed and frecv_ is invoked until the timeout occurs
+   * or the condition function passes.
+   *
+   * \param pf A condition function that returns true when enough data has been received for the
+   *  caller to proceed.
+   * \param timeout Pointer to number of microseconds to wait before timing out. If nullptr, no
+   *  timeout ever occurs in this function, so it may block forever. If 0, a single non-blocking
+   *  read is performed, and any data returned is processed.
+   * \return true if the condition passed, false if the timeout expired.
+   */
+  bool ReceiveUntil(TypedPackedFunc<bool(void)> pf, ::std::chrono::microseconds* timeout) {
     if (pf()) {
       return true;
     }
 
-    auto end_time = ::std::chrono::steady_clock::now() + timeout;
+    auto end_time = ::std::chrono::steady_clock::now();
+    if (timeout != nullptr) {
+      end_time += *timeout;
+    }
     for (;;) {
-      while (pending_chunk_.size() > 0) {
-        size_t bytes_consumed = 0;
-        int unframer_error = unframer_.Write((const uint8_t*)pending_chunk_.data(),
-                                             pending_chunk_.size(), &bytes_consumed);
-
-        ICHECK(bytes_consumed <= pending_chunk_.size())
-            << "consumed " << bytes_consumed << " want <= " << pending_chunk_.size();
-        pending_chunk_ = pending_chunk_.substr(bytes_consumed);
-        bytes_received += bytes_consumed;
-        if (unframer_error < 0) {
-          LOG(ERROR) << "unframer got error code: " << unframer_error;
-        } else {
-          if (pf()) {
-            return true;
-          }
-        }
+      if (ConsumeReceivedPayload(pf)) {
+        return true;
       }
 
       ::std::string chunk;
-      if (timeout != ::std::chrono::microseconds::zero()) {
+      if (timeout != nullptr) {
         ::std::chrono::microseconds iter_timeout{
             ::std::max(::std::chrono::microseconds{0},
                        ::std::chrono::duration_cast<::std::chrono::microseconds>(
                            end_time - ::std::chrono::steady_clock::now()))};
-        chunk = frecv_(128, iter_timeout.count()).operator std::string();
+        chunk = frecv_(kReceiveBufferSizeBytes, iter_timeout.count()).operator std::string();
       } else {
-        chunk = frecv_(128, nullptr).operator std::string();
+        chunk = frecv_(kReceiveBufferSizeBytes, nullptr).operator std::string();
       }
       pending_chunk_ = chunk;
       if (pending_chunk_.size() == 0) {
@@ -137,41 +160,63 @@ class MicroTransportChannel : public RPCChannel {
     }
   }
 
-  bool StartSession() {
-    ICHECK(state_ == State::kReset)
-        << "MicroSession: state_: expected kReset, got " << uint8_t(state_);
+  bool StartSessionInternal() {
+    using ::std::chrono::duration_cast;
+    using ::std::chrono::microseconds;
+    using ::std::chrono::steady_clock;
 
-    ::std::chrono::steady_clock::time_point start_time = ::std::chrono::steady_clock::now();
+    steady_clock::time_point start_time = steady_clock::now();
+    ICHECK_EQ(kTvmErrorNoError, session_.Initialize());
+    ICHECK_EQ(kTvmErrorNoError, session_.StartSession());
+
+    if (session_start_timeout_ == microseconds::zero() &&
+        session_start_retry_timeout_ == microseconds::zero()) {
+      ICHECK(ReceiveUntil([this]() -> bool { return session_.IsEstablished(); }, nullptr))
+        << "ReceiveUntil indicated timeout expired, but no timeout set!";
+      ICHECK(session_.IsEstablished()) << "Session not established, but should be";
+      return true;
+    }
+
     auto session_start_end_time = start_time + session_start_timeout_;
-
-    ::std::chrono::steady_clock::time_point end_time;
+    steady_clock::time_point end_time;
     if (session_start_retry_timeout_ != ::std::chrono::microseconds::zero()) {
       end_time = start_time + session_start_retry_timeout_;
     } else {
       end_time = session_start_end_time;
     }
+
     while (!session_.IsEstablished()) {
+      microseconds time_remaining = ::std::max(
+        microseconds{0},
+        duration_cast<microseconds>(end_time - steady_clock::now()));
+      if (ReceiveUntil([this]() -> bool { return session_.IsEstablished(); }, &time_remaining)) {
+        break;
+      }
+
+      if (session_start_timeout_ != microseconds::zero() &&
+          end_time >= session_start_end_time) {
+        return false;
+      }
+      end_time += session_start_retry_timeout_;
+
       ICHECK_EQ(kTvmErrorNoError, session_.Initialize());
       ICHECK_EQ(kTvmErrorNoError, session_.StartSession());
-
-      ::std::chrono::microseconds time_remaining = ::std::max(
-          ::std::chrono::microseconds{0}, ::std::chrono::duration_cast<::std::chrono::microseconds>(
-                                              end_time - ::std::chrono::steady_clock::now()));
-
-      if (!ReceiveUntil([this]() -> bool { return session_.IsEstablished(); }, time_remaining)) {
-        if (session_start_timeout_ != ::std::chrono::microseconds::zero() &&
-            end_time >= session_start_end_time) {
-          break;
-        }
-        end_time += session_start_retry_timeout_;
-      }
     }
 
-    if (session_.IsEstablished()) {
+    return true;
+  }
+
+ public:
+  bool StartSession() {
+    ICHECK(state_ == State::kReset)
+        << "MicroSession: state_: expected kReset, got " << uint8_t(state_);
+
+    bool to_return = StartSessionInternal();
+    if (to_return) {
       write_stream_.SetWriteTimeout(session_established_timeout_);
     }
 
-    return session_.IsEstablished();
+    return to_return;
   }
 
   size_t Send(const void* data, size_t size) override {
@@ -198,9 +243,12 @@ class MicroTransportChannel : public RPCChannel {
       }
 
       did_receive_message_ = false;
-      if (!ReceiveUntil([this]() -> bool { return did_receive_message_; },
-                        session_established_timeout_)) {
-        if (session_established_timeout_ != ::std::chrono::microseconds::zero()) {
+      if (session_established_timeout_ == ::std::chrono::microseconds::zero()) {
+        ICHECK(ReceiveUntil([this]() -> bool { return did_receive_message_; }, nullptr))
+          << "ReceiveUntil timeout expired, but no timeout configured!";
+      } else {
+        if (!ReceiveUntil([this]() -> bool { return did_receive_message_; },
+                          &session_established_timeout_)) {
           std::stringstream ss;
           ss << "MicroSessionTimeoutError: failed to read reply message after timeout "
              << session_established_timeout_.count() / 1e6 << "s";
@@ -223,6 +271,37 @@ class MicroTransportChannel : public RPCChannel {
   }
 
  private:
+  /*!
+   * \brief Consume the entire received payload, unless the pf condition is met halfway through.
+   *
+   * This function expects pending_chunk_ to contain a chunk of unprocessed packet data. It
+   * repeatedly writes the chunk to the Unframer until either a) pf() returns True or b) no more
+   * data remains to be written.
+   *
+   * \param pf A PackedFunc which returns true when ReceiveUntil should return.
+   * \returns true if pf() returned true during processing; false otherwise.
+   */
+  bool ConsumeReceivedPayload(TypedPackedFunc<bool(void)> pf) {
+    while (pending_chunk_.size() > 0) {
+      size_t bytes_consumed = 0;
+      int unframer_error = unframer_.Write((const uint8_t*)pending_chunk_.data(),
+                                           pending_chunk_.size(), &bytes_consumed);
+
+      ICHECK(bytes_consumed <= pending_chunk_.size())
+        << "consumed " << bytes_consumed << " want <= " << pending_chunk_.size();
+      pending_chunk_ = pending_chunk_.substr(bytes_consumed);
+      if (unframer_error < 0) {
+        LOG(ERROR) << "unframer got error code: " << unframer_error;
+      } else {
+        if (pf()) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
   static void HandleMessageReceivedCb(void* context, MessageType message_type, FrameBuffer* buf) {
     static_cast<MicroTransportChannel*>(context)->HandleMessageReceived(message_type, buf);
   }
@@ -294,7 +373,8 @@ TVM_REGISTER_GLOBAL("micro._rpc_connect").set_body([](TVMArgs args, TVMRetValue*
                                 ::std::chrono::microseconds(uint64_t(args[5])));
   if (!micro_channel->StartSession()) {
     std::stringstream ss;
-    ss << "MicroSessionTimeoutError: session start handshake failed after " << double(args[4]) / 1e6
+    ss << "MicroSessionTimeoutError: session start handshake failed after "
+       << double(args[4]) / 1e6
        << "s";
     throw std::runtime_error(ss.str());
   }

--- a/src/runtime/micro/micro_session.cc
+++ b/src/runtime/micro/micro_session.cc
@@ -172,7 +172,7 @@ class MicroTransportChannel : public RPCChannel {
     if (session_start_timeout_ == microseconds::zero() &&
         session_start_retry_timeout_ == microseconds::zero()) {
       ICHECK(ReceiveUntil([this]() -> bool { return session_.IsEstablished(); }, nullptr))
-        << "ReceiveUntil indicated timeout expired, but no timeout set!";
+          << "ReceiveUntil indicated timeout expired, but no timeout set!";
       ICHECK(session_.IsEstablished()) << "Session not established, but should be";
       return true;
     }
@@ -186,15 +186,13 @@ class MicroTransportChannel : public RPCChannel {
     }
 
     while (!session_.IsEstablished()) {
-      microseconds time_remaining = ::std::max(
-        microseconds{0},
-        duration_cast<microseconds>(end_time - steady_clock::now()));
+      microseconds time_remaining =
+          ::std::max(microseconds{0}, duration_cast<microseconds>(end_time - steady_clock::now()));
       if (ReceiveUntil([this]() -> bool { return session_.IsEstablished(); }, &time_remaining)) {
         break;
       }
 
-      if (session_start_timeout_ != microseconds::zero() &&
-          end_time >= session_start_end_time) {
+      if (session_start_timeout_ != microseconds::zero() && end_time >= session_start_end_time) {
         return false;
       }
       end_time += session_start_retry_timeout_;
@@ -245,7 +243,7 @@ class MicroTransportChannel : public RPCChannel {
       did_receive_message_ = false;
       if (session_established_timeout_ == ::std::chrono::microseconds::zero()) {
         ICHECK(ReceiveUntil([this]() -> bool { return did_receive_message_; }, nullptr))
-          << "ReceiveUntil timeout expired, but no timeout configured!";
+            << "ReceiveUntil timeout expired, but no timeout configured!";
       } else {
         if (!ReceiveUntil([this]() -> bool { return did_receive_message_; },
                           &session_established_timeout_)) {
@@ -288,7 +286,7 @@ class MicroTransportChannel : public RPCChannel {
                                            pending_chunk_.size(), &bytes_consumed);
 
       ICHECK(bytes_consumed <= pending_chunk_.size())
-        << "consumed " << bytes_consumed << " want <= " << pending_chunk_.size();
+          << "consumed " << bytes_consumed << " want <= " << pending_chunk_.size();
       pending_chunk_ = pending_chunk_.substr(bytes_consumed);
       if (unframer_error < 0) {
         LOG(ERROR) << "unframer got error code: " << unframer_error;
@@ -373,8 +371,7 @@ TVM_REGISTER_GLOBAL("micro._rpc_connect").set_body([](TVMArgs args, TVMRetValue*
                                 ::std::chrono::microseconds(uint64_t(args[5])));
   if (!micro_channel->StartSession()) {
     std::stringstream ss;
-    ss << "MicroSessionTimeoutError: session start handshake failed after "
-       << double(args[4]) / 1e6
+    ss << "MicroSessionTimeoutError: session start handshake failed after " << double(args[4]) / 1e6
        << "s";
     throw std::runtime_error(ss.str());
   }

--- a/tests/python/unittest/test_micro_transport.py
+++ b/tests/python/unittest/test_micro_transport.py
@@ -1,0 +1,189 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for common micro transports."""
+
+import logging
+import sys
+import unittest
+
+import pytest
+
+import tvm.testing
+
+
+@tvm.testing.requires_micro
+class TransportLoggerTests(unittest.TestCase):
+  import tvm.micro
+
+  class TestTransport(tvm.micro.transport.Transport):
+    def __init__(self):
+      self.exc = None
+      self.to_return = None
+
+    def _raise_or_return(self):
+      if self.exc is not None:
+        to_raise = self.exc
+        self.exc = None
+        raise to_raise
+      elif self.to_return is not None:
+        to_return = self.to_return
+        self.to_return = None
+        return to_return
+      else:
+        assert False, 'should not get here'
+
+    def open(self):
+      pass
+
+    def close(self):
+      pass
+
+    def timeouts(self):
+      raise NotImplementedError()
+
+    def read(self, n, timeout_sec):
+      return self._raise_or_return()
+
+    def write(self, data, timeout_sec):
+      return self._raise_or_return()
+
+  def test_transport_logger(self):
+    """Tests the TransportLogger class."""
+
+    logger = logging.getLogger('transport_logger_test')
+    with self.assertLogs(logger) as test_log:
+      transport = self.TestTransport()
+      transport_logger = tvm.micro.transport.TransportLogger('foo', transport, logger=logger)
+
+      transport_logger.open()
+      assert test_log.records[-1].getMessage() == 'foo: opening transport'
+
+      ########### read() tests ##########
+
+      # Normal log, single-line data returned.
+      transport.to_return = b'data'
+      transport_logger.read(23, 3.0)
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: read { 3.00s}   23 B -> [  4 B]: 64 61 74 61'
+         '                                      data'))
+
+      # Normal log, multi-line data returned.
+      transport.to_return = b'data' * 6
+      transport_logger.read(23, 3.0)
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: read { 3.00s}   23 B -> [ 24 B]:\n'
+         '0000  64 61 74 61 64 61 74 61 64 61 74 61 64 61 74 61  datadatadatadata\n'
+         '0010  64 61 74 61 64 61 74 61                          datadata'))
+
+      # Lack of timeout prints.
+      transport.to_return = b'data'
+      transport_logger.read(15, None)
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: read { None }   15 B -> [  4 B]: 64 61 74 61'
+         '                                      data'))
+
+      # IoTimeoutError includes the timeout value.
+      transport.exc = tvm.micro.transport.IoTimeoutError()
+      with self.assertRaises(tvm.micro.transport.IoTimeoutError):
+        transport_logger.read(23, 0.0)
+
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: read { 0.00s}   23 B -> [IoTimeoutError  0.00s]'))
+
+      # Other exceptions are logged by name.
+      transport.exc = tvm.micro.transport.TransportClosedError()
+      with self.assertRaises(tvm.micro.transport.TransportClosedError):
+        transport_logger.read(8, 0.0)
+
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: read { 0.00s}    8 B -> [err: TransportClosedError]'))
+
+      # KeyboardInterrupt produces no log record.
+      before_len = len(test_log.records)
+      transport.exc = KeyboardInterrupt()
+      with self.assertRaises(KeyboardInterrupt):
+        transport_logger.read(8, 0.0)
+
+      assert len(test_log.records) == before_len
+
+      ########### write() tests ##########
+
+      # Normal log, single-line data written.
+      transport.to_return = 3
+      transport_logger.write(b'data', 3.0)
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: write { 3.00s}        <- [  3 B]: 64 61 74   '
+         '                                      dat'))
+
+      # Normal log, multi-line data written.
+      transport.to_return = 20
+      transport_logger.write(b'data' * 6, 3.0)
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: write { 3.00s}        <- [ 20 B]:\n'
+         '0000  64 61 74 61 64 61 74 61 64 61 74 61 64 61 74 61  datadatadatadata\n'
+         '0010  64 61 74 61                                      data'))
+
+      # Lack of timeout prints.
+      transport.to_return = 3
+      transport_logger.write(b'data', None)
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: write { None }        <- [  3 B]: 64 61 74   '
+         '                                      dat'))
+
+      # IoTimeoutError includes the timeout value.
+      transport.exc = tvm.micro.transport.IoTimeoutError()
+      with self.assertRaises(tvm.micro.transport.IoTimeoutError):
+        transport_logger.write(b'data', 0.0)
+
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: write { 0.00s}       <- [  4 B]: [IoTimeoutError  0.00s]'))
+
+      # Other exceptions are logged by name.
+      transport.exc = tvm.micro.transport.TransportClosedError()
+      with self.assertRaises(tvm.micro.transport.TransportClosedError):
+        transport_logger.write(b'data', 0.0)
+
+      assert (
+        test_log.records[-1].getMessage() ==
+        ('foo: write { 0.00s}       <- [  4 B]: [err: TransportClosedError]'))
+
+      # KeyboardInterrupt produces no log record.
+      before_len = len(test_log.records)
+      transport.exc = KeyboardInterrupt()
+      with self.assertRaises(KeyboardInterrupt):
+        transport_logger.write(b'data', 0.0)
+
+      assert len(test_log.records) == before_len
+
+      transport_logger.close()
+      assert test_log.records[-1].getMessage() == 'foo: closing transport'
+
+
+
+
+if __name__ == '__main__':
+  sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/unittest/test_micro_transport.py
+++ b/tests/python/unittest/test_micro_transport.py
@@ -28,162 +28,160 @@ import tvm.testing
 
 @tvm.testing.requires_micro
 class TransportLoggerTests(unittest.TestCase):
-  import tvm.micro
+    import tvm.micro
 
-  class TestTransport(tvm.micro.transport.Transport):
-    def __init__(self):
-      self.exc = None
-      self.to_return = None
+    class TestTransport(tvm.micro.transport.Transport):
+        def __init__(self):
+            self.exc = None
+            self.to_return = None
 
-    def _raise_or_return(self):
-      if self.exc is not None:
-        to_raise = self.exc
-        self.exc = None
-        raise to_raise
-      elif self.to_return is not None:
-        to_return = self.to_return
-        self.to_return = None
-        return to_return
-      else:
-        assert False, 'should not get here'
+        def _raise_or_return(self):
+            if self.exc is not None:
+                to_raise = self.exc
+                self.exc = None
+                raise to_raise
+            elif self.to_return is not None:
+                to_return = self.to_return
+                self.to_return = None
+                return to_return
+            else:
+                assert False, "should not get here"
 
-    def open(self):
-      pass
+        def open(self):
+            pass
 
-    def close(self):
-      pass
+        def close(self):
+            pass
 
-    def timeouts(self):
-      raise NotImplementedError()
+        def timeouts(self):
+            raise NotImplementedError()
 
-    def read(self, n, timeout_sec):
-      return self._raise_or_return()
+        def read(self, n, timeout_sec):
+            return self._raise_or_return()
 
-    def write(self, data, timeout_sec):
-      return self._raise_or_return()
+        def write(self, data, timeout_sec):
+            return self._raise_or_return()
 
-  def test_transport_logger(self):
-    """Tests the TransportLogger class."""
+    def test_transport_logger(self):
+        """Tests the TransportLogger class."""
 
-    logger = logging.getLogger('transport_logger_test')
-    with self.assertLogs(logger) as test_log:
-      transport = self.TestTransport()
-      transport_logger = tvm.micro.transport.TransportLogger('foo', transport, logger=logger)
+        logger = logging.getLogger("transport_logger_test")
+        with self.assertLogs(logger) as test_log:
+            transport = self.TestTransport()
+            transport_logger = tvm.micro.transport.TransportLogger("foo", transport, logger=logger)
 
-      transport_logger.open()
-      assert test_log.records[-1].getMessage() == 'foo: opening transport'
+            transport_logger.open()
+            assert test_log.records[-1].getMessage() == "foo: opening transport"
 
-      ########### read() tests ##########
+            ########### read() tests ##########
 
-      # Normal log, single-line data returned.
-      transport.to_return = b'data'
-      transport_logger.read(23, 3.0)
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: read { 3.00s}   23 B -> [  4 B]: 64 61 74 61'
-         '                                      data'))
+            # Normal log, single-line data returned.
+            transport.to_return = b"data"
+            transport_logger.read(23, 3.0)
+            assert test_log.records[-1].getMessage() == (
+                "foo: read { 3.00s}   23 B -> [  4 B]: 64 61 74 61"
+                "                                      data"
+            )
 
-      # Normal log, multi-line data returned.
-      transport.to_return = b'data' * 6
-      transport_logger.read(23, 3.0)
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: read { 3.00s}   23 B -> [ 24 B]:\n'
-         '0000  64 61 74 61 64 61 74 61 64 61 74 61 64 61 74 61  datadatadatadata\n'
-         '0010  64 61 74 61 64 61 74 61                          datadata'))
+            # Normal log, multi-line data returned.
+            transport.to_return = b"data" * 6
+            transport_logger.read(23, 3.0)
+            assert test_log.records[-1].getMessage() == (
+                "foo: read { 3.00s}   23 B -> [ 24 B]:\n"
+                "0000  64 61 74 61 64 61 74 61 64 61 74 61 64 61 74 61  datadatadatadata\n"
+                "0010  64 61 74 61 64 61 74 61                          datadata"
+            )
 
-      # Lack of timeout prints.
-      transport.to_return = b'data'
-      transport_logger.read(15, None)
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: read { None }   15 B -> [  4 B]: 64 61 74 61'
-         '                                      data'))
+            # Lack of timeout prints.
+            transport.to_return = b"data"
+            transport_logger.read(15, None)
+            assert test_log.records[-1].getMessage() == (
+                "foo: read { None }   15 B -> [  4 B]: 64 61 74 61"
+                "                                      data"
+            )
 
-      # IoTimeoutError includes the timeout value.
-      transport.exc = tvm.micro.transport.IoTimeoutError()
-      with self.assertRaises(tvm.micro.transport.IoTimeoutError):
-        transport_logger.read(23, 0.0)
+            # IoTimeoutError includes the timeout value.
+            transport.exc = tvm.micro.transport.IoTimeoutError()
+            with self.assertRaises(tvm.micro.transport.IoTimeoutError):
+                transport_logger.read(23, 0.0)
 
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: read { 0.00s}   23 B -> [IoTimeoutError  0.00s]'))
+            assert test_log.records[-1].getMessage() == (
+                "foo: read { 0.00s}   23 B -> [IoTimeoutError  0.00s]"
+            )
 
-      # Other exceptions are logged by name.
-      transport.exc = tvm.micro.transport.TransportClosedError()
-      with self.assertRaises(tvm.micro.transport.TransportClosedError):
-        transport_logger.read(8, 0.0)
+            # Other exceptions are logged by name.
+            transport.exc = tvm.micro.transport.TransportClosedError()
+            with self.assertRaises(tvm.micro.transport.TransportClosedError):
+                transport_logger.read(8, 0.0)
 
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: read { 0.00s}    8 B -> [err: TransportClosedError]'))
+            assert test_log.records[-1].getMessage() == (
+                "foo: read { 0.00s}    8 B -> [err: TransportClosedError]"
+            )
 
-      # KeyboardInterrupt produces no log record.
-      before_len = len(test_log.records)
-      transport.exc = KeyboardInterrupt()
-      with self.assertRaises(KeyboardInterrupt):
-        transport_logger.read(8, 0.0)
+            # KeyboardInterrupt produces no log record.
+            before_len = len(test_log.records)
+            transport.exc = KeyboardInterrupt()
+            with self.assertRaises(KeyboardInterrupt):
+                transport_logger.read(8, 0.0)
 
-      assert len(test_log.records) == before_len
+            assert len(test_log.records) == before_len
 
-      ########### write() tests ##########
+            ########### write() tests ##########
 
-      # Normal log, single-line data written.
-      transport.to_return = 3
-      transport_logger.write(b'data', 3.0)
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: write { 3.00s}        <- [  3 B]: 64 61 74   '
-         '                                      dat'))
+            # Normal log, single-line data written.
+            transport.to_return = 3
+            transport_logger.write(b"data", 3.0)
+            assert test_log.records[-1].getMessage() == (
+                "foo: write { 3.00s}        <- [  3 B]: 64 61 74   "
+                "                                      dat"
+            )
 
-      # Normal log, multi-line data written.
-      transport.to_return = 20
-      transport_logger.write(b'data' * 6, 3.0)
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: write { 3.00s}        <- [ 20 B]:\n'
-         '0000  64 61 74 61 64 61 74 61 64 61 74 61 64 61 74 61  datadatadatadata\n'
-         '0010  64 61 74 61                                      data'))
+            # Normal log, multi-line data written.
+            transport.to_return = 20
+            transport_logger.write(b"data" * 6, 3.0)
+            assert test_log.records[-1].getMessage() == (
+                "foo: write { 3.00s}        <- [ 20 B]:\n"
+                "0000  64 61 74 61 64 61 74 61 64 61 74 61 64 61 74 61  datadatadatadata\n"
+                "0010  64 61 74 61                                      data"
+            )
 
-      # Lack of timeout prints.
-      transport.to_return = 3
-      transport_logger.write(b'data', None)
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: write { None }        <- [  3 B]: 64 61 74   '
-         '                                      dat'))
+            # Lack of timeout prints.
+            transport.to_return = 3
+            transport_logger.write(b"data", None)
+            assert test_log.records[-1].getMessage() == (
+                "foo: write { None }        <- [  3 B]: 64 61 74   "
+                "                                      dat"
+            )
 
-      # IoTimeoutError includes the timeout value.
-      transport.exc = tvm.micro.transport.IoTimeoutError()
-      with self.assertRaises(tvm.micro.transport.IoTimeoutError):
-        transport_logger.write(b'data', 0.0)
+            # IoTimeoutError includes the timeout value.
+            transport.exc = tvm.micro.transport.IoTimeoutError()
+            with self.assertRaises(tvm.micro.transport.IoTimeoutError):
+                transport_logger.write(b"data", 0.0)
 
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: write { 0.00s}       <- [  4 B]: [IoTimeoutError  0.00s]'))
+            assert test_log.records[-1].getMessage() == (
+                "foo: write { 0.00s}       <- [  4 B]: [IoTimeoutError  0.00s]"
+            )
 
-      # Other exceptions are logged by name.
-      transport.exc = tvm.micro.transport.TransportClosedError()
-      with self.assertRaises(tvm.micro.transport.TransportClosedError):
-        transport_logger.write(b'data', 0.0)
+            # Other exceptions are logged by name.
+            transport.exc = tvm.micro.transport.TransportClosedError()
+            with self.assertRaises(tvm.micro.transport.TransportClosedError):
+                transport_logger.write(b"data", 0.0)
 
-      assert (
-        test_log.records[-1].getMessage() ==
-        ('foo: write { 0.00s}       <- [  4 B]: [err: TransportClosedError]'))
+            assert test_log.records[-1].getMessage() == (
+                "foo: write { 0.00s}       <- [  4 B]: [err: TransportClosedError]"
+            )
 
-      # KeyboardInterrupt produces no log record.
-      before_len = len(test_log.records)
-      transport.exc = KeyboardInterrupt()
-      with self.assertRaises(KeyboardInterrupt):
-        transport_logger.write(b'data', 0.0)
+            # KeyboardInterrupt produces no log record.
+            before_len = len(test_log.records)
+            transport.exc = KeyboardInterrupt()
+            with self.assertRaises(KeyboardInterrupt):
+                transport_logger.write(b"data", 0.0)
 
-      assert len(test_log.records) == before_len
+            assert len(test_log.records) == before_len
 
-      transport_logger.close()
-      assert test_log.records[-1].getMessage() == 'foo: closing transport'
-
-
+            transport_logger.close()
+            assert test_log.records[-1].getMessage() == "foo: closing transport"
 
 
-if __name__ == '__main__':
-  sys.exit(pytest.main([__file__] + sys.argv[1:]))
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
This commit makes an internal API change in the µTVM transport library and which allows for some fixes to the GdbDebugger class, improving if not unbreaking the debug flow. When timeouts were introduced to the µTVM transport, it was assumed that a timeout was always wanted, since a lack of timeout could break automated tests. However, in debugging, this is is not the case--in fact, no timeouts are wanted, save on physical hardware where a session start retry timeout can be useful.

Overall effects of this change:
 - When tvm.micro.transport.Transport.read() or tvm.micro.transport.Transport.write() are called, timeout_sec can now be None. When None, implementations should block forever. Previously, 0 could have meant "block forever" (almost always) or "perform non-blocking I/O" (in edge cases on session start). Now, there is an unambiguous meaning that matches pyserial.
 - When using GdbDebugger, never terminate the debugger. Always block on the debugger until the user exits. This allows the user to finish debugging problems without stepping on them in the event that a host-side exception occurs.
 - Immediately restore Ctrl+C handler when the debugger quits. If the debugger cleanup flow hangs, allows the user to typically find the problem by Ctrl+C. Before, explicit kill was required.