### PR TITLE
[AutoScheduler] Fix task extraction

### DIFF
--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -186,7 +186,8 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
     all_impls = get_valid_implementations(op, attrs, inputs, out_type, target)
     best_plevel_impl = max(all_impls, key=lambda x: x.plevel)
 
-    # check if auto_scheduler is enabled, and disable autotvm if so
+    # Disable autotvm if auto_scheduler is enabled.
+    # (i.e. always return the implementation with the highest priority for auto-scheduler).
     if PassContext.current().config.get("relay.backend.use_auto_scheduler", False):
         use_autotvm = False
 

--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -187,7 +187,7 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
     best_plevel_impl = max(all_impls, key=lambda x: x.plevel)
 
     # Disable autotvm if auto_scheduler is enabled.
-    # (i.e. always return the implementation with the highest priority for auto-scheduler).
+    # (i.e., always return the implementation with the highest priority for auto-scheduler).
     if PassContext.current().config.get("relay.backend.use_auto_scheduler", False):
         use_autotvm = False
 

--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -186,6 +186,10 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
     all_impls = get_valid_implementations(op, attrs, inputs, out_type, target)
     best_plevel_impl = max(all_impls, key=lambda x: x.plevel)
 
+    # check if auto_scheduler is enabled, and disable autotvm if so
+    if PassContext.current().config.get("relay.backend.use_auto_scheduler", False):
+        use_autotvm = False
+
     # If not use autotvm, always return the implementation with the highest priority
     if not use_autotvm:
         logger.info(
@@ -288,10 +292,7 @@ def lower_call(call, inputs, target):
             env.tracing = False
             reenable_tracing = True
 
-    # check if auto_scheduler is enabled, and use pevel to select the implementation if so
-    use_auto_scheduler = PassContext.current().config.get("relay.backend.use_auto_scheduler", False)
-
-    if not is_dyn and not use_auto_scheduler:
+    if not is_dyn:
         best_impl, outputs = select_implementation(op, call.attrs, inputs, ret_type, target)
     else:
         # TODO(@icemelon9): Allow tvm to generate multiple kernels for dynamic shapes.

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -107,7 +107,7 @@ def naive_schedule(_, outs, target):
         # For GPU, we at least need thread binding to make a valid schedule.
         # So the naive schedule cannot be compiled.
         raise RuntimeError(
-            "Cannot compile for GPU targets if no tuned schedule is found."
+            "Cannot compile for GPU targets if no tuned schedule is found. "
             "Please see the warning messages above for more information about the failed workloads."
         )
     return tvm.te.create_schedule(outs[-1].op)


### PR DESCRIPTION
Follow up of #6956 .
The previous PR does not work for the cases where `select_implementation` is called during alter op layout in TOPI.

https://github.com/apache/incubator-tvm/blob/b2e418cb109df4cd1f17a2cf2894a1b396a6b838/python/tvm/topi/cuda/conv2d_alter_op.py#L47-L49 
We should move the check from `lower_call` to `select_implementation` itself.
