### PR TITLE
Bug-fix] Fix tir allocation with multiple lanes

### DIFF
--- a/python/tvm/tir/ir_builder.py
+++ b/python/tvm/tir/ir_builder.py
@@ -103,7 +103,7 @@ class BufferVar(ObjectGeneric):
         index = self._linear_index(index)
         if t.lanes > 1:
             base = index * t.lanes
-            index = _expr.Ramp(base, const(1, base.dtype), t.lanes)
+            index = _expr.Ramp(base, 1, t.lanes)
         return _expr.Load(self._content_type, self._buffer_var, index)
 
     def __setitem__(self, index, value):
@@ -116,7 +116,7 @@ class BufferVar(ObjectGeneric):
         t = DataType(self._content_type)
         if t.lanes > 1:
             base = index * t.lanes
-            index = _expr.Ramp(base, const(1, base.dtype), t.lanes)
+            index = _expr.Ramp(base, 1, t.lanes)
         self._builder.emit(_stmt.Store(self._buffer_var, value, index))
 
 

--- a/python/tvm/tir/ir_builder.py
+++ b/python/tvm/tir/ir_builder.py
@@ -103,7 +103,8 @@ class BufferVar(ObjectGeneric):
         index = self._linear_index(index)
         if t.lanes > 1:
             base = index * t.lanes
-            index = _expr.Ramp(base, 1, t.lanes)
+            stride = 1 if (not hasattr(base, "dtype")) else const(1, base.dtype)
+            index = _expr.Ramp(base, stride, t.lanes)
         return _expr.Load(self._content_type, self._buffer_var, index)
 
     def __setitem__(self, index, value):
@@ -116,7 +117,8 @@ class BufferVar(ObjectGeneric):
         t = DataType(self._content_type)
         if t.lanes > 1:
             base = index * t.lanes
-            index = _expr.Ramp(base, 1, t.lanes)
+            stride = 1 if (not hasattr(base, "dtype")) else const(1, base.dtype)
+            index = _expr.Ramp(base, stride, t.lanes)
         self._builder.emit(_stmt.Store(self._buffer_var, value, index))
 
 

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -20,21 +20,6 @@ import numpy as np
 import tvm.testing
 
 
-def test_allocate_with_lanes():
-    ib = tvm.tir.ir_builder.create()
-    n = te.size_var("n")
-    A = ib.allocate("float32x4", n, name="A", scope="global")
-    B = ib.allocate("float32x4", n, name="A", scope="global")
-    A[0] = tvm.tir.const(0, "float32x4")
-    B[0] = A[0]
-    body = ib.get()
-    assert A == A
-    print(body)
-    assert isinstance(body, tvm.tir.AttrStmt)
-    body = body.body
-    assert isinstance(body, tvm.tir.Allocate)
-
-
 def test_for():
     ib = tvm.tir.ir_builder.create()
     n = te.size_var("n")
@@ -192,6 +177,5 @@ if __name__ == "__main__":
     test_prefetch()
     test_if()
     test_for()
-    test_allocate_with_lanes()
     test_cpu()
     test_gpu()

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -20,6 +20,21 @@ import numpy as np
 import tvm.testing
 
 
+def test_allocate_with_lanes():
+    ib = tvm.tir.ir_builder.create()
+    n = te.size_var("n")
+    A = ib.allocate("float32x4", n, name="A", scope="global")
+    B = ib.allocate("float32x4", n, name="A", scope="global")
+    A[0] = tvm.tir.const(0, "float32x4")
+    B[0] = A[0]
+    body = ib.get()
+    assert A == A
+    print(body)
+    assert isinstance(body, tvm.tir.AttrStmt)
+    body = body.body
+    assert isinstance(body, tvm.tir.Allocate)
+
+
 def test_for():
     ib = tvm.tir.ir_builder.create()
     n = te.size_var("n")
@@ -177,5 +192,6 @@ if __name__ == "__main__":
     test_prefetch()
     test_if()
     test_for()
+    test_allocate_with_lanes()
     test_cpu()
     test_gpu()

--- a/tests/python/unittest/test_tir_transform_narrow_datatype.py
+++ b/tests/python/unittest/test_tir_transform_narrow_datatype.py
@@ -126,9 +126,10 @@ def test_multilanes():
         B = ib.buffer_ptr(Bb)
         with ib.for_range(0, m, name="i", dtype=m.dtype) as i:
             B[i] = A[i] + 1
+        A[0] = B[1]
         stmt = ib.get()
         stmt = lower_stmt([Ab, Bb], stmt, target_bits)
-        assert stmt.loop_var.dtype == target_dtype
+        assert stmt.seq[0].loop_var.dtype == target_dtype
 
     # i32 -> i32
     check(const(2 ** 10, dtype="int32"), 2, target_bits=32, target_dtype="int32")


### PR DESCRIPTION
This PR stemmed from https://github.com/apache/incubator-tvm/pull/6907
and it is fixing a small error in the getter and setter of a buffer for
the case where `t.lanes > 1`. I also added a test to stress the issue.
