### PR TITLE
fix tvm.relay.build() docs

### DIFF
--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -201,6 +201,8 @@ class BuildModule(object):
 
 
 def build(mod, target=None, target_host=None, params=None, mod_name="default"):
+    # fmt: off
+    # pylint: disable=line-too-long
     """Helper function that builds a Relay function to run on TVM graph runtime.
 
     Parameters
@@ -239,6 +241,8 @@ def build(mod, target=None, target_host=None, params=None, mod_name="default"):
     params : dict
         The parameters of the final graph.
     """
+    # pylint: enable=line-too-long
+    # fmt: on
     if not isinstance(mod, (IRModule, _function.Function)):
         raise ValueError("Type of input parameter mod must be tvm.IRModule")
 

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -201,16 +201,14 @@ class BuildModule(object):
 
 
 def build(mod, target=None, target_host=None, params=None, mod_name="default"):
-    """Helper function that builds a Relay function to run on TVM graph
-    runtime.
+    """Helper function that builds a Relay function to run on TVM graph runtime.
 
     Parameters
     ----------
     mod : :py:class:`~tvm.IRModule`
         The IR module to build. Using relay.Function is deprecated.
 
-    target : str, :any:`tvm.target.Target`, or dict of str(i.e. device/context
-    name) to str/tvm.target.Target, optional
+    target : str, :any:`tvm.target.Target`, or dict of str(i.e. device/context name) to str/tvm.target.Target, optional
         For heterogeneous compilation, it is a dictionary indicating context to
         target mapping. For homogeneous compilation, it is a build target.
 


### PR DESCRIPTION
Looks like some line breaks are corrupting the `tvm.relay.build` [docs](https://tvm.apache.org/docs/api/python/relay/index.html#tvm.relay.build):

**Parameters**
- mod (IRModule) – The IR module to build. Using relay.Function is deprecated.
- target (str, tvm.target.Target, or dict of str(i.e. device/context) –
- to str/tvm.target.Target (name)) – For heterogeneous compilation, it is a dictionary indicating context to target mapping. For homogeneous compilation, it is a build target.
- optional – For heterogeneous compilation, it is a dictionary indicating context to target mapping. For homogeneous compilation, it is a build target.
- target_host (str or tvm.target.Target, optional) – Host compilation target, if target is device. When TVM compiles device specific program such as CUDA, we also need host(CPU) side code to interact with the driver setup the dimensions and parameters correctly. target_host is used to specify the host side codegen target. By default, llvm is used if it is enabled, otherwise a stackvm intepreter is used.
- params (dict of str to NDArray) – Input parameters to the graph that do not change during inference time. Used for constant folding.
- mod_name (Optional[str]) – The module name we will build
