### PR TITLE
[Runtime][RelayVM] Explicitly use new to avoid exit-time destruction of global state

### DIFF
--- a/src/runtime/vm/memory_manager.cc
+++ b/src/runtime/vm/memory_manager.cc
@@ -110,8 +110,10 @@ NDArray StorageObj::AllocNDArray(size_t offset, std::vector<int64_t> shape, DLDa
 }
 
 MemoryManager* MemoryManager::Global() {
-  static MemoryManager memory_manager;
-  return &memory_manager;
+  // NOTE: explicitly use new to avoid exit-time destruction of global state
+  // Global state will be recycled by OS as the process exits.
+  static auto* inst = new MemoryManager();
+  return inst;
 }
 
 Allocator* MemoryManager::GetOrCreateAllocator(TVMContext ctx, AllocatorType type) {


### PR DESCRIPTION
Extends https://github.com/apache/incubator-tvm/pull/6292 to RelayVM MemoryManager which is also affected by the same de-allocation order issue.

@tqchen @zhiics @icemelon9 @samskalicky 