### PR TITLE
Lazy import XGBoost

### DIFF
--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -23,15 +23,12 @@ from collections import defaultdict
 
 import numpy as np
 
-try:
-    import xgboost as xgb
-except ImportError:
-    xgb = None
-
 from tvm.autotvm.tuner.metric import max_curve
 from .cost_model import PythonBasedModel
 from ..feature import get_per_store_features_from_measure_pairs, get_per_store_features_from_states
 from ..measure_record import RecordReader
+
+xgb = None
 
 logger = logging.getLogger("auto_scheduler")
 
@@ -92,9 +89,12 @@ class XGBModel(PythonBasedModel):
     """
 
     def __init__(self, verbose_eval=25, num_warmup_sample=100, seed=None):
-
-        if xgb is None:
-            raise ImportError(
+        global xgb
+        try:
+            if xgb is None:
+                xgb = __import__("xgboost")
+        except ImportError:
+            print(
                 "XGBoost is required for XGBModel. "
                 "Please install its python package first. "
                 "Help: (https://xgboost.readthedocs.io/en/latest/) "

--- a/python/tvm/autotvm/tuner/xgboost_cost_model.py
+++ b/python/tvm/autotvm/tuner/xgboost_cost_model.py
@@ -23,15 +23,12 @@ import time
 
 import numpy as np
 
-try:
-    import xgboost as xgb
-except ImportError:
-    xgb = None
-
 from .. import feature
 from ..utils import get_rank
 from .metric import max_curve, recall_curve, cover_curve
 from .model_based_tuner import CostModel, FeatureCache
+
+xgb = None
 
 logger = logging.getLogger("autotvm")
 
@@ -75,10 +72,13 @@ class XGBoostCostModel(CostModel):
     def __init__(
         self, task, feature_type, loss_type, num_threads=None, log_interval=25, upper_model=None
     ):
+        global xgb
         super(XGBoostCostModel, self).__init__()
-
-        if xgb is None:
-            raise RuntimeError(
+        try:
+            if xgb is None:
+                xgb = __import__("xgboost")
+        except ImportError:
+            print(
                 "XGBoost is required for XGBoostCostModel. "
                 "Please install its python package first. "
                 "Help: (https://xgboost.readthedocs.io/en/latest/) "


### PR DESCRIPTION
I encountered the same issue as this one: https://discuss.tvm.apache.org/t/conflict-with-xgboost-when-thrust-is-enabled/6889 with CUDA 10.0 and thrust enabled after upgrading XGBoost to 1.1.0. Since XGBoost is imported by AutoTVM, and AutoTVM is used everywhere (e.g., TOPI, VM, etc), I got the error even with only `from tvm import relay`, as mentioned in the latest reply in the post.

Since we cannot reproduce this error in docker and it's a potential issue, this PR makes the XGBoost import lazy.

cc @merrymercy @tqchen @vinx13 @zhiics 
