### PR TITLE
[AutoScheduler] Fix task scheduler restoring

### DIFF
--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -283,8 +283,10 @@ class TaskScheduler:
         )
 
         # do a round robin first to warm up
-        for i in range(len(self.tasks)):
-            self._tune_task(i)
+        for idx in range(len(self.tasks)):
+            # skip warming up this task if it has been tuned before (restored from the log file)
+            if self.task_cts[idx] == 0:
+                self._tune_task(idx)
         self.best_ct = self.ct
         self.best_score = self.cur_score
 
@@ -472,5 +474,8 @@ class TaskScheduler:
             # `num_measures_per_round` is different from the last tuning.
             self.task_cts[i] = int(self.task_cts[i] / num_measures_per_round + 0.5)
             self.task_costs_history[i].append(self.best_costs[i])
+
+        # Recover the score
+        self.cur_score = self._compute_score(self.best_costs)
 
         logger.info("TaskScheduler: Loaded %d measurement records from %s", total_ct + 1, log_file)

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -285,7 +285,7 @@ class TaskScheduler:
         # do a round robin first to warm up
         for idx in range(len(self.tasks)):
             # skip warming up this task if it has been tuned before (restored from the log file)
-            if self.task_cts[idx] == 0:
+            if not self.task_cts[idx]:
                 self._tune_task(idx)
         self.best_ct = self.ct
         self.best_score = self.cur_score
@@ -475,7 +475,6 @@ class TaskScheduler:
             self.task_cts[i] = int(self.task_cts[i] / num_measures_per_round + 0.5)
             self.task_costs_history[i].append(self.best_costs[i])
 
-        # Recover the score
         self.cur_score = self._compute_score(self.best_costs)
 
         logger.info("TaskScheduler: Loaded %d measurement records from %s", total_ct + 1, log_file)

--- a/tests/python/unittest/test_auto_scheduler_task_scheduler.py
+++ b/tests/python/unittest/test_auto_scheduler_task_scheduler.py
@@ -54,7 +54,7 @@ def test_task_scheduler_round_robin():
         for task in tasks:
             counters[task.workload_key] = 0
 
-        for inp, res in auto_scheduler.load_records(log_file):
+        for inp, _ in auto_scheduler.load_records(log_file):
             counters[inp.task.workload_key] += 1
 
         for task in tasks:
@@ -121,7 +121,7 @@ def test_task_scheduler_gradient():
         for task in tasks:
             counters[task.workload_key] = 0
 
-        for inp, res in auto_scheduler.load_records(log_file):
+        for inp, _ in auto_scheduler.load_records(log_file):
             counters[inp.task.workload_key] += 1
 
         assert counters[tasks[0].workload_key] == n_trials - 1


### PR DESCRIPTION
After loading the log file to restore the task scheduler state:
* In the round-robin stage, skip the tasks which `ct` is greater than zero, meaning that they have been tuned before.
* Restore the `cur_score`; otherwise the estimated total latency would be `inf` instead of `-` when the costs of all tasks are restored (i.e., `all(cost < 1e9 for cost in self.best_costs)` is `True`) (ref: https://github.com/apache/incubator-tvm/blob/main/python/tvm/auto_scheduler/task_scheduler.py#L395).